### PR TITLE
stitcher: CBDT/CBLC passthrough for color emoji sources

### DIFF
--- a/lib/fontisan/error.rb
+++ b/lib/fontisan/error.rb
@@ -199,6 +199,13 @@ module Fontisan
     end
   end
 
+  # Multiple CBDT sources detected in Stitcher
+  #
+  # Raised when more than one CBDT/CBLC source is registered with the
+  # Stitcher. Only single-source CBDT passthrough is supported; merging
+  # CBDT/CBLC across multiple sources requires a dedicated rebuild.
+  class MultipleCbdtSourcesError < Error; end
+
   # Variation data corrupted (for use in data_extractor)
   #
   # Raised when extracted variation data appears corrupted.

--- a/lib/fontisan/stitcher.rb
+++ b/lib/fontisan/stitcher.rb
@@ -70,12 +70,23 @@ module Fontisan
     end
 
     # Write the stitched font to disk.
+    #
+    # For CBDT/CBLC sources (e.g. NotoColorEmoji), the raw CBDT and
+    # CBLC tables are copied byte-for-byte into the output. This works
+    # because CBDT-mode glyphs are processed first (GIDs 0..N-1),
+    # matching the source's GID layout. Only one CBDT source is
+    # supported; multiple CBDT sources raise MultipleCbdtSourcesError.
+    #
     # @param path [String] output file path
     # @param format [Symbol] :ttf or :otf
     def write_to(path, format: :ttf)
       build_target_font
       compiler = compiler_for(format)
-      compiler.new(@target).compile(output_path: path)
+      compiler_instance = compiler.new(@target)
+      compiler_instance.compile(output_path: path)
+
+      propagate_cbdt_tables(path) if cbdt_source
+
       path
     end
 
@@ -96,6 +107,53 @@ module Fontisan
       end
     end
 
+    # Find the single CBDT source among registered sources, if any.
+    # Raises if more than one CBDT source is present (merge not supported).
+    # @return [Source, nil]
+    def cbdt_source
+      cbdts = @sources.values.select { |s| s.bitmap_mode == :cbdt }
+      if cbdts.size > 1
+        raise MultipleCbdtSourcesError,
+              "multiple CBDT sources not supported (found #{cbdts.size})"
+      end
+
+      cbdts.first
+    end
+
+    # Copy raw CBDT + CBLC table bytes from the CBDT source into the
+    # compiled output file. The GIDs must match (CBDT glyphs are at
+    # the same GIDs in both source and output because they were added
+    # first during build_target_font).
+    def propagate_cbdt_tables(path)
+      source = cbdt_source
+      return unless source
+
+      compiled = Fontisan::FontLoader.load(path)
+
+      tables = {}
+      compiled.table_names.each do |tag|
+        raw = extract_raw_table(compiled, tag)
+        tables[tag] = raw if raw
+      end
+
+      cbdt_bytes = source.raw_table_bytes("CBDT")
+      cblc_bytes = source.raw_table_bytes("CBLC")
+      tables["CBDT"] = cbdt_bytes if cbdt_bytes
+      tables["CBLC"] = cblc_bytes if cblc_bytes
+
+      sfnt = tables.key?("CFF ") ? 0x4F54544F : 0x00010000
+      Fontisan::FontWriter.write_to_file(tables, path, sfnt_version: sfnt)
+    end
+
+    def extract_raw_table(font, tag)
+      sfnt_table = font.table(tag)
+      return nil unless sfnt_table
+
+      sfnt_table.raw_data
+    rescue StandardError
+      nil
+    end
+
     def compiler_for(format)
       case format.to_sym
       when :ttf then Ufo::Compile::TtfCompiler
@@ -107,26 +165,28 @@ module Fontisan
 
     # Walk bindings in codepoint order, assign sequential new gids,
     # copy each glyph into the target font's default layer.
+    #
+    # When a CBDT source is present, its glyphs are added FIRST (in
+    # source GID order) so that the CBLC's GID references remain valid.
+    # Glyf-source bindings are processed AFTER, appending new glyphs.
     def assign_gids_and_copy_glyphs
-      # Always put .notdef at gid 0 first.
-      notdef_binding = @bindings.find { |b| b[:donor_gid].zero? }
-      if notdef_binding
-        copy_glyph_into(@target, name: ".notdef",
-                                 source: notdef_binding[:source],
-                                 donor_gid: 0)
+      cbdt = cbdt_source
+
+      if cbdt
+        add_all_cbdt_glyphs(cbdt)
       else
-        # Synthesize an empty .notdef
-        @target.layers.default_layer.add(Ufo::Glyph.new(name: ".notdef"))
+        add_notdef_from_bindings
       end
 
       sorted_bindings.each do |binding|
-        next if binding[:donor_gid].zero? # already handled
+        next if binding[:donor_gid].zero?
+
+        # Skip bindings from the CBDT source — its glyphs are already added.
+        next if cbdt && binding[:source].equal?(cbdt)
 
         glyph = binding[:source].glyph_for_gid(binding[:donor_gid])
         next unless glyph
 
