### PR TITLE
docs: align WOFF/WOFF2 docs with strategy-DSL compression knobs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2133,11 +2133,33 @@ Generating options (control how the output font is written):
 * `--optimize-tables` - Enable table optimization
 * `--decompose-on-output` - Decompose composites in output
 
+WOFF compression knobs (apply to `--to woff` only):
+
+* `--zlib-level=N` - zlib level (0–9, default 6)
+* `--uncompressed` - store tables uncompressed (legal per WOFF 1.0 §5.1)
+* `--compression-threshold=N` - skip compression for tables smaller than N bytes
+
+WOFF2 compression knobs (apply to `--to woff2` only):
+
+* `--brotli-quality=N` - Brotli quality (0–11, default 11)
+* `--transform-tables` / `--no-transform-tables` - apply glyf/loca + hmtx transformations
+
+The format selection (`--to woff` vs `--to woff2`) **is** the algorithm
+choice: WOFF mandates zlib, WOFF2 mandates Brotli. Passing a knob that
+doesn't apply to the requested target exits 1 with a clear error.
+
 [source,shell]
 ----
 # Convert with autohinting and optimization
 fontisan convert font.ttf --to otf --output font.otf \
   --autohint --hinting-mode auto --optimize-tables
+
+# Smallest WOFF2 (max Brotli + table transforms)
+fontisan convert font.ttf --to woff2 --output font.woff2 \
+  --brotli-quality 11 --transform-tables
+
+# WOFF for IE 9+ legacy reach (max zlib)
+fontisan convert font.ttf --to woff --output font.woff --zlib-level 9
 ----
 
 For detailed information on all available options and conversion scenarios,
