### PR TITLE
compile: wire GPOS kern into BaseCompiler (TODO 08 complete)

### DIFF
--- a/lib/fontisan/ufo/compile/base_compiler.rb
+++ b/lib/fontisan/ufo/compile/base_compiler.rb
@@ -40,10 +40,11 @@ module Fontisan
 
         private
 
-        # All tables every OTF/TTF must have.
+        # All tables every OTF/TTF must have, plus optional feature
+        # tables (GPOS for kerning) when the UFO source has kerning data.
         def build_tables
           glyphs = font.glyphs.values
-          {
+          tables = {
             "head" => Head.build(font, glyphs: glyphs),
             "hhea" => Hhea.build(font, glyphs: glyphs),
             "maxp" => Maxp.build(font, glyphs: glyphs),
@@ -52,7 +53,13 @@ module Fontisan
             "post" => Post.build(font, glyphs: glyphs),
             "hmtx" => Hmtx.build(font, glyphs: glyphs),
             "cmap" => Cmap.build(font, glyphs: glyphs),
-          }.merge(build_outline_tables)
+          }
+
+          # GPOS kern table (only when the UFO source has kerning pairs)
+          gpos = Gpos.build(font, glyphs: glyphs)
+          tables["GPOS"] = gpos if gpos
+
+          tables.merge(build_outline_tables)
         end
 
         def write(tables_hash, output_path)


### PR DESCRIPTION
Wires the GPOS kern feature writer into the compiler pipeline. When a UFO source has kerning data, the compiler automatically emits a GPOS table.

This completes TODO 08 for the kern feature. The GPOS table contains:
- ScriptList: DFLT script
- FeatureList: kern feature
- LookupList: PairPos format 1 (individual glyph pairs)

Test plan:
- [x] 51 specs pass
- [x] Rubocop clean
- [ ] CI green