-        # If multiple codepoints map to the same glyph, only the first
-        # binding creates the glyph; subsequent ones add unicode entries.
         if @target.glyphs.key?(glyph.name)
           add_extra_unicode(glyph.name, binding[:codepoint])
         else
@@ -157,6 +217,51 @@ module Fontisan
 
       glyph = @target.glyph(glyph_name)
       glyph.add_unicode(codepoint) unless glyph.unicodes.include?(codepoint)
+    end
+
+    # Add .notdef at GID 0 from the first binding that references gid 0.
+    # Falls back to a synthesized empty .notdef if none found.
+    def add_notdef_from_bindings
+      notdef_binding = @bindings.find { |b| b[:donor_gid].zero? }
+      if notdef_binding
+        copy_glyph_into(@target, name: ".notdef",
+                                 source: notdef_binding[:source],
+                                 donor_gid: 0)
+      else
+        @target.layers.default_layer.add(Ufo::Glyph.new(name: ".notdef"))
+      end
+    end
+
+    # Add ALL glyphs from a CBDT source in source GID order. This
+    # ensures the CBLC's GID references remain valid in the output
+    # without rewriting the table. Each glyph gets a placeholder
+    # (no contours) since the bitmap data is in CBDT, not glyf.
+    def add_all_cbdt_glyphs(source)
+      ufo = source.font.is_a?(Ufo::Font) ? source.font : nil
+      if ufo
+        ufo.glyphs.each_value { |g| @target.layers.default_layer.add(clone_glyph(g, name: g.name)) }
+        return
+      end
+
+      # For loaded TTF/OTF sources, iterate via cmap to get glyph names.
+      # CBDT fonts (like NotoColorEmoji) may have thousands of glyphs;
+      # we add them all as placeholders.
+      maxp = source.font.table("maxp")
+      num_glyphs = maxp&.num_glyphs || 0
+      cmap = source.font.table("cmap")
+      mappings = cmap&.unicode_mappings || {}
+
+      # Build gid → [codepoints] from cmap
+      gid_cps = Hash.new { |h, k| h[k] = [] }
+      mappings.each { |cp, gid| gid_cps[gid] << cp }
+
+      num_glyphs.times do |gid|
+        name = gid.zero? ? ".notdef" : "gid#{gid}"
+        glyph = Ufo::Glyph.new(name: name)
+        glyph.width = 0
+        gid_cps[gid].each { |cp| glyph.add_unicode(cp) }
+        @target.layers.default_layer.add(glyph)
+      end
     end
 
     # Deep-copy a glyph with a new name. Used so multiple target

--- a/lib/fontisan/stitcher/source.rb
+++ b/lib/fontisan/stitcher/source.rb
@@ -10,6 +10,11 @@ module Fontisan
     # via Ufo::Convert::FromBinData on first glyph access, then cached.
     # This is O(n) in donor glyph count but amortized across all
     # codepoint extractions from that donor.
+    #
+    # CBDT/CBLC sources (e.g. NotoColorEmoji) are detected via
+    # #bitmap_mode. When a source is :cbdt, the Stitcher propagates
+    # the raw CBDT/CBLC tables into the output instead of extracting
+    # outlines. The glyph data lives in the bitmap tables, not in glyf.
     class Source
       attr_reader :font
 
@@ -28,6 +33,27 @@ module Fontisan
         end
       end
 
+      # Detect how this source stores glyph data.
+      #
+      # - :glyf — TrueType outlines (glyf table present)
+      # - :cbdt — Color bitmaps (CBDT + CBLC tables, no glyf)
+      # - :mixed — Both glyf and CBDT
+      # - :none  — UFO source or neither table present
+      #
+      # @return [Symbol]
+      def bitmap_mode
+        return :none if @font.is_a?(Fontisan::Ufo::Font)
+        return :none unless @font.respond_to?(:has_table?)
+
+        has_cbdt = @font.has_table?("CBDT") && @font.has_table?("CBLC")
+        has_glyf = @font.has_table?("glyf") || @font.has_table?("CFF ")
+        return :mixed if has_cbdt && has_glyf
+        return :cbdt if has_cbdt
+        return :glyf if has_glyf
+
+        :none
+      end
+
       # Find the gid for a Unicode codepoint in this source.
       # @param codepoint [Integer]
       # @return [Integer, nil]
@@ -39,6 +65,9 @@ module Fontisan
       end
 
       # Extract a glyph by gid.
+      #
+      # For CBDT sources, returns a placeholder glyph (no contours)
+      # since the glyph data lives in the bitmap tables, not outlines.
       # @param gid [Integer]
       # @return [Fontisan::Ufo::Glyph, nil]
       def glyph_for_gid(gid)
@@ -46,6 +75,18 @@ module Fontisan
         when Fontisan::Ufo::Font then ufo_glyph_at(gid)
         else converted_ufo_glyph_at(gid)
         end
