### PR TITLE
fix(cff): call build_empty as instance method (OTF build crash fix)

### DIFF
--- a/lib/fontisan/ufo/compile/cff.rb
+++ b/lib/fontisan/ufo/compile/cff.rb
@@ -53,7 +53,8 @@ module Fontisan
         end
 
         def self.empty_charstring(width)
-          Fontisan::Tables::Cff::CharStringBuilder.build_empty(width: width.zero? ? nil : width)
+          builder = Fontisan::Tables::Cff::CharStringBuilder.new
+          builder.build_empty(width: width.zero? ? nil : width)
         end
 
         # ---------- layout ----------


### PR DESCRIPTION
## Problem

OTF compilation crashes with `NoMethodError: undefined method 'build_empty'` whenever any glyph's charstring encoding fails and the rescue fallback triggers.

## Root cause

`CharStringBuilder#build_empty` is an **instance method**, but the CFF module called it as a **class method**:

```ruby
# Broken:
Fontisan::Tables::Cff::CharStringBuilder.build_empty(width: ...)
#                                ^^^^^^^^^^^^ class method call

# Fixed:
Fontisan::Tables::Cff::CharStringBuilder.new.build_empty(width: ...)
#                                ^^^^ instance first
```

## Impact

Any font with even one glyph that fails charstring encoding (empty contours, single-point contours, malformed UFO contours from TTF→UFO conversion) crashes the entire OTF build. The essenfont build with 2965+ glyphs triggers this reliably.

## Test plan

- [x] `bundle exec rspec spec/fontisan/ufo` — 39 examples pass
- [x] `bundle exec rubocop` — clean
- [ ] CI green