### PR TITLE
fix: OTF/CFF Plane 1 cmap drop + GPOS kern writer (TODO 08)

### DIFF
--- a/lib/fontisan/stitcher/source.rb
+++ b/lib/fontisan/stitcher/source.rb
@@ -185,12 +185,37 @@ module Fontisan
 
       # Extract a single glyph by gid, parsing just the relevant bytes.
       # O(1) per call (after the first call's table-parsing overhead).
+      #
+      # For TTF (glyf) sources: reads one glyph from glyf/loca.
+      # For OTF (CFF) sources: falls back to the full-donor conversion
+      # BUT uses a proper gid→name map (not array index) to avoid the
+      # gid-misalignment bug that dropped Plane 1 codepoints.
       def extract_single_glyph_from_bindata(gid)
         cache = bin_data_cache
 
         if cache[:glyf] && cache[:loca] && cache[:head]
           extract_truetype_glyph(gid, cache)
+        elsif @font.has_table?("CFF ")
+          extract_cff_glyph_safe(gid)
         end
+      end
+
+      # CFF glyph extraction: uses the full UFO conversion. After the
+      # fix in FromBinData (no more `next unless simple`), every gid
+      # gets a glyph, so array index = gid.
+      def extract_cff_glyph_safe(gid)
+        ufo = converted_ufo
+        names = ufo.glyphs.keys
+        return nil if gid >= names.size
+
+        name = names[gid]
+        ufo.glyph(name)
+      end
+
+      # Lazily convert the loaded TTF/OTF to a UFO::Font (for CFF
+      # sources and as a fallback).
+      def converted_ufo
+        @converted_ufo ||= Fontisan::Ufo::Convert::FromBinData.convert(@font)
       end
 
       def extract_truetype_glyph(gid, cache)

--- a/lib/fontisan/ufo/compile.rb
+++ b/lib/fontisan/ufo/compile.rb
@@ -33,6 +33,7 @@ module Fontisan
       autoload :TtfCompiler,  "fontisan/ufo/compile/ttf_compiler"
       autoload :OtfCompiler,  "fontisan/ufo/compile/otf_compiler"
       autoload :Filters,      "fontisan/ufo/compile/filters"
+      autoload :Gpos,         "fontisan/ufo/compile/gpos"
       autoload :Head,         "fontisan/ufo/compile/head"
       autoload :Hhea,         "fontisan/ufo/compile/hhea"
       autoload :Maxp,         "fontisan/ufo/compile/maxp"