@@ -2202,6 +2224,26 @@ options = Fontisan::ConversionOptions.new(
 # Use with converter
 converter = Fontisan::Converters::OutlineConverter.new
 tables = converter.convert(font, options: options)
+----
+====
+
+
+.One-shot conversion via Fontisan.convert
+[example]
+====
+[source,ruby]
+----
+require 'fontisan'
+
+# TTF → WOFF2 (modern browsers)
+Fontisan.convert('font.ttf', to: :woff2, output: 'font.woff2',
+                 brotli_quality: 11, transform_tables: true)
+
+# TTF → WOFF (IE 9+ legacy reach, max zlib)
+Fontisan.convert('font.ttf', to: :woff, output: 'font.woff', zlib_level: 9)
+
+# WOFF stored uncompressed (legal per WOFF 1.0 §5.1; useful for tooling)
+Fontisan.convert('font.ttf', to: :woff, output: 'font.woff', uncompressed: true)
 ----
 ====
 

--- a/docs/CONVERSION_GUIDE.adoc
+++ b/docs/CONVERSION_GUIDE.adoc
@@ -113,11 +113,20 @@ Generating options control how the output font is written.
 | `optimize_tables` | Boolean | Enable table optimization | Reduce file size |
 | `reencode_first_256` | Boolean | Reencode first 256 glyphs | Type 1 output |
 | `encoding_vector` | String | Custom encoding vector | Type 1 output |
-| `compression` | String | Compression: zlib, brotli, none | Web font output |
-| `transform_tables` | Boolean | Transform tables for output | Format-specific transformations |
+| `zlib_level` | Integer (0–9) | zlib compression level | WOFF output (default 6) |
+| `uncompressed` | Boolean | Store tables uncompressed | WOFF only (legal per WOFF 1.0 §5.1) |
+| `compression_threshold` | Integer | Skip compression for tables < N bytes | WOFF only (default 100) |
+| `brotli_quality` | Integer (0–11) | Brotli quality | WOFF2 output (default 11) |
+| `transform_tables` | Boolean | Apply glyf/loca + hmtx transformations | WOFF2 only |
+| `metadata_xml` | String | Optional WOFF metadata XML | WOFF only |
+| `private_data` | String | Optional WOFF private data | WOFF only |
 | `preserve_metadata` | Boolean | Preserve copyright/license metadata | Maintain font metadata |
 | `strip_metadata` | Boolean | Remove metadata | Reduce file size |
 | `target_format` | String | Collection target format | Collection conversions |
+
+Compression knobs are declared by each strategy (`WoffWriter`, `Woff2Encoder`)
+via the `ConversionStrategy` DSL. `FormatConverter.validate_options_for_target!`
+rejects knobs that don't apply to the requested target format.
 
 === CLI Option Mapping
 
@@ -388,7 +397,7 @@ Notes: dfont supports both TrueType and OpenType/CFF, or mixed formats.
 Fontisan::ConversionOptions.from_preset(:web_optimized)
 # From: :otf, To: :woff2
 # opening: {}
-# generating: { compression: "brotli", transform_tables: true,
+# generating: { brotli_quality: 11, transform_tables: true,
 #              optimize_tables: true, preserve_metadata: true }
 ----
 
@@ -398,8 +407,10 @@ Benefits: 30-50% smaller than TTF/OTF
 
 [source,ruby]
 ----
-# generating: { compression: "zlib", preserve_metadata: true,
-#              add_private_data: false }
+Fontisan::ConversionOptions.from_preset(:legacy_web)
+# From: :otf, To: :woff
+# generating: { zlib_level: 9, optimize_tables: true,
+#              preserve_metadata: true }
 ----
 
 ==== Type 1 → WOFF/WOFF2
@@ -410,8 +421,8 @@ Workflow: Type 1 → OTF → WOFF2
 ----
 # Via OTF intermediate
 # opening: { decompose_composites: false, generate_unicode: true }
-# generating: { compression: "brotli" }  # WOFF2
-# OR compression: "zlib"    # WOFF
+# generating: { brotli_quality: 11 }    # WOFF2
+# OR generating: { zlib_level: 9 }      # WOFF
 ----
 
 === SVG Font Generation
@@ -481,7 +492,7 @@ Optimize fonts for web delivery:
 Fontisan::ConversionOptions.from_preset(:web_optimized)
 # From: :otf, To: :woff2
 # opening: {}
-# generating: { compression: "brotli", transform_tables: true,
+# generating: { brotli_quality: 11, transform_tables: true,
 #              optimize_tables: true, preserve_metadata: true }
 ----
 
@@ -490,6 +501,18 @@ Use cases:
 * Web font delivery
 * Reducing page load time
 * Bandwidth optimization
+
+=== legacy_web
+
+WOFF with maximum zlib compression for legacy browser reach (IE 9+):
+
+[source,ruby]
+----
+Fontisan::ConversionOptions.from_preset(:legacy_web)
+# From: :otf, To: :woff
+# generating: { zlib_level: 9, optimize_tables: true,
+#              preserve_metadata: true }
+----
 
 === archive_to_modern
 

--- a/docs/api/conversion-options.md
+++ b/docs/api/conversion-options.md
@@ -51,6 +51,7 @@ options = Fontisan::ConversionOptions.from_preset(:type1_to_modern)
 | `type1_to_modern` | Type 1 | OTF |
 | `modern_to_type1` | OTF | Type 1 |
 | `web_optimized` | OTF | WOFF2 |
+| `legacy_web` | OTF | WOFF |
 | `archive_to_modern` | TTC | OTF |
 
 ### new(**kwargs)
@@ -96,19 +97,28 @@ Opening options control source font processing.
 
 Generating options control output font writing.
 
-| Option | Type | Default |
-|--------|------|---------|
-| `write_pfm` | Boolean | false |
-| `write_afm` | Boolean | false |
-| `write_inf` | Boolean | false |
-| `select_encoding_automatically` | Boolean | false |
-| `hinting_mode` | String | 'preserve' |
-| `decompose_on_output` | Boolean | false |
-| `write_custom_tables` | Boolean | true |
-| `optimize_tables` | Boolean | false |
-| `compression` | String | nil |
-| `transform_tables` | Boolean | false |
-| `preserve_metadata` | Boolean | true |
+| Option | Type | Default | Applies to |
+|--------|------|---------|------------|
+| `write_pfm` | Boolean | false | Type 1 output |
+| `write_afm` | Boolean | false | Type 1 output |
+| `write_inf` | Boolean | false | Type 1 output |
+| `select_encoding_automatically` | Boolean | false | Type 1 output |
+| `hinting_mode` | String | 'preserve' | All outline conversions |
+| `decompose_on_output` | Boolean | false | All outline conversions |
+| `write_custom_tables` | Boolean | true | All |
+| `optimize_tables` | Boolean | false | All |
+| `zlib_level` | Integer (0–9) | 6 | WOFF only |
+| `uncompressed` | Boolean | false | WOFF only |
+| `compression_threshold` | Integer (bytes) | 100 | WOFF only |
+| `brotli_quality` | Integer (0–11) | 11 | WOFF2 only |
+| `transform_tables` | Boolean | false | WOFF2 only |
+| `metadata_xml` | String | nil | WOFF only |
+| `private_data` | String | nil | WOFF only |
+| `preserve_metadata` | Boolean | true | All |
+
+Compression knobs are declared by each strategy (`WoffWriter`, `Woff2Encoder`)
+via the `ConversionStrategy` DSL. `FormatConverter.validate_options_for_target!`
+rejects knobs that don't apply to the requested target format.
 
 ## Examples
 
@@ -131,11 +141,24 @@ Fontisan::FontWriter.write(font, 'output.woff2', options: options)
 
 ```ruby
 options = Fontisan::ConversionOptions.new(
+  from: :ttf,
+  to: :woff2,
   opening: { autohint: true },
   generating: {
     hinting_mode: 'auto',
     optimize_tables: true,
-    compression: 'brotli'
+    brotli_quality: 11,
+    transform_tables: true
   }
+)
+```
+
+### WOFF with Max zlib (Legacy Browser Reach)
+
+```ruby
+options = Fontisan::ConversionOptions.new(
+  from: :ttf,
+  to: :woff,
+  generating: { zlib_level: 9, preserve_metadata: true }
 )
 ```

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -36,6 +36,15 @@ These are individual font formats that can be converted:
 | `--output FILE` | Output file path |
 | `--optimize` | Enable outline optimization |
 | `--flatten` | Flatten composite glyphs |
+| `--zlib-level=N` | WOFF only: zlib compression level (0–9, default 6) |
+| `--uncompressed` | WOFF only: store tables uncompressed (legal per WOFF 1.0 §5.1) |
+| `--compression-threshold=N` | WOFF only: skip compression for tables smaller than N bytes (default 100) |
+| `--brotli-quality=N` | WOFF2 only: Brotli quality (0–11, default 11) |
+| `--transform-tables` / `--no-transform-tables` | WOFF2 only: apply glyf/loca + hmtx transformations |
+
+The format you pick (`--to woff` vs `--to woff2`) **is** the algorithm
+choice — WOFF mandates zlib, WOFF2 mandates Brotli. Passing a WOFF knob
+to a WOFF2 target (or vice versa) exits 1 with a clear error.
 
 ## Common Workflows
 
@@ -45,8 +54,18 @@ These are individual font formats that can be converted:
 # TTF to WOFF2 (recommended for modern browsers)
 fontisan convert font.ttf --to woff2 --output font.woff2
 
-# OTF to WOFF (broader compatibility)
+# OTF to WOFF (broader compatibility — works on IE 9+)
 fontisan convert font.otf --to woff --output font.woff
+
+# Smallest possible WOFF2 (max Brotli + table transforms)
+fontisan convert font.ttf --to woff2 --output font.woff2 \
+  --brotli-quality 11 --transform-tables
+
+# WOFF with max zlib compression
+fontisan convert font.ttf --to woff --output font.woff --zlib-level 9
+
+# WOFF stored uncompressed (legal per WOFF 1.0 §5.1; useful for tooling)
+fontisan convert font.ttf --to woff --output font.woff --uncompressed
 ```
 
 ### Convert Between Outline Formats

--- a/docs/guide/color.md
+++ b/docs/guide/color.md
@@ -43,7 +43,7 @@ end
 
 ```ruby
 # Convert color font to WOFF2
-Fontisan.convert('color-font.ttf', output_format: :woff2)
+Fontisan.convert('color-font.ttf', to: :woff2, output: 'color-font.woff2')
 ```
 
 ## Related

--- a/docs/guide/conversion.md
+++ b/docs/guide/conversion.md
@@ -18,10 +18,10 @@ Fontisan supports conversion between various font formats.
 require 'fontisan'
 
 # Convert TTF to WOFF2
-Fontisan.convert('font.ttf', output_format: :woff2)
+Fontisan.convert('font.ttf', to: :woff2, output: 'font.woff2')
 
-# Convert with custom output path
-Fontisan.convert('font.ttf', output_path: 'output/font.woff2')
+# Convert TTF to OTF
+Fontisan.convert('font.ttf', to: :otf, output: 'font.otf')
 ```
 
 ## Batch Conversion
@@ -30,10 +30,11 @@ Fontisan.convert('font.ttf', output_path: 'output/font.woff2')
 # Convert multiple files
 fonts = Dir.glob('fonts/*.ttf')
 fonts.each do |font|
-  Fontisan.convert(font, output_format: :otf)
+  out = font.sub(/\.ttf$/, '.otf')
+  Fontisan.convert(font, to: :otf, output: out)
 end
 ```
 
 ## Related
 
-- [WOFF/WOFF2 Formats](/guide/woff) - Details on web font formats
+- [WOFF/WOFF2 Formats](/guide/conversion/web) - Details on web font formats

--- a/docs/guide/conversion/options.md
+++ b/docs/guide/conversion/options.md
@@ -40,12 +40,21 @@ Generating options control how the output font is written.
 | `optimize_tables` | Boolean | Enable table optimization | Reduce file size |
 | `reencode_first_256` | Boolean | Reencode first 256 glyphs | Type 1 output |
 | `encoding_vector` | String | Custom encoding vector | Type 1 output |
-| `compression` | String | Compression: zlib, brotli, none | Web font output |
-| `transform_tables` | Boolean | Transform tables for output | Format-specific |
+| `zlib_level` | Integer (0–9) | zlib compression level for WOFF | WOFF output (default 6) |
+| `uncompressed` | Boolean | Store WOFF tables uncompressed (legal per WOFF 1.0 §5.1) | Tooling pipelines |
+| `compression_threshold` | Integer | Skip compression for tables smaller than N bytes | Tiny-table edge cases |
+| `brotli_quality` | Integer (0–11) | Brotli quality for WOFF2 | WOFF2 output (default 11) |
+| `transform_tables` | Boolean | Apply WOFF2 glyf/loca + hmtx transformations | Smaller WOFF2 output |
+| `metadata_xml` | String | Optional WOFF metadata XML block | WOFF metadata block |
+| `private_data` | String | Optional WOFF private data block | WOFF private block |
 | `preserve_metadata` | Boolean | Preserve copyright/license metadata | Maintain metadata |
 | `strip_metadata` | Boolean | Remove metadata | Reduce file size |
 | `target_format` | String | Collection target format | Collection conversions |
 | `curve_tolerance` | Float | Curve approximation tolerance | OTF → TTF |
+
+Compression knobs come from each strategy's `ConversionStrategy` DSL
+declarations. Knobs that don't apply to the requested target format are
+rejected by `FormatConverter.validate_options_for_target!`.
 
 ## CLI Option Mapping
 
@@ -103,6 +112,16 @@ Generating options control how the output font is written.
 
 # Curves
 --curve-tolerance N   # Approximation tolerance (0.1-2.0)
+
+# WOFF only (zlib)
+--zlib-level=N              # 0–9, default 6
+--uncompressed              # Store tables uncompressed (legal per WOFF 1.0 §5.1)
+--compression-threshold=N   # Skip compression for tables < N bytes (default 100)
+
+# WOFF2 only (Brotli)
+--brotli-quality=N          # 0–11, default 11
+--transform-tables          # Apply glyf/loca + hmtx transformations
+--no-transform-tables       # Disable transformations (default)
 ```
 
 ### Preset Option
@@ -194,8 +213,18 @@ Fonts optimized for web delivery.
 Fontisan::ConversionOptions.from_preset(:web_optimized)
 # From: :otf, To: :woff2
 # opening: {}
-# generating: { compression: "brotli", transform_tables: true,
+# generating: { brotli_quality: 11, transform_tables: true,
 #              optimize_tables: true, preserve_metadata: true }
+```
+
+### legacy_web
+
+WOFF with maximum zlib compression for legacy browser reach (IE 9+).
+
+```ruby
+Fontisan::ConversionOptions.from_preset(:legacy_web)
+# From: :otf, To: :woff
+# generating: { zlib_level: 9, optimize_tables: true, preserve_metadata: true }
 ```
 
 ### archive_to_modern

--- a/docs/guide/conversion/ttf-otf.md
+++ b/docs/guide/conversion/ttf-otf.md
@@ -157,7 +157,7 @@ Result: Some precision loss unavoidable.
 # Convert all TTF files in a directory
 Dir.glob('fonts/*.ttf').each do |input|
   output = input.sub('.ttf', '.otf')
-  Fontisan.convert(input, output_format: :otf, output_path: output)
+  Fontisan.convert(input, to: :otf, output: output)
 end
 ```
 

--- a/docs/guide/conversion/type1.md
+++ b/docs/guide/conversion/type1.md
@@ -203,6 +203,6 @@ fontisan convert font.pfb --to woff2 --output font.woff2 \
 ```ruby
 Dir.glob('legacy/*.pfb').each do |input|
   output = input.sub('.pfb', '.otf').sub('legacy/', 'modern/')
-  Fontisan.convert(input, output_format: :otf, output_path: output)
+  Fontisan.convert(input, to: :otf, output: output)
 end
 ```

--- a/docs/guide/conversion/web.md
+++ b/docs/guide/conversion/web.md
@@ -10,8 +10,13 @@ Fontisan supports conversion to web-optimized formats (WOFF and WOFF2) for optim
 
 | Format | Compression | Browser Support | Use Case |
 |--------|-------------|-----------------|----------|
-| WOFF | zlib | All modern browsers | Wide compatibility |
-| WOFF2 | brotli | Modern browsers | Smallest size |
+| WOFF | zlib | All modern browsers (IE 9+) | Wide compatibility |
+| WOFF2 | Brotli | Modern browsers | Smallest size |
+
+The format you pick **is** the algorithm choice — WOFF 1.0 mandates zlib,
+WOFF2 mandates Brotli. There is no separate `--compression` flag. Each
+format exposes its algorithm's tunable parameters instead (level, quality,
+threshold, transform).
 
 ## WOFF2
 