+      end
+
+      # Raw table bytes from the loaded font (for passthrough).
+      # @param tag [String] 4-byte table tag (e.g. "CBDT", "CBLC")
+      # @return [String, nil] raw bytes or nil if table not present
+      def raw_table_bytes(tag)
+        sfnt_table = @font.table(tag)
+        return nil unless sfnt_table
+
+        sfnt_table.raw_data
+      rescue StandardError
+        nil
       end
 
       private

--- a/spec/fontisan/stitcher/cbdt_spec.rb
+++ b/spec/fontisan/stitcher/cbdt_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan"
+require "fontisan/stitcher"
+
+RSpec.describe Fontisan::Stitcher::Source, "#bitmap_mode" do
+  # Minimal double that responds to has_table? like SfntFont.
+  let(:fake_ttf) do
+    instance_double(Fontisan::SfntFont, has_table?: false)
+  end
+
+  it "returns :cbdt when both CBDT and CBLC are present" do
+    allow(fake_ttf).to receive(:has_table?).with("CBDT").and_return(true)
+    allow(fake_ttf).to receive(:has_table?).with("CBLC").and_return(true)
+    allow(fake_ttf).to receive(:has_table?).with("glyf").and_return(false)
+    allow(fake_ttf).to receive(:has_table?).with("CFF ").and_return(false)
+
+    source = described_class.new(fake_ttf)
+    expect(source.bitmap_mode).to eq(:cbdt)
+  end
+
+  it "returns :glyf when only glyf is present" do
+    allow(fake_ttf).to receive(:has_table?).with("glyf").and_return(true)
+    allow(fake_ttf).to receive(:has_table?).with("CFF ").and_return(false)
+    allow(fake_ttf).to receive(:has_table?).with("CBDT").and_return(false)
+    allow(fake_ttf).to receive(:has_table?).with("CBLC").and_return(false)
+
+    source = described_class.new(fake_ttf)
+    expect(source.bitmap_mode).to eq(:glyf)
+  end
+
+  it "returns :glyf when only CFF is present (OTF)" do
+    allow(fake_ttf).to receive(:has_table?).with("CFF ").and_return(true)
+    allow(fake_ttf).to receive(:has_table?).with("glyf").and_return(false)
+    allow(fake_ttf).to receive(:has_table?).with("CBDT").and_return(false)
+    allow(fake_ttf).to receive(:has_table?).with("CBLC").and_return(false)
+
+    source = described_class.new(fake_ttf)
+    expect(source.bitmap_mode).to eq(:glyf)
+  end
+
+  it "returns :mixed when both glyf and CBDT are present" do
+    allow(fake_ttf).to receive(:has_table?).with("CBDT").and_return(true)
+    allow(fake_ttf).to receive(:has_table?).with("CBLC").and_return(true)
+    allow(fake_ttf).to receive(:has_table?).with("glyf").and_return(true)
+    allow(fake_ttf).to receive(:has_table?).with("CFF ").and_return(false)
+
+    source = described_class.new(fake_ttf)
+    expect(source.bitmap_mode).to eq(:mixed)
+  end
+
+  it "returns :none for a UFO source" do
+    source = described_class.new(Fontisan::Ufo::Font.new)
+    expect(source.bitmap_mode).to eq(:none)
+  end
+end


### PR DESCRIPTION
## What

Adds bitmap-mode detection and table propagation to `Fontisan::Stitcher` so NotoColorEmoji and other CBDT-based fonts can be used as Stitcher sources alongside glyf-based text fonts.

## Why

NotoColorEmoji uses CBDT/CBLC tables (color bitmap data) — not glyf. Without this fix, the Stitcher cannot produce a font that includes color emoji.

## How

- **R1 Detection**: `Stitcher::Source#bitmap_mode` returns `:cbdt`, `:glyf`, `:mixed`, or `:none` based on which tables the source has.
- **R3 Table propagation**: When a CBDT source is registered, the Stitcher adds all its glyphs FIRST (in source GID order) so the output's first N GIDs match the source's GID layout. The CBLC table is then copied byte-for-byte from the source into the output via `Fontisan::FontWriter`.
- **R4 Constraint**: Single CBDT source only — multiple raise `MultipleCbdtSourcesError`. Multi-source merge is tracked as TODO.

## Acceptance

- [x] `bitmap_mode` correctly detects `:cbdt`, `:glyf`, `:mixed`, `:none`
- [x] Single CBDT source: tables propagated after compile
- [x] Multiple CBDT sources: raise `MultipleCbdtSourcesError`
- [x] 48 specs pass (43 existing + 5 new for CBDT detection)
- [ ] CI green
- [ ] End-to-end test with real NotoColorEmoji (blocked on acquiring a valid download — local file is HTML, not a font)

## Architecture

The implementation uses identity GID mapping (approach (a) from REQ): CBDT source's GIDs 0..N-1 map directly to output GIDs 0..N-1 because the CBDT source is processed first. The CBLC table's GID references remain valid without rewriting.

For multi-source CBDT merge (R5 in the REQ), a separate, larger feature is required — tracked in `TODO.full/ufo/23-cbdt-passthrough.md`.