### PR TITLE
fix(docs): link_checker exclude + resolve duplicate-route collisions

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -22,6 +22,18 @@ export default defineConfig({
   // https://vitepress.dev/guide/routing#generating-clean-url
   cleanUrls: true,
 
+  // Exclude standalone guide stubs that collide with directory routes.
+  // Both guide/<name>.md and guide/<name>/index.md exist for these three
+  // (hinting, validation, conversion); the directory version is the canonical
+  // one (sidebar-linked, richer content). Excluding the standalone stub from
+  // the build resolves the duplicate-route collision while keeping the source
+  // files in the repo.
+  srcExclude: [
+    "guide/hinting.md",
+    "guide/validation.md",
+    "guide/conversion.md",
+  ],
+
   title: "Fontisan",
   description:
     "The most comprehensive font processing library for Ruby — 100% Pure Ruby, no Python, no C++, no C# dependencies.",

--- a/docs/EXTRACT_TTC_MIGRATION.md
+++ b/docs/EXTRACT_TTC_MIGRATION.md
@@ -246,7 +246,7 @@ fontisan maintains 100% backward compatibility:
 
 = ExtractTTC to Fontisan Migration Guide
 
-This guide helps users migrate from https://github.com/fontist/extract_ttc[ExtractTTC] to Fontisan.
+This guide helps users migrate from [ExtractTTC](https://github.com/fontist/extract_ttc) to Fontisan.
 
 Fontisan provides complete compatibility with all ExtractTTC functionality while adding comprehensive font analysis, subsetting, validation, and format conversion capabilities.
 

--- a/docs/guide/migrations/extract-ttc.md
+++ b/docs/guide/migrations/extract-ttc.md
@@ -246,7 +246,7 @@ fontisan maintains 100% backward compatibility:
 
 = ExtractTTC to Fontisan Migration Guide
 
-This guide helps users migrate from https://github.com/fontist/extract_ttc[ExtractTTC] to Fontisan.
+This guide helps users migrate from [ExtractTTC](https://github.com/fontist/extract_ttc) to Fontisan.
 
 Fontisan provides complete compatibility with all ExtractTTC functionality while adding comprehensive font analysis, subsetting, validation, and format conversion capabilities.
 

--- a/docs/guide/type1.md
+++ b/docs/guide/type1.md
@@ -55,4 +55,4 @@ end
 
 ## Related
 
-- [Font Conversion](/guide/conversion) - General conversion guide
+- [Font Conversion](/guide/conversion/) - General conversion guide

--- a/docs/guide/woff.md
+++ b/docs/guide/woff.md
@@ -56,4 +56,4 @@ Fontisan.convert('font.woff2', output_format: :otf)
 
 ## Related
 
-- [Font Conversion](/guide/conversion) - General conversion guide
+- [Font Conversion](/guide/conversion/) - General conversion guide

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -23,7 +23,11 @@ include_verbatim = true
 # Exclude URLs (regex patterns)
 exclude = [
   'github\.com/fontist/fontisan/issues',
-  'github\.com/fontist/extract_ttc',
+  'github\.com/extract_ttc',
+  # Exclude internal /fontisan/ links — these are deployment base paths that
+  # resolve correctly when deployed but fail lychee's local file:// checks
+  # (the built HTML has /fontisan/<path>; the file lives at dist/<path>).
+  '^file://.*/fontisan/',
 ]
 
 # Exclude paths from checking (regex patterns)


### PR DESCRIPTION
Fixes the two pre-existing fontisan issues flagged during the subsite verification.

## 1. link_checker has been failing every run for weeks

Lychee resolves the built HTML's base-prefixed internal links (`/fontisan/assets/...`, `/fontisan/guide/...`) against `dist/fontisan/...`, which doesn't exist (the `base` is a URL concept, not a filesystem path — files live at `dist/...`). Every link_checker run on `main` has failed since at least 2026-06-07.

**Fix:** add `'^file://.*/fontisan/'` to `lychee.toml`'s `exclude` — the same pattern fontist/fontist uses (its link_checker passes). The build itself still verifies internal structure; lychee continues to check external links.

## 2. Duplicate-route collisions (`guide/hinting`, `validation`, `conversion`)

Both `guide/<name>.md` **and** `guide/<name>/index.md` exist for these three. The directory version is canonical (sidebar links to `/guide/<name>/`, and it has 2–4× richer content: e.g. `hinting` 86 vs 44 lines, `validation` 132 vs 47, `conversion` 157 vs 39). The standalone `.md` is an older stub. VitePress was emitting both files, so the dirify step logged `skip ... target exists` and the site served two different pages at `/guide/<name>` vs `/guide/<name>/`.

**Fix:** `srcExclude` the three standalone stubs in `config.ts`. This resolves the route collision (VitePress no longer builds them, no more dirify conflicts) **without deleting the source files** — they remain in the repo for reference.

Two inbound links to the now-excluded `/guide/conversion` (in `guide/type1.md` and `guide/woff.md`) are updated to the canonical directory route `/guide/conversion/`.

## Verification (local)

- `npm run build` → `build complete`, `[post-build] dirified 83 route(s), kept 1 at root` — **no more `skip ... target exists` warnings**.
- `dist/guide/hinting.html` is gone; `dist/guide/hinting/index.html` remains (canonical).
- The dead-link check passes (the two updated links resolve to the directory route).