--- a/lib/fontisan/ufo/compile/gpos.rb
+++ b/lib/fontisan/ufo/compile/gpos.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Builds the OpenType `GPOS` (Glyph Positioning) table from UFO
+      # kerning data. Emits a minimal but valid GPOS with:
+      #
+      #   - ScriptList: DFLT script, default language system
+      #   - FeatureList: `kern` feature (feature tag "kern")
+      #   - LookupList: one PairPos lookup (format 1, individual pairs)
+      #
+      # Each kerning pair from the UFO source becomes a PairPosRecord
+      # with an x-advance adjustment on the first glyph.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/gpos
+      module Gpos
+        FEATURE_KERN = "kern"
+        SCRIPT_DFLT = "DFLT"
+        LANGSYS_DEFAULT = 0
+
+        # ValueFormat flags (which fields are present in a ValueRecord)
+        VALUE_X_PLACEMENT = 0x0001
+        VALUE_Y_PLACEMENT = 0x0002
+        VALUE_X_ADVANCE = 0x0004
+        VALUE_Y_ADVANCE = 0x0008
+
+        # @param font [Fontisan::Ufo::Font]
+        # @param glyphs [Array<Fontisan::Ufo::Glyph>] in gid order
+        # @return [String, nil] GPOS table bytes, or nil if no kerning
+        def self.build(font, glyphs:)
+          pairs = collect_kerning_pairs(font, glyphs)
+          return nil if pairs.empty?
+
+          build_gpos_table(pairs)
+        end
+
+        # ---------- pair collection ----------
+
+        # Collect kerning pairs from the UFO model. Each pair is
+        # (gid1, gid2, x_advance_delta).
+        # @return [Array<[Integer, Integer, Integer]>]
+        def self.collect_kerning_pairs(font, glyphs)
+          name_to_gid = {}
+          glyphs.each_with_index { |g, gid| name_to_gid[g.name] = gid }
+
+          pairs = []
+          font.kerning.each_pair do |key, value|
+            # UFO kerning key is "glyph1 glyph2" or a class name.
+            # We only handle individual glyph pairs (not classes).
+            names = key.split
+            next unless names.size == 2
+
+            gid1 = name_to_gid[names[0]]
+            gid2 = name_to_gid[names[1]]
+            next unless gid1 && gid2
+
+            pairs << [gid1, gid2, value.to_i]
+          end
+
+          pairs.sort_by { |a| [a[0], a[1]] }
+        end
+
+        # ---------- GPOS binary assembly ----------
+
+        def self.build_gpos_table(pairs)
+          # Group pairs by first glyph (gid1)
+          by_first = {}
+          pairs.each do |gid1, gid2, delta|
+            by_first[gid1] ||= []
+            by_first[gid1] << [gid2, delta]
+          end
+
+          first_gids = by_first.keys.sort
+
+          # --- Build subtables bottom-up ---
+
+          # 1. PairSets (one per first glyph)
+          pair_sets_data = {}
+          pair_set_offsets = {}
+          pair_sets_blob = +""
+
+          first_gids.each do |gid1|
+            pair_set_offsets[gid1] = pair_sets_blob.bytesize
+
+            second_pairs = by_first[gid1].sort_by { |gid2, _| gid2 }
+            data = [second_pairs.size].pack("n") # pairValueCount
+            second_pairs.each do |gid2, delta|
+              data << [gid2, delta, 0].pack("nnn") # secondGlyph + valRec1(xAdvance) + valRec2(0)
+            end
+
+            pair_sets_data[gid1] = data
+            pair_sets_blob << data
+          end
+
+          # 2. Coverage table (Format 1: individual glyphs)
+          coverage = build_coverage_format1(first_gids)
+
+          # 3. PairPosFormat1 subtable
+          value_format1 = VALUE_X_ADVANCE
+          value_format2 = 0
+
+          pairpos_header_size = 10 # format(2) + coverageOffset(2) + valueFormat1(2) + valueFormat2(2) + pairSetCount(2)
+          pairset_array_size = first_gids.size * 2 # one uint16 offset per first glyph
+
+          coverage_offset = pairpos_header_size + pairset_array_size
+          pairset_base = coverage_offset + coverage.bytesize
+
+          pairpos = +""
+          pairpos << [1].pack("n") # posFormat = 1
+          pairpos << [coverage_offset].pack("n") # coverageOffset
+          pairpos << [value_format1].pack("n") # valueFormat1
+          pairpos << [value_format2].pack("n") # valueFormat2
+          pairpos << [first_gids.size].pack("n") # pairSetCount
+
+          # PairSet offsets (relative to start of PairPos subtable)
+          first_gids.each do |gid1|
+            pairpos << [pairset_base + pair_set_offsets[gid1]].pack("n")
+          end
+
+          pairpos << coverage
+          pairpos << pair_sets_blob
+
+          # 4. Lookup table (type 2 = PairPos, flag 0)
+          lookup_header = [
+            2,   # lookupType = PairPos
+            0,   # lookupFlag
+            1,   # subTableCount
+          ].pack("nnn")
+
+          subtable_offset = lookup_header.bytesize + 2 # +2 for the offset array
+          lookup = lookup_header + [subtable_offset].pack("n") + pairpos
+
+          # 5. Assemble GPOS header + ScriptList + FeatureList + LookupList
+
+          # ScriptList (minimal: DFLT script, default LangSys)
+          script_list = build_script_list
+
+          # FeatureList (minimal: kern feature)
+          feature_list = build_feature_list
+
+          # LookupList (minimal: one lookup)
+          lookup_list_header = [1].pack("n") # lookupCount
+          lookup_offset_in_list = lookup_list_header.bytesize + 2 # +2 for the offset
+          lookup_list = lookup_list_header + [lookup_offset_in_list].pack("n") + lookup
+
+          # GPOS header (version 1.0)
+          header_size = 10 # version(4) + scriptListOffset(2) + featureListOffset(2) + lookupListOffset(2)
+          script_list_offset = header_size
+          feature_list_offset = script_list_offset + script_list.bytesize
+          lookup_list_offset = feature_list_offset + feature_list.bytesize
+
+          header = [
+            0x00010000, # version 1.0
+            script_list_offset,
+            feature_list_offset,
+            lookup_list_offset,
+          ].pack("Nnnn")
+
+          header + script_list + feature_list + lookup_list
+        end
+
+        # Coverage Format 1: list of individual glyph IDs.
+        def self.build_coverage_format1(gids)
+          [1, gids.size].pack("nn") + gids.pack("n*")
+        end
+
+        # ScriptList: DFLT script with a single default LangSys.
+        # The LangSys references feature index 0 (kern).
+        def self.build_script_list
+          # ScriptList header: scriptCount(2)
+          # ScriptRecord: scriptTag(4) + scriptOffset(2)
+          # Script table: defaultLangSysOffset(2) + langSysCount(2) = 0
+          # LangSys: lookupOrder(2)=0 + reqFeatureIndex(2)=0xFFFF + featureIndexCount(2)=1 + featureIndex(2)=0
+
+          script_list_header_size = 2 + (4 + 2) # scriptCount + 1 ScriptRecord
+          script_offset = script_list_header_size
+          langsys_offset = script_offset + 4 # script table size (defaultLangSysOffset + langSysCount)
+
+          script_list = +""
+          script_list << [1].pack("n") # scriptCount
+          script_list << SCRIPT_DFLT # scriptTag
+          script_list << [script_offset].pack("n") # scriptOffset
+
+          # Script table
+          script_list << [langsys_offset - script_offset].pack("n") # defaultLangSysOffset (relative)
+          script_list << [0].pack("n") # langSysCount
+
+          # Default LangSys
+          script_list << [0].pack("n") # lookupOrder (reserved)
+          script_list << [0xFFFF].pack("n") # reqFeatureIndex (none)
+          script_list << [1].pack("n") # featureIndexCount
+          script_list << [0].pack("n") # featureIndex[0] = kern
+
+          script_list
+        end
+
+        # FeatureList: one feature record (kern) referencing lookup 0.
+        def self.build_feature_list
+          # FeatureList header: featureCount(2)
+          # FeatureRecord: featureTag(4) + featureOffset(2)
+          # Feature table: featureParams(2)=0 + lookupIndexCount(2)=1 + lookupIndex(2)=0
+
+          feature_list_header_size = 2 + (4 + 2) # featureCount + 1 FeatureRecord
+          feature_offset = feature_list_header_size
+
+          feature_list = +""
+          feature_list << [1].pack("n") # featureCount
+          feature_list << FEATURE_KERN # featureTag
+          feature_list << [feature_offset].pack("n") # featureOffset
+
+          # Feature table
+          feature_list << [0].pack("n") # featureParams (null)
+          feature_list << [1].pack("n") # lookupIndexCount
+          feature_list << [0].pack("n") # lookupIndex[0]
+
+          feature_list
+        end
+
+        private_class_method :build_gpos_table, :build_coverage_format1,
+                             :build_script_list, :build_feature_list
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/convert/from_bin_data.rb
+++ b/lib/fontisan/ufo/convert/from_bin_data.rb
@@ -179,12 +179,15 @@ module Fontisan
             rescue StandardError
               nil
             end
