### PR TITLE
feat(docs): per-page OG tags, sitemap, robots.txt, trailing-slash fix

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,19 @@
-import { defineConfig } from "vitepress";
+import { defineConfig, type HeadConfig } from "vitepress";
+
+const SITE_ORIGIN = "https://www.fontist.org";
+const BASE_PATH = "/fontisan/";
+const DEFAULT_DESCRIPTION =
+  "The most comprehensive font processing library for Ruby — 100% Pure Ruby, no Python, no C++, no C# dependencies.";
+const DEFAULT_OG_IMAGE = `${SITE_ORIGIN}/og-image.png`;
+
+// Map a page's source path to its canonical public URL (origin + base + clean path).
+function pathToUrl(relativePath: string): string {
+  const bare = relativePath.replace(/\.md$/, "").replace(/\\/g, "/");
+  if (bare === "index") return `${SITE_ORIGIN}${BASE_PATH}`;
+  if (bare.endsWith("/index"))
+    return `${SITE_ORIGIN}${BASE_PATH}${bare.slice(0, -6)}/`;
+  return `${SITE_ORIGIN}${BASE_PATH}${bare}`;
+}
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -12,6 +27,11 @@ export default defineConfig({
     "The most comprehensive font processing library for Ruby — 100% Pure Ruby, no Python, no C++, no C# dependencies.",
 
   lastUpdated: true,
+
+  // https://vitepress.dev/reference/site-config#sitemap
+  sitemap: {
+    hostname: SITE_ORIGIN,
+  },
 
   // Base path for deployment (e.g., /fontisan/ for fontist.org/fontisan/)
   base: process.env.BASE_PATH || "/fontisan/",
@@ -29,18 +49,30 @@ export default defineConfig({
     ],
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
     ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:title", content: "Fontisan" }],
-    [
-      "meta",
-      {
-        property: "og:description",
-        content:
-          "The most comprehensive font processing library for Ruby — 100% Pure Ruby.",
-      },
-    ],
-    ["meta", { property: "og:image", content: "/logo-full.svg" }],
-    ["meta", { name: "twitter:card", content: "summary_large_image" }],
   ],
+
+  // Per-page og:* and twitter:* tags are derived from each page's frontmatter.
+  // https://vitepress.dev/reference/site-config#transformhead
+  transformHead(ctx) {
+    const { pageData } = ctx;
+    const url = pathToUrl(pageData.relativePath);
+    const title = pageData.title || "Fontisan";
+    const description = pageData.description || DEFAULT_DESCRIPTION;
+    const image = pageData.frontmatter.image || DEFAULT_OG_IMAGE;
+
+    const tags: HeadConfig[] = [
+      ["meta", { property: "og:title", content: title }],
+      ["meta", { property: "og:description", content: description }],
+      ["meta", { property: "og:url", content: url }],
+      ["meta", { property: "og:image", content: image }],
+      ["meta", { name: "twitter:card", content: "summary_large_image" }],
+      ["meta", { name: "twitter:title", content: title }],
+      ["meta", { name: "twitter:description", content: description }],
+      ["meta", { name: "twitter:image", content: image }],
+    ];
+
+    return tags;
+  },
 
   // https://vitepress.dev/reference/default-theme-config
   themeConfig: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "vitepress dev",
-    "build": "vitepress build",
+    "build": "vitepress build && node scripts/post-build.mjs",
     "preview": "vitepress preview",
     "format": "prettier -w ."
   },

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.fontist.org/fontisan/sitemap.xml

--- a/docs/scripts/post-build.mjs
+++ b/docs/scripts/post-build.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Post-build fixes for GitHub Pages subpath deployment.
+//
+// 1. Dirify: convert VitePress file-style output (foo.html) to directory-style
+//    (foo/index.html) so GitHub Pages resolves BOTH /foo and /foo/. Without
+//    this, /foo/ 404s because foo.html is a file, not a directory.
+//
+// 2. Sitemap base: insert the deployment base path into sitemap.xml URLs.
+//    VitePress omits `base` from sitemap route paths (and ignores the path
+//    portion of `sitemap.hostname`), so the generated URLs point at the origin
+//    root instead of the subsite. We rewrite each <loc> to include the base.
+//
+// Idempotent. Kept at the dist root: index.html (site root), 404.html (GHP 404 page).
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+const DIST = ".vitepress/dist";
+const HTML = ".html";
+const KEEP_AT_ROOT = new Set(["index.html", "404.html"]);
+// Subsite identity — must match config.ts base and the real deployment URL.
+const ORIGIN = "https://www.fontist.org";
+const BASE = "fontisan"; // path segment under ORIGIN (no slashes)
+
+let moved = 0;
+let skipped = 0;
+
+function dirify(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      dirify(full);
+      continue;
+    }
+    if (!entry.endsWith(HTML)) continue;
+    if (entry === "index.html") continue; // already directory-style
+    if (dir === DIST && KEEP_AT_ROOT.has(entry)) {
+      skipped++; // root index.html / 404.html stay put
+      continue;
+    }
+    const name = entry.slice(0, -HTML.length);
+    const targetDir = join(dir, name);
+    const targetIndex = join(targetDir, "index.html");
+    if (existsSync(targetIndex)) {
+      console.warn(`[post-build] skip ${full.replace(DIST + "/", "")}: target exists`);
+      skipped++;
+      continue;
+    }
+    mkdirSync(targetDir, { recursive: true });
+    renameSync(full, targetIndex);
+    moved++;
+  }
+}
+
+function fixSitemapBase() {
+  const sitemap = `${DIST}/sitemap.xml`;
+  if (!existsSync(sitemap)) return false;
+  let xml = readFileSync(sitemap, "utf8");
+  // Insert BASE after the origin unless the path already starts with BASE
+  // (VitePress emits the homepage route as "/<base>"; other routes omit it).
+  const originPattern = new RegExp(
+    `(<loc>${ORIGIN.replaceAll("/", "\\/")}\\/)(?!${BASE}(\\/|$))`,
+    "g",
+  );
+  xml = xml.replace(originPattern, `$1${BASE}/`);
+  writeFileSync(sitemap, xml);
+  return true;
+}
+
+dirify(DIST);
+const sitemapFixed = fixSitemapBase();
+console.log(
+  `[post-build] dirified ${moved} route(s), kept ${skipped} at root; sitemap ${sitemapFixed ? "rewritten with /" + BASE + "/" : "absent (skipped)"}`,
+);