@@ -34,7 +39,7 @@ fontisan convert font.pfb --to woff2 --output font.woff2
 Fontisan::ConversionOptions.from_preset(:web_optimized)
 # From: :otf, To: :woff2
 # opening: {}
-# generating: { compression: "brotli", transform_tables: true,
+# generating: { brotli_quality: 11, transform_tables: true,
 #              optimize_tables: true, preserve_metadata: true }
 ```
 
@@ -61,11 +66,18 @@ fontisan convert font.ttf --to woff --output font.woff
 options = Fontisan::ConversionOptions.new(
   to: :woff,
   generating: {
-    compression: "zlib",
-    preserve_metadata: true,
-    add_private_data: false
+    zlib_level: 9,           # max zlib compression
+    preserve_metadata: true
   }
 )
+```
+
+For maximum legacy reach use the `:legacy_web` preset:
+
+```ruby
+Fontisan::ConversionOptions.from_preset(:legacy_web)
+# From: :otf, To: :woff
+# generating: { zlib_level: 9, optimize_tables: true, preserve_metadata: true }
 ```
 
 ## web_optimized Preset
@@ -76,7 +88,7 @@ Optimize fonts for web delivery:
 Fontisan::ConversionOptions.from_preset(:web_optimized)
 # From: :otf, To: :woff2
 # opening: {}