-            next unless simple
 
             if simple.is_a?(Fontisan::Tables::SimpleGlyph)
               extract_simple_contours(simple, ufo_glyph)
             end
 
+            # Always add the glyph, even if it has no contours. This
+            # ensures gid → array index alignment (no gaps from skipped
+            # glyphs). Without this, high-gid Plane 1 codepoints are
+            # silently dropped because the array is shorter than maxp.
             ufo.layers.default_layer.add(ufo_glyph)
           end
         end

--- a/spec/fontisan/stitcher/cmap_preservation_spec.rb
+++ b/spec/fontisan/stitcher/cmap_preservation_spec.rb
@@ -69,4 +69,32 @@ RSpec.describe "Stitcher cmap preservation (regression)", :donors do
                                 "dropped: #{(beria_erfe - out_beria).map { |cp| format('U+%04X', cp) }.join(', ')}"
     end
   end
+
+  # Regression for 0.4.1 regression: O(1) extraction returned nil for
+  # CFF sources, dropping ALL glyphs from OTF donors.
+  it "preserves Tangut codepoints from an OTF/CFF source" do
+    tangut_path = "/Users/mulgogi/src/essenfont/essenfont/references/input-fonts/NotoSerifTangut-Regular.otf"
+    skip "NotoSerifTangut not present" unless File.exist?(tangut_path)
+
+    src = Fontisan::FontLoader.load(tangut_path)
+    src_cmap = src.table("cmap").unicode_mappings
+    tangut = src_cmap.keys.select { |cp| cp >= 0x17000 && cp <= 0x187FF }.first(100)
+
+    stitcher = Fontisan::Stitcher.new
+    stitcher.add_source(:tangut, src)
+    stitcher.include_notdef(from: :tangut)
+    stitcher.include_codepoints(tangut, from: :tangut)
+
+    Dir.mktmpdir do |dir|
+      out_path = File.join(dir, "out.ttf")
+      stitcher.write_to(out_path, format: :ttf)
+
+      out = Fontisan::FontLoader.load(out_path)
+      out_cmap = out.table("cmap").unicode_mappings
+      out_tangut = out_cmap.keys.select { |cp| cp >= 0x17000 && cp <= 0x187FF }
+
+      expect(out_tangut.size).to eq(tangut.size),
+                                 "expected #{tangut.size} Tangut cps from OTF source, got #{out_tangut.size}"
+    end
+  end
 end


