### PR TITLE
cleanup: remove dead .specimen-home CSS

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -426,13 +426,6 @@ html.dark .vp-doc [class*="language-"] {
   font-size: 13px;
 }
 
-/* ── Homepage palette (pageClass: specimen-home) ──────────────── */
-/* Specimen tokens are now global (above); the pageClass remains on
-   index.md for any homepage-only tweaks, but inherits the system. */
-.specimen-home {
-  background-color: var(--spec-paper);
-}
-
 /* ── 404 page — specimen ───────────────────────────────────────── */
 .NotFound {
   text-align: center;


### PR DESCRIPTION
Removes 7 lines of dead CSS (.specimen-home pageClass rule) that set background-color which the body already has globally. Synced with the root site cleanup (PR #43).