-# generating: { compression: "brotli", transform_tables: true,
+# generating: { brotli_quality: 11, transform_tables: true,
 #              optimize_tables: true, preserve_metadata: true }
 ```
 
@@ -113,43 +125,72 @@ fontisan convert font.otf --to woff2 --output font.woff2
 # Via OTF intermediate
 options = Fontisan::ConversionOptions.new(
   opening: { decompose_composites: false, generate_unicode: true },
-  generating: { compression: "brotli" }  # WOFF2
-  # OR: generating: { compression: "zlib" }    # WOFF
+  generating: {
+    brotli_quality: 11     # WOFF2
+    # For WOFF instead, use: zlib_level: 9
+  }
 )
 ```
 
-## Compression Options
+## Compression Knobs
 
-### brotli (WOFF2)
+Each web format exposes its algorithm's parameters. Knobs that don't apply
+to the requested target are rejected up-front with a clear error.
 
-```ruby
-generating: { compression: "brotli" }
-```
+### WOFF (zlib)
 
-- Best compression ratio
-- Requires modern browsers
-- Transforms tables for better compression
-
-### zlib (WOFF)
-
-```ruby
-generating: { compression: "zlib" }
-```
-
-- Good compression
-- Wide browser support
-- No table transforms
-
-### none
+| Option | CLI | Range | Default | Notes |
+|--------|-----|-------|---------|-------|
+| `zlib_level` | `--zlib-level=N` | 0–9 | 6 | 0 = no compression, 9 = smallest |
+| `uncompressed` | `--uncompressed` | bool | false | Store tables uncompressed (legal per WOFF 1.0 §5.1; `compLength == origLength`) |
+| `compression_threshold` | `--compression-threshold=N` | bytes | 100 | Skip compression for tables smaller than N |
 
 ```ruby
-generating: { compression: "none" }
+# Max zlib compression
+options = Fontisan::ConversionOptions.new(
+  to: :woff,
+  generating: { zlib_level: 9 }
+)
+
+# No compression (legal per spec; useful for tooling pipelines)
+options = Fontisan::ConversionOptions.new(
+  to: :woff,
+  generating: { uncompressed: true }
+)
 ```
 
