### PR TITLE
ci: auto-publish gem on tag push (single-step release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
           Next release version. Possible values: x.y.z, major, minor, patch or pre|rc|etc
         required: true
         default: "skip"
+  push:
+    tags:
+      - v*
   repository_dispatch:
     types: [do-release]
 


### PR DESCRIPTION
## Summary

- Add `push: tags: [v*]` trigger to `.github/workflows/release.yml`.
- Today's flow needs two manual triggers (workflow_dispatch to bump+tag, repository_dispatch to publish). After this change, the bump step's tag push auto-fires the publish run.
- The reusable metanorma/ci `rubygems-release.yml` workflow gates its publish step on `github.event_name == 'push'` or `'repository_dispatch'`. workflow_dispatch alone never satisfies that gate, which is why the second step was required. Tag push satisfies it directly.

## Single-step release command after merge

```
gh workflow run release.yml -f next_version=patch
```

That one command will: bump version, tag, push tag, auto-trigger the publish run via the new tag-push trigger, and push the gem to RubyGems.

## Test plan

- [x] YAML lint clean (the change is a 3-line addition to the `on:` block)
- [x] Existing triggers (`workflow_dispatch`, `repository_dispatch`) unchanged
- [ ] First patch release after merge uses only the single command above (validates end-to-end)

## Out of scope

- Removing the `repository_dispatch` trigger (still useful for external automation like chat bots)
- Switching from API-key auth to OIDC trusted publishing (separate concern)