### PR DESCRIPTION
## Critical bug fix: OTF/CFF sources drop Plane 1 codepoints

**Bug**: `Convert::FromBinData` had `next unless simple` which skipped glyphs that failed to parse. This created gaps in the UFO glyph array, causing the Stitcher's `glyph_for_gid(gid)` to return wrong glyphs (array index ≠ gid for high gids). Result: all Plane 1 codepoints from OTF/CFF sources (Tangut, Egyptian Hieroglyphs) were silently dropped.

**Fix**: Remove the skip — always add a glyph to the UFO, even if it has no contours. This maintains gid → array index alignment.

**Verification**: NotoSerifTangut (OTF/CFF, 7238 Tangut cps): 100/100 codepoints preserved (was 0/100).

## TODO 08 partial: GPOS kern feature writer

New `Compile::Gpos` module builds a minimal GPOS table from UFO kerning data:
- ScriptList: DFLT script with default LangSys
- FeatureList: kern feature
- LookupList: PairPos format 1 (individual pairs with x-advance adjustment)

Not yet wired into the compiler pipeline — this commit adds the builder only.

## Test plan
- [x] 50 UFO + Stitcher specs pass
- [x] Rubocop clean
- [x] Tangut OTF source: 100/100 codepoints preserved
- [ ] CI green