-- No compression
-- For debugging
+### WOFF2 (Brotli)
 
-## Table Transforms
+| Option | CLI | Range | Default | Notes |
+|--------|-----|-------|---------|-------|
+| `brotli_quality` | `--brotli-quality=N` | 0–11 | 11 | 0 = fastest, 11 = smallest |
+| `transform_tables` | `--[no-]transform-tables` | bool | false | Apply glyf/loca and hmtx transformations |
+
+```ruby
+# Smallest possible WOFF2
+options = Fontisan::ConversionOptions.new(
+  to: :woff2,
+  generating: { brotli_quality: 11, transform_tables: true }
+)
+```
+
+### Cross-format validation
+
+Passing a WOFF knob to a WOFF2 target (or vice versa) is rejected at
+conversion time by `FormatConverter.validate_options_for_target!`:
+
+```ruby
+# Rejected at convert time: brotli_quality does not apply to woff
+Fontisan.convert('font.ttf', to: :woff, output: 'font.woff',
+                 brotli_quality: 11)
+# => Fontisan::Error: ... Option(s) :brotli_quality do not apply to --to woff.
+#    Accepted for woff: zlib_level, uncompressed, compression_threshold,
+#                       metadata_xml, private_data
+```
+
+The CLI equivalent exits 1 with the same message.
+
+## Table Transforms (WOFF2)
 
 WOFF2 supports table transformations for better compression:
 
@@ -164,6 +205,12 @@ options = Fontisan::ConversionOptions.new(
   to: :woff2,
   generating: { transform_tables: true }
 )
+```
+
+CLI equivalent:
+
+```bash
+fontisan convert font.ttf --to woff2 --output font.woff2 --transform-tables
 ```
 
 ## Metadata Handling
@@ -198,20 +245,32 @@ font = Fontisan::FontLoader.load('source.ttf')
 woff2_options = Fontisan::ConversionOptions.from_preset(:web_optimized)
 Fontisan::FontWriter.write(font, 'font.woff2', options: woff2_options)
 
-# Create WOFF for older browsers
-woff_options = Fontisan::ConversionOptions.new(
-  to: :woff,
-  generating: { compression: "zlib", preserve_metadata: true }
-)
+# Create WOFF for older browsers (max zlib)
+woff_options = Fontisan::ConversionOptions.from_preset(:legacy_web)
 Fontisan::FontWriter.write(font, 'font.woff', options: woff_options)
+```
+
+### Top-level Fontisan.convert
+
+```ruby
+# WOFF2 with max Brotli
+Fontisan.convert('font.ttf', to: :woff2, output: 'font.woff2',
+                 brotli_quality: 11, transform_tables: true)
+
+# WOFF with max zlib (for IE / older browsers)
+Fontisan.convert('font.ttf', to: :woff, output: 'font.woff', zlib_level: 9)
+
+# WOFF stored uncompressed (legal per WOFF 1.0 §5.1)
+Fontisan.convert('font.ttf', to: :woff, output: 'font.woff', uncompressed: true)
 ```
 
 ### Batch Web Conversion
 
 ```bash
-# Convert all TTF files to WOFF2
+# Convert all TTF files to WOFF2 with max Brotli
 for f in fonts/*.ttf; do
-  fontisan convert "$f" --to woff2 --output "web/$(basename "${f%.ttf}.woff2")"
+  fontisan convert "$f" --to woff2 --output "web/$(basename "${f%.ttf}.woff2")" \
+    --brotli-quality 11 --transform-tables
 done
 ```
 

--- a/docs/guide/formats/woff.md
+++ b/docs/guide/formats/woff.md
@@ -10,8 +10,13 @@ Web Open Font Format (WOFF and WOFF2) are optimized for web delivery.
 
 | Format | Compression | Browser Support |
 |--------|-------------|-----------------|
-| WOFF | zlib | All modern browsers |
-| WOFF2 | brotli | Modern browsers |
+| WOFF | zlib | All modern browsers (IE 9+) |
+| WOFF2 | Brotli | Modern browsers |
+
+The format you pick **is** the algorithm choice — WOFF 1.0 mandates zlib,
+WOFF2 mandates Brotli. Each format exposes its algorithm's parameters
+(level, quality, transform) rather than offering a separate algorithm
+selector.
 
 ## WOFF2 Benefits
 
@@ -27,6 +32,9 @@ fontisan convert font.ttf --to woff --output font.woff
 
 # From OTF
 fontisan convert font.otf --to woff --output font.woff
+
+# Max zlib compression
+fontisan convert font.ttf --to woff --output font.woff --zlib-level 9
 ```
 
 ## Converting to WOFF2
@@ -40,6 +48,10 @@ fontisan convert font.otf --to woff2 --output font.woff2
 
 # From Type 1
 fontisan convert font.pfb --to woff2 --output font.woff2
+
+# Smallest possible output (max Brotli + table transforms)
+fontisan convert font.ttf --to woff2 --output font.woff2 \
+  --brotli-quality 11 --transform-tables
 ```
 
 ## API Usage
@@ -47,28 +59,40 @@ fontisan convert font.pfb --to woff2 --output font.woff2
 ```ruby
 options = Fontisan::ConversionOptions.from_preset(:web_optimized)
 # From: :otf, To: :woff2
-# generating: { compression: "brotli", transform_tables: true }
+# generating: { brotli_quality: 11, transform_tables: true,
+#              optimize_tables: true, preserve_metadata: true }
 
 Fontisan::FontWriter.write(font, 'font.woff2', options: options)
 ```
 
-## Compression Options
+## Compression Knobs
 
-### brotli (WOFF2)
+### WOFF (zlib)
 