### PR DESCRIPTION
Applies the fontist.org SEO + routing fixes (fontist.org PRs #37/#38/#40) to the **fontisan** subsite so it matches the greater setup. Identical pattern to fontist/fontist#476.

## Changes

| Area | Before | After |
|---|---|---|
| **Trailing-slash URLs** | `/fontisan/<page>/` → **404** (file-route) | → **200** (dirified) |
| **og:image** | `/logo-full.svg` (relative — invalid) | `https://www.fontist.org/og-image.png` (shared absolute PNG) |
| **og:title / og:description** | site-wide static | per-page via `transformHead` |
| **og:url** | absent | per-page canonical, base-aware |
| **sitemap.xml** | absent (404) | generated; post-build inserts `/fontisan/` base |
| **robots.txt** | absent (404) | points at subsite sitemap |

## Files

- `docs/.vitepress/config.ts` — `transformHead`, `sitemap`, removed static og/twitter, helpers.
- `docs/scripts/post-build.mjs` — **new**: dirify + sitemap-base rewrite. Idempotent.
- `docs/public/robots.txt` — **new**.
- `docs/package.json` — `build` runs `vitepress build && node scripts/post-build.mjs`. No new deps.

## Verification (local)

- `npm run build` → `[post-build] dirified 83 route(s); sitemap rewritten with /fontisan/`.
- Sitemap: `https://www.fontist.org/fontisan/<page>`, homepage `https://www.fontist.org/fontisan/`, no doubled segments.
- Per-page OG on `guide/installation/index.html`: `og:title="Installation"`, `og:url="https://www.fontist.org/fontisan/guide/installation"`, `og:image="https://www.fontist.org/og-image.png"`.
- Idempotent.

## Pre-existing content note (not introduced by this PR)

The build logs two `[post-build] skip ... target exists` warnings for `guide/hinting.html` and `guide/validation.html`. This is because **both** `guide/hinting.md` and `guide/hinting/index.md` exist (same for validation) — i.e. two source files map to the same route prefix. VitePress emits both `guide/hinting.html` and `guide/hinting/index.html`, so the dirify step can't consolidate them (it leaves the `.html` in place; both URL forms still resolve). This is a content-authoring issue worth resolving separately (delete one of each duplicate pair), but it's orthogonal to this PR and both URLs work today.
