### PR TITLE
ufo: add fvar table builder (variable fonts Phase 1, TODO 09)

### DIFF
--- a/lib/fontisan/ufo/compile.rb
+++ b/lib/fontisan/ufo/compile.rb
@@ -33,6 +33,7 @@ module Fontisan
       autoload :TtfCompiler,  "fontisan/ufo/compile/ttf_compiler"
       autoload :OtfCompiler,  "fontisan/ufo/compile/otf_compiler"
       autoload :Filters,      "fontisan/ufo/compile/filters"
+      autoload :Fvar,         "fontisan/ufo/compile/fvar"
       autoload :Gpos,         "fontisan/ufo/compile/gpos"
       autoload :Head,         "fontisan/ufo/compile/head"
       autoload :Hhea,         "fontisan/ufo/compile/hhea"

--- a/lib/fontisan/ufo/compile/fvar.rb
+++ b/lib/fontisan/ufo/compile/fvar.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Builds the OpenType `fvar` (Font Variations) table from a
+      # list of axis definitions and named instances.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/fvar
+      module Fvar
+        VERSION_MAJOR = 1
+        VERSION_MINOR = 0
+        AXIS_SIZE = 20
+        INSTANCE_SIZE = 4 # + 4 per axis
+        FIXED_SHIFT = 16
+        FIXED_ONE = 1 << FIXED_SHIFT
+
+        # @param font [Fontisan::Ufo::Font]
+        # @param axes [Array<Hash>] axis definitions
+        # @param instances [Array<Hash>] named instance definitions
+        # @return [String, nil] fvar table bytes, or nil if no axes
+        def self.build(font, axes: nil, instances: nil)
+          axes ||= font.info.respond_to?(:axes) ? font.info.axes : nil
+          instances ||= font.info.respond_to?(:named_instances) ? font.info.named_instances : nil
+
+          axes ||= []
+          return nil if axes.empty?
+
+          axes_bytes = build_axes(axes)
+          instances_bytes = build_instances(instances || [], axes.size)
+          header = build_header(axes.size, axes_bytes, instances_bytes, instances)
+          header + axes_bytes + instances_bytes
+        end
+
+        # ---------- header ----------
+
+        # Header is 16 bytes:
+        #   majorVersion (2) + minorVersion (2) + axesArrayOffset (2)
+        #   + reserved (2) + axisCount (2) + axisSize (2)
+        #   + instanceCount (2) + instanceSize (2)
+        def self.build_header(axis_count, axes_bytes, _instances_bytes, instances)
+          axes_offset = 16
+          axes_offset + axes_bytes.bytesize
+
+          [
+            VERSION_MAJOR,
+            VERSION_MINOR,
+            axes_offset,
+            0, # reserved
+            axis_count,
+            AXIS_SIZE,
+            instances&.size || 0,
+            (instances&.size || 0).zero? ? 0 : (INSTANCE_SIZE + axis_count * 4),
+          ].pack("nnnnnnnn")
+        end
+
+        # ---------- axes ----------
+
+        # Each axis record is 20 bytes:
+        #   axisTag (4) + minValue (4) + defaultValue (4) + maxValue (4)
+        #   + flags (2) + axisNameID (2)
+        def self.build_axes(axes)
+          io = +""
+          axes.each do |axis|
+            tag = (axis[:tag] || axis["tag"] || "wght").to_s.ljust(4, " ")[0, 4]
+            min = fixed_value(axis[:min] || axis["min"] || 100)
+            default = fixed_value(axis[:default] || axis["default"] || 400)
+            max = fixed_value(axis[:max] || axis["max"] || 900)
+            flags = axis[:flags] || axis["flags"] || 0
+            name_id = axis[:name_id] || axis["name_id"] || 0
+
+            io << tag
+            io << [min, default, max, flags, name_id].pack("NNNnn")
+          end
+          io
+        end
+
+        # ---------- instances ----------
+
+        # Each instance record: subfamilyNameID (2) + flags (2) + per-axis coords
+        def self.build_instances(instances, axis_count)
+          return +"" if instances.empty?
+
+          io = +""
+          instances.each do |inst|
+            name_id = inst[:name_id] || inst["name_id"] || 0
+            flags = inst[:flags] || inst["flags"] || 0
+            coords = inst[:coords] || inst["coords"] || []
+            padded = coords.first(axis_count) + Array.new([axis_count - coords.size, 0].max, 0)
+            padded = padded.first(axis_count).map { |c| fixed_value(c) }
+
+            io << [name_id, flags].pack("nn")
+            io << padded.pack("N*")
+          end
+          io
+        end
+
+        # ---------- helpers ----------
+
+        # Convert a float to OpenType Fixed 16.16 (int32).
+        def self.fixed_value(value)
+          (value.to_f * FIXED_ONE).to_i
+        end
+        private_class_method :build_header, :build_axes, :build_instances,
+                             :fixed_value
+      end
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile_fvar_spec.rb
+++ b/spec/fontisan/ufo/compile_fvar_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan"
+require "fontisan/ufo/compile"
+
+RSpec.describe Fontisan::Ufo::Compile::Fvar do
+  describe ".build" do
+    it "returns nil when no axes are defined" do
+      font = Fontisan::Ufo::Font.new
+      expect(described_class.build(font)).to be_nil
+    end
+
+    it "returns nil when axes list is empty" do
+      font = Fontisan::Ufo::Font.new
+      expect(described_class.build(font, axes: [])).to be_nil
+    end
+
+    it "builds a valid fvar header for a single axis" do
+      font = Fontisan::Ufo::Font.new
+      bytes = described_class.build(
+        font,
+        axes: [{ tag: "wght", min: 100, default: 400, max: 900 }],
+      )
+
+      major, minor = bytes.unpack("@0 n n")
+      expect(major).to eq(1)
+      expect(minor).to eq(0)
+    end
+
+    it "encodes axis min/default/max as Fixed 16.16" do
+      font = Fontisan::Ufo::Font.new
+      bytes = described_class.build(
+        font,
+        axes: [{ tag: "wght", min: 100, default: 400, max: 900 }],
+      )
+
+      # After 16 bytes of header, the axis record starts.
+      # axisTag (4) + minValue (4) + defaultValue (4) + maxValue (4) ...
+      axis_data = bytes[16, 20]
+      tag = axis_data[0, 4]
+      min, default, max = axis_data[4, 12].unpack("N*")
+
+      expect(tag).to eq("wght")
+      expect(min).to eq(100 * 65_536)      # 100.0 in Fixed
+      expect(default).to eq(400 * 65_536)  # 400.0
+      expect(max).to eq(900 * 65_536)      # 900.0
+    end
+
+    it "emits multiple axes" do
+      font = Fontisan::Ufo::Font.new
+      bytes = described_class.build(
+        font,
+        axes: [
+          { tag: "wght", min: 100, default: 400, max: 900 },
+          { tag: "wdth", min: 75, default: 100, max: 125 },
+        ],
+      )
+
+      axis_count = bytes.unpack1("@8 n")
+      expect(axis_count).to eq(2)
+      expect(bytes.bytesize).to be >= (16 + 2 * 20)
+    end
+
+    it "emits named instances when provided" do
+      font = Fontisan::Ufo::Font.new
+      bytes = described_class.build(
+        font,
+        axes: [{ tag: "wght", min: 100, default: 400, max: 900 }],
+        instances: [
+          { name_id: 256, flags: 0, coords: [400] },
+          { name_id: 257, flags: 0, coords: [700] },
+        ],
+      )
+
+      instance_count = bytes.unpack1("@12 n")
+      expect(instance_count).to eq(2)
+    end
+
+    it "pads instance coords to axis count" do
+      font = Fontisan::Ufo::Font.new
+      bytes = described_class.build(
+        font,
+        axes: [
+          { tag: "wght", min: 100, default: 400, max: 900 },
+          { tag: "wdth", min: 75, default: 100, max: 125 },
+        ],
+        instances: [{ name_id: 256, flags: 0, coords: [500] }], # only 1 coord for 2 axes
+      )
+
+      # header(16) + axes(2*20) + instances(1 * (4 + 2*4))
+      expected_min = 16 + (2 * 20) + (4 + (2 * 4))
+      expect(bytes.bytesize).to be >= expected_min
+    end
+
+    it "emits an axisSize of 20 bytes" do
+      font = Fontisan::Ufo::Font.new
+      bytes = described_class.build(
+        font,
+        axes: [{ tag: "wght", min: 100, default: 400, max: 900 }],
+      )
+
+      axis_size = bytes.unpack1("@10 n")
+      expect(axis_size).to eq(20)
+    end
+  end
+end


### PR DESCRIPTION
First step toward variable font support. The `Compile::Fvar` module builds the OpenType fvar (Font Variations) table from axis definitions and named instances.

Features:
- Axis records: tag + min/default/max (Fixed 16.16) + flags + nameID
- Instance records: subfamilyNameID + flags + per-axis coords
- Instance coords auto-padded to axis count
- Returns nil when no axes (non-variable fonts are unaffected)

8 specs covering header validation, Fixed encoding, multi-axis, named instances, coord padding.

This is Phase 1 of 4 for TODO 09 (variable fonts):
- Phase 1 ✅: fvar (this PR)
- Phase 2: gvar + avar (the hard part — per-glyph deltas + IUP)
- Phase 3: HVAR + MVAR + STAT
- Phase 4: integration tests with VariableTtf compiler

Test plan:
- [x] 59 UFO + Stitcher specs pass
- [x] Rubocop clean
- [ ] CI green