-```ruby
-generating: { compression: "brotli" }
-```
-
-Best compression ratio.
-
-### zlib (WOFF)
+| Option | CLI | Range | Default |
+|--------|-----|-------|---------|
+| `zlib_level` | `--zlib-level=N` | 0–9 | 6 |
+| `uncompressed` | `--uncompressed` | bool | false |
+| `compression_threshold` | `--compression-threshold=N` | bytes | 100 |
 
 ```ruby
-generating: { compression: "zlib" }
+generating: { zlib_level: 9 }           # max zlib
+generating: { uncompressed: true }      # legal per WOFF 1.0 §5.1
 ```
 
-Wide compatibility.
+### WOFF2 (Brotli)
+
+| Option | CLI | Range | Default |
+|--------|-----|-------|---------|
+| `brotli_quality` | `--brotli-quality=N` | 0–11 | 11 |
+| `transform_tables` | `--[no-]transform-tables` | bool | false |
+
+```ruby
+generating: { brotli_quality: 11, transform_tables: true }
+```
+
+Cross-format misuse (e.g. `brotli_quality` on `:woff`) raises
+`ArgumentError` from `FormatConverter.validate_options_for_target!`.
 
 ## Table Transforms
 
@@ -110,6 +134,6 @@ fontisan convert font.woff2 --to otf --output font.otf
 ## Best Practices
 
 1. **Use WOFF2 primarily** — Best compression
-2. **Provide WOFF fallback** — For older browsers
+2. **Provide WOFF fallback** — For older browsers (IE 9+)
 3. **Keep original** — For editing
 4. **Preserve metadata** — Unless stripping for size

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -86,7 +86,7 @@ puts tables.keys
 
 ```ruby
 # Simple conversion
-Fontisan.convert('input.ttf', output_format: :woff2)
+Fontisan.convert('input.ttf', to: :woff2, output: 'output.woff2')
 
 # With custom options
 options = Fontisan::ConversionOptions.new(
@@ -94,7 +94,7 @@ options = Fontisan::ConversionOptions.new(
   to: :otf,
   opening: { autohint: true, convert_curves: true }
 )
-Fontisan.convert('input.ttf', output_format: :otf, options: options)
+Fontisan.convert('input.ttf', to: :otf, output: 'output.otf', options: options)
 ```
 
 ### Validate Fonts

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -70,13 +70,13 @@ fontisan info font.ttf --format json
 
 ```ruby
 # TTF to OTF
-Fontisan.convert('input.ttf', output_format: :otf)
+Fontisan.convert('input.ttf', to: :otf, output: 'output.otf')
 
 # OTF to WOFF2
-Fontisan.convert('input.otf', output_format: :woff2)
+Fontisan.convert('input.otf', to: :woff2, output: 'output.woff2')
 
 # Type 1 to OTF
-Fontisan.convert('input.pfb', output_format: :otf)
+Fontisan.convert('input.pfb', to: :otf, output: 'output.otf')
 ```
 
 ### With Options
@@ -89,7 +89,7 @@ options = Fontisan::ConversionOptions.new(
   generating: { hinting_mode: 'auto' }
 )
 
-Fontisan.convert('input.ttf', output_format: :otf, options: options)
+Fontisan.convert('input.ttf', to: :otf, output: 'output.otf', options: options)
 ```
 
 ### Using CLI

--- a/docs/guide/type1.md
+++ b/docs/guide/type1.md
@@ -28,13 +28,13 @@ puts font.num_glyphs
 
 ```ruby
 # Convert to TrueType
-Fontisan.convert('font.pfb', output_format: :ttf)
+Fontisan.convert('font.pfb', to: :ttf, output: 'font.ttf')
 
 # Convert to OpenType
-Fontisan.convert('font.pfb', output_format: :otf)
+Fontisan.convert('font.pfb', to: :otf, output: 'font.otf')
 
 # Convert to WOFF2
-Fontisan.convert('font.pfb', output_format: :woff2)
+Fontisan.convert('font.pfb', to: :woff2, output: 'font.woff2')
 ```
 
 ## Handling Encodings

--- a/docs/guide/woff.md
+++ b/docs/guide/woff.md
@@ -9,41 +9,42 @@ WOFF and WOFF2 are web font formats optimized for use on websites:
 - **WOFF** - Compressed version of TrueType/OpenType with metadata support
 - **WOFF2** - Improved compression using Brotli algorithm (typically 30% smaller than WOFF)
 
+The format you pick (`--to woff` vs `--to woff2`) **is** the algorithm
+choice: WOFF mandates zlib, WOFF2 mandates Brotli. Each format exposes
+its algorithm's parameters (level, quality, transform) rather than
+offering a separate algorithm selector.
+
 ## Converting to WOFF
 
 ```ruby
 require 'fontisan'
 
-# Convert to WOFF
-Fontisan.convert('font.ttf', output_format: :woff)
+# Convert to WOFF (max zlib for legacy browser reach)
+Fontisan.convert('font.ttf', to: :woff, output: 'font.woff', zlib_level: 9)
 
-# Convert to WOFF2 (recommended for web)
-Fontisan.convert('font.ttf', output_format: :woff2)
+# Convert to WOFF2 (recommended for modern browsers)
+Fontisan.convert('font.ttf', to: :woff2, output: 'font.woff2',
+                 brotli_quality: 11, transform_tables: true)
 ```
 
 ## Metadata
 
-WOFF files can contain extended metadata:
+WOFF files can carry an extended metadata block:
 
 ```ruby
-# Add metadata when converting
+# Add WOFF metadata when converting
 Fontisan.convert('font.ttf',
-  output_format: :woff2,
-  metadata: {
-    unique_id: 'my-font-1.0',
-    license: 'OFL',
-    license_url: 'https://scripts.sil.org/OFL',
-    description: 'My custom font'
-  }
-)
+  to: :woff,
+  output: 'font.woff',
+  metadata_xml: '<metadata>...</metadata>')
 ```
 
 ## Extracting from WOFF
 
 ```ruby
 # Extract original font from WOFF
-Fontisan.convert('font.woff', output_format: :ttf)
-Fontisan.convert('font.woff2', output_format: :otf)
+Fontisan.convert('font.woff', to: :ttf, output: 'font.ttf')
+Fontisan.convert('font.woff2', to: :otf, output: 'font.otf')
 ```
 
 ## Compression Comparison
@@ -56,4 +57,5 @@ Fontisan.convert('font.woff2', output_format: :otf)
 
 ## Related
 
+- [Web Font Formats](/guide/conversion/web) - Detailed WOFF/WOFF2 guide with all compression knobs
 - [Font Conversion](/guide/conversion/) - General conversion guide


### PR DESCRIPTION
## Summary

The v0.2.18 release shipped with strategy-declared compression knobs (`zlib_level`, `brotli_quality`, `uncompressed`, `compression_threshold`, `transform_tables`) and removed the vestigial `:compression` field — but only `docs/WOFF_WOFF2_FORMATS.adoc` was updated. Every other doc that referenced compression still showed examples that now raise `ArgumentError`, and none of them mentioned the new CLI flags or the top-level `Fontisan.convert` API.

This PR fixes the doc debt.

## What changed

**Replaced removed `:compression` field examples** (previously raised `ArgumentError`):
- `docs/guide/conversion/web.md` — full rewrite of the "Compression Options" section into per-strategy knob tables (WOFF vs WOFF2) with examples; cross-format validation example using `Fontisan.convert`
- `docs/CONVERSION_GUIDE.adoc` — generating-options table and preset examples
- `docs/api/conversion-options.md` — generating-options table now lists which target each knob applies to; new preset row for `:legacy_web`; WOFF-max-zlib example
- `docs/guide/conversion/options.md` — generating-options table, CLI mapping section, preset example
- `docs/guide/formats/woff.md` — full rewrite of compression section

**Documented new CLI flags** (`--zlib-level`, `--uncompressed`, `--compression-threshold`, `--brotli-quality`, `--[no-]transform-tables`):
- `docs/cli/convert.md` — added to options table and "Convert for Web" examples
- `README.adoc` — added knob lists under custom conversion options, plus WOFF2/WOFF/uncompressed CLI examples and a one-shot `Fontisan.convert` API section

**Documented new `:legacy_web` preset** (`otf → woff`, `zlib_level: 9`):
- `docs/api/conversion-options.md`
- `docs/guide/conversion/options.md`
- `docs/CONVERSION_GUIDE.adoc`
- `docs/guide/conversion/web.md`

**Fixed pre-existing broken `Fontisan.convert` examples** (used non-existent `output_format:` / `output_path:` kwargs that would have raised `ArgumentError` once the method existed):
- `docs/guide/quick-start.md`
- `docs/guide/index.md`
- `docs/guide/conversion.md`
- `docs/guide/conversion/ttf-otf.md`
- `docs/guide/conversion/type1.md`
- `docs/guide/color.md`
- `docs/guide/woff.md`
- `docs/guide/type1.md`

## Verification

- `grep -rn 'compression:' docs/ README.adoc` — remaining matches are natural-language references, not field-name uses
- `grep -rn 'output_format\|Fontisan.convert.*output_path' docs/ README.adoc` — clean
- Cross-format rejection example in `web.md` matches actual `Fontisan::Error` message produced at runtime
- All presets documented match `Fontisan::ConversionOptions.available_presets`

No code changes — docs-only.
