### PR TITLE
ufo: variable font Phase 3+4 (avar, HVAR, MVAR, STAT, VariableTtf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Fontisan::Ufo::Compile::Avar` — builds the OpenType `avar` (Axis
+  Variation) table with per-axis non-linear maps (defaults to identity
+  -1/0/1 mapping).
+- `Fontisan::Ufo::Compile::Hvar` — builds the OpenType `HVAR`
+  (Horizontal Metrics Variation) table with advance-width deltas per
+  glyph.
+- `Fontisan::Ufo::Compile::Mvar` — builds the OpenType `MVAR`
+  (Metrics Variation) table for font-wide metric deltas (ascender,
+  descender, etc.).
+- `Fontisan::Ufo::Compile::Stat` — builds the OpenType `STAT` (Style
+  Attributes) table with design axes, axis value tables, and elided
+  fallback name ID.
+- `Fontisan::Ufo::Compile::ItemVariationStore` — shared builder for
+  the ItemVariationStore structure used by HVAR and MVAR
+  (VariationRegionList + ItemVariationData with int8/int16 delta
+  packing).
+- `Fontisan::Ufo::Compile::VariableTtf` — orchestrator that compiles
+  a default UFO master plus variation masters into a single variable
+  TTF (emits fvar, gvar, HVAR, MVAR, avar, STAT alongside the standard
+  TTF tables).
+- `TtfCompiler#build_tables` — extracted public method returning the
+  TTF table hash without writing, so `VariableTtf` can reuse the
+  standard table pipeline.
+
 ### Removed
 
 - Audit subsystem (`Fontisan::Audit`, `Fontisan::Commands::Audit*`,

--- a/lib/fontisan/ufo/compile.rb
+++ b/lib/fontisan/ufo/compile.rb
@@ -46,6 +46,13 @@ module Fontisan
       autoload :Cmap,         "fontisan/ufo/compile/cmap"
       autoload :GlyfLoca,     "fontisan/ufo/compile/glyf_loca"
       autoload :Cff,          "fontisan/ufo/compile/cff"
+      autoload :Avar,         "fontisan/ufo/compile/avar"
+      autoload :Hvar,         "fontisan/ufo/compile/hvar"
+      autoload :Mvar,         "fontisan/ufo/compile/mvar"
+      autoload :Stat,         "fontisan/ufo/compile/stat"
+      autoload :VariableTtf,  "fontisan/ufo/compile/variable_ttf"
+      autoload :ItemVariationStore,
+               "fontisan/ufo/compile/item_variation_store"
     end
   end
 end

--- a/lib/fontisan/ufo/compile/avar.rb
+++ b/lib/fontisan/ufo/compile/avar.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Builds the OpenType `avar` (Axis Variation) table.
+      #
+      # avar defines non-linear interpolation curves for each axis.
+      # For axes with linear interpolation (the common case), each
+      # axis gets 3 default maps: (-1→-1, 0→0, 1→1).
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/avar
+      module Avar
+        # @param axes [Array<Hash>] axis definitions (tag + optional maps)
+        # @return [String] avar table bytes
+        def self.build(axes:)
+          return nil if axes.nil? || axes.empty?
+
+          io = +""
+          io << [0x00010000].pack("N") # version 1.0
+          io << [0].pack("n")          # reserved
+          io << [axes.size].pack("n")  # axisCount
+
+          axes.each do |axis|
+            maps = axis[:maps] || default_maps
+            io << [maps.size].pack("n")
+            maps.each do |from, to|
+              io << [f2dot14(from), f2dot14(to)].pack("nn")
+            end
+          end
+
+          io
+        end
+
+        def self.default_maps
+          [[-1.0, -1.0], [0.0, 0.0], [1.0, 1.0]].freeze
+        end
+
+        def self.f2dot14(value)
+          (value.to_f * 16384).to_i.clamp(-16384, 16384)
+        end
+        private_class_method :default_maps, :f2dot14
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/hvar.rb
+++ b/lib/fontisan/ufo/compile/hvar.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Builds the OpenType `HVAR` (Horizontal Metrics Variation) table.
+      #
+      # Stores advance-width variation deltas per glyph, enabling
+      # variable-font renderers to adjust spacing without loading gvar.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/HVAR
+      module Hvar
+        # @param default_widths [Array<Integer>] advance widths for default master
+        # @param master_widths [Array<Array<Integer>>] advance widths per master
+        # @param axis_count [Integer]
+        # @return [String] HVAR table bytes
+        def self.build(default_widths:, master_widths:, axis_count:)
+          glyph_count = default_widths.size
+          master_count = master_widths.size
+
+          # Compute deltas: deltas[glyph][master] = master_width - default_width
+          deltas = Array.new(glyph_count) do |gid|
+            Array.new(master_count) do |mid|
+              master_widths.dig(mid, gid).to_i - default_widths[gid].to_i
+            end
+          end
+
+          store = ItemVariationStore.build(
+            axis_count: axis_count,
+            master_count: master_count,
+            item_count: glyph_count,
+            deltas: deltas,
+          )
+
+          # HVAR header: version(4) + itemVariationStoreOffset(4) +
+          # advanceWidthMappingOffset(4) + lsbMappingOffset(4) + rsbMappingOffset(4)
+          [0x00010000, 20].pack("NN") + [0, 0, 0].pack("NNN") + store
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/item_variation_store.rb
+++ b/lib/fontisan/ufo/compile/item_variation_store.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Shared builder for the ItemVariationStore structure used by
+      # HVAR, MVAR, and other variation tables.
+      #
+      # The ItemVariationStore consists of:
+      #   1. A VariationRegionList (defines axis regions)
+      #   2. One or more ItemVariationData (delta sets per item)
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats
+      module ItemVariationStore
+        # @param axis_count [Integer]
+        # @param master_count [Integer] number of masters (one region per master)
+        # @param item_count [Integer] number of items (glyphs for HVAR, metrics for MVAR)
+        # @param deltas [Array<Array<Integer>>] deltas[item][master] = delta value
+        # @return [String] ItemVariationStore bytes
+        def self.build(axis_count:, master_count:, item_count:, deltas:)
+          # Build regions: one per master, each with peak=1.0 on its axis
+          regions = build_regions(axis_count, master_count)
+          region_list = serialize_region_list(regions, axis_count)
+
+          # Build ItemVariationData: one data block covering all items
+          var_data = serialize_variation_data(item_count, master_count, deltas)
+
+          # Assemble the store
+          # Header layout: format(uint16) + variationRegionListOffset(uint32)
+          # + itemVariationDataCount(uint16) + itemVariationDataOffsets[1](uint32)
+          #             = 2 + 4 + 2 + 4 = 12 bytes total before region list
+          header_size = 8 # format(2) + regionListOffset(4) + itemVariationDataCount(2)
+          offsets_array_size = 4 # one data block → one offset
+          region_list_offset = header_size + offsets_array_size
+          var_data_offset = region_list_offset + region_list.bytesize
+
+          store = +""
+          store << [1].pack("n")                    # format = 1
+          store << [region_list_offset].pack("N")   # variationRegionListOffset
+          store << [1].pack("n")                    # itemVariationDataCount
+          store << [var_data_offset].pack("N")      # itemVariationDataOffsets[0]
+          store << region_list
+          store << var_data
+          store
+        end
+
+        def self.build_regions(axis_count, master_count)
+          Array.new(master_count) do |master_idx|
+            Array.new(axis_count) do |axis_idx|
+              if axis_idx == master_idx
+                { start: -1.0, peak: 1.0, end: 1.0 }
+              else
+                { start: -1.0, peak: 0.0, end: 1.0 }
+              end
+            end
+          end
+        end
+
+        def self.serialize_region_list(regions, axis_count)
+          io = +""
+          io << [axis_count].pack("n") # axisCount
+          io << [regions.size].pack("n") # regionCount
+          regions.each do |region|
+            region.each do |coords|
+              io << [f2dot14(coords[:start]), f2dot14(coords[:peak]), f2dot14(coords[:end])].pack("nnn")
+            end
+          end
+          io
+        end
+
+        def self.serialize_variation_data(item_count, region_count, deltas)
+          # Determine if all deltas fit in int8 (-128..127)
+          all_short = deltas.flatten.any? { |d| !d.between?(-127, 127) }
+          short_count = all_short ? region_count : 0
+
+          io = +""
+          io << [item_count].pack("n")     # itemCount
+          io << [short_count].pack("n")    # shortDeltaCount
+          io << [region_count].pack("n")   # regionIndexCount (all regions)
+          region_count.times { |i| io << [i].pack("n") } # regionIndices
+
+          deltas.each do |item_deltas|
+            item_deltas.each_with_index do |delta, i|
+              io << (i < short_count ? [delta].pack("s>") : [delta].pack("c"))
+            end
+          end
+
+          io
+        end
+
+        def self.f2dot14(value)
+          (value.to_f * 16384).to_i.clamp(-16384, 16384)
+        end
+        private_class_method :build_regions, :serialize_region_list,
+                             :serialize_variation_data, :f2dot14
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/mvar.rb
+++ b/lib/fontisan/ufo/compile/mvar.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Builds the OpenType `MVAR` (Metrics Variation) table.
+      #
+      # Stores deltas for font-wide metrics (ascender, descender, etc.)
+      # so they can vary across the design space.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/MVAR
+      module Mvar
+        HEADER_SIZE = 10 # majorVersion(2) + minorVersion(2) + valueRecordSize(2) +
+        #                valueRecordCount(2) + itemVariationStoreOffset(2)
+        VALUE_RECORD_SIZE = 8 # tag(4) + outerIndex(2) + innerIndex(2)
+
+        # @param default_metrics [Hash<Symbol, Integer>] e.g. { hasc: 800, hdsc: -200 }
+        # @param master_metrics [Array<Hash<Symbol, Integer>>] per master
+        # @param axis_count [Integer]
+        # @return [String] MVAR table bytes
+        def self.build(default_metrics:, master_metrics:, axis_count:)
+          tags = default_metrics.keys
+          return nil if tags.empty?
+
+          master_count = master_metrics.size
+
+          deltas = []
+          records = +""
+          tags.each_with_index do |tag, idx|
+            tag_bytes = tag.to_s.ljust(4, " ")[0, 4]
+            delta = master_metrics.dig(0, tag).to_i - default_metrics[tag].to_i
+            records << tag_bytes
+            records << [0, idx].pack("nn") # outerIndex=0, innerIndex=idx
+            deltas << [delta]
+          end
+
+          store = ItemVariationStore.build(
+            axis_count: axis_count,
+            master_count: master_count,
+            item_count: tags.size,
+            deltas: deltas,
+          )
+
+          store_offset = HEADER_SIZE + records.bytesize
+
+          io = +""
+          io << [1].pack("n")                # majorVersion
+          io << [0].pack("n")                # minorVersion
+          io << [VALUE_RECORD_SIZE].pack("n")
+          io << [tags.size].pack("n")        # valueRecordCount
+          io << [store_offset].pack("n")     # itemVariationStoreOffset (Offset16)
+          io << records
+          io << store
+          io
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/stat.rb
+++ b/lib/fontisan/ufo/compile/stat.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Builds the OpenType `STAT` (Style Attributes) table.
+      #
+      # Describes style attributes for each axis and named instances.
+      # Required for proper font matching in operating systems.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/STAT
+      module Stat
+        HEADER_SIZE = 20
+        DESIGN_AXIS_RECORD_SIZE = 8 # tag(4) + nameID(2) + ordering(2)
+        AXIS_VALUE_OFFSET_SIZE = 4  # uint32 per axis value
+
+        # @param axes [Array<Hash>] axis definitions with tag + name_id + ordering
+        # @param axis_values [Array<Hash>] value records per axis
+        # @param elided_name_id [Integer, nil] fallback name ID
+        # @return [String] STAT table bytes
+        def self.build(axes:, axis_values: nil, elided_name_id: nil)
+          return nil if axes.nil? || axes.empty?
+
+          design_axis_count = axes.size
+          axis_value_list = axis_values || []
+          axis_value_count = axis_value_list.size
+
+          design_axes = serialize_design_axes(axes)
+          value_tables, value_offsets = serialize_axis_values(axis_value_list, design_axes.bytesize)
+
+          header = serialize_header(
+            design_axis_count: design_axis_count,
+            design_axes_size: design_axes.bytesize,
+            axis_value_count: axis_value_count,
+            elided_name_id: elided_name_id,
+          )
+
+          io = +""
+          io << header
+          io << design_axes
+          axis_value_list.each_index do |i|
+            io << [value_offsets[i]].pack("N")
+          end
+          io << value_tables
+          io
+        end
+
+        def self.serialize_header(design_axis_count:, design_axes_size:, axis_value_count:, elided_name_id:)
+          design_axes_offset = HEADER_SIZE
+          offset_to_axis_value_offsets = design_axes_offset + design_axes_size
+
+          [
+            0x00010001, # version 1.1
+            DESIGN_AXIS_RECORD_SIZE,
+            design_axis_count,
+            design_axes_offset,
+            axis_value_count,
+            offset_to_axis_value_offsets,
+            elided_name_id || 0,
+          ].pack("NnnNnNn")
+        end
+
+        def self.serialize_design_axes(axes)
+          io = +""
+          axes.each_with_index do |axis, i|
+            tag = (axis[:tag] || axis["tag"] || "    ").to_s.ljust(4, " ")[0, 4]
+            name_id = axis[:name_id] || axis["name_id"] || 0
+            ordering = axis[:ordering] || axis["ordering"] || i
+            io << tag
+            io << [name_id, ordering].pack("nn")
+          end
+          io
+        end
+
+        # Each AxisValueTable is Format 1 (nominal): format(2) + axisIndex(2)
+        # + flags(2) + valueNameID(2) + value(F2DOT14) = 10 bytes.
+        def self.serialize_axis_values(axis_values, design_axes_size)
+          value_tables = +""
+          value_offsets = []
+          base = HEADER_SIZE + design_axes_size + (axis_values.size * AXIS_VALUE_OFFSET_SIZE)
+
+          axis_values.each do |av|
+            value_offsets << (base + value_tables.bytesize)
+            format = 1
+            axis_idx = av[:axis_index] || av["axis_index"] || 0
+            flags = av[:flags] || av["flags"] || 0
+            name_id = av[:name_id] || av["name_id"] || 0
+            value = f2dot14(av[:value] || av["value"] || 0)
+            value_tables << [format, axis_idx, flags, name_id, value].pack("nnnnn")
+          end
+
+          [value_tables, value_offsets]
+        end
+
+        def self.f2dot14(value)
+          (value.to_f * 16384).to_i.clamp(-16384, 16384)
+        end
+        private_class_method :serialize_header, :serialize_design_axes,
+                             :serialize_axis_values, :f2dot14
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/ttf_compiler.rb
+++ b/lib/fontisan/ufo/compile/ttf_compiler.rb
@@ -12,7 +12,8 @@ module Fontisan
       class TtfCompiler < BaseCompiler
         SFNT_VERSION = SFNT_VERSION_TRUE_TYPE
 
-        def compile(output_path:)
+        # @return [Hash<String, #to_binary_s>] all TTF tables, not yet written
+        def build_tables
           glyphs = font.glyphs.values
 
           # Deep-clone glyphs so filters don't mutate the source UFO.
@@ -22,7 +23,7 @@ module Fontisan
           glyf_loca = GlyfLoca.build(font, glyphs: filtered)
           loca_format = glyf_loca.delete(:loca_format)
 
-          tables = {
+          {
             "head" => Head.build(font, glyphs: filtered,
                                        loca_format: loca_format || Head::LOCA_FORMAT_LONG),
             "hhea" => Hhea.build(font, glyphs: filtered),
@@ -36,8 +37,10 @@ module Fontisan
             "glyf" => glyf_loca["glyf"],
             "loca" => glyf_loca["loca"],
           }
+        end
 
-          write(tables, output_path)
+        def compile(output_path:)
+          write(build_tables, output_path)
           output_path
         end
 

--- a/lib/fontisan/ufo/compile/variable_ttf.rb
+++ b/lib/fontisan/ufo/compile/variable_ttf.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Orchestrates compilation of a UFO source plus its variation
+      # masters into a single variable TrueType font.
+      #
+      # Pipeline:
+      #
+      #   default UFO font
+      #     │
+      #     ├─ TtfCompiler tables (head, hhea, maxp, OS/2, name,
+      #     │                     post, hmtx, cmap, glyf, loca)
+      #     │
+      #     ├─ fvar  (axes + named instances)
+      #     ├─ gvar  (per-glyph point deltas across masters)
+      #     ├─ HVAR  (advance-width deltas across masters)
+      #     ├─ MVAR  (font-wide metric deltas across masters)
+      #     ├─ avar  (per-axis non-linear maps; defaults to identity)
+      #     └─ STAT  (style attributes for OS matching)
+      #
+      # Masters are supplied as an Array of Hashes, each with:
+      #   - :font   — the master UFO::Font
+      #   - :axes   — Hash<String, Float> mapping axis tag → region peak
+      #
+      class VariableTtf
+        SFNT_VERSION = BaseCompiler::SFNT_VERSION_TRUE_TYPE
+
+        # @param font [Fontisan::Ufo::Font] default master
+        # @param axes [Array<Hash>] axis definitions (tag, min/default/max,
+        #   optional name_id, ordering, maps)
+        # @param masters [Array<Hash>] each master: { font:, axes: }
+        # @param instances [Array<Hash>] named instances for fvar
+        # @param stat_axis_values [Array<Hash>, nil] STAT axis value records
+        # @param stat_elided_name_id [Integer, nil] STAT elided fallback name
+        # @param default_metrics [Hash<Symbol, Integer>, nil] MVAR defaults
+        # @param master_metrics [Array<Hash<Symbol, Integer>>, nil] MVAR per-master
+        def initialize(font:, axes:, masters:, instances: nil,
+                       stat_axis_values: nil, stat_elided_name_id: nil,
+                       default_metrics: nil, master_metrics: nil)
+          @font = font
+          @axes = axes
+          @masters = masters
+          @instances = instances
+          @stat_axis_values = stat_axis_values
+          @stat_elided_name_id = stat_elided_name_id
+          @default_metrics = default_metrics
+          @master_metrics = master_metrics
+        end
+
+        # @param output_path [String]
+        # @return [String] the output path
+        def compile(output_path:)
+          tables = base_tables.merge(variation_tables)
+          write(tables, output_path)
+          output_path
+        end
+
+        private
+
+        def base_tables
+          @base_tables ||= TtfCompiler.new(@font).build_tables
+        end
+
+        def variation_tables
+          axis_count = @axes.size
+          tables = {}
+
+          fvar_bytes = Fvar.build(@font, axes: @axes, instances: @instances)
+          tables["fvar"] = fvar_bytes if fvar_bytes
+
+          avar_bytes = Avar.build(axes: @axes)
+          tables["avar"] = avar_bytes if avar_bytes
+
+          stat_bytes = Stat.build(
+            axes: stat_axes,
+            axis_values: @stat_axis_values,
+            elided_name_id: @stat_elided_name_id,
+          )
+          tables["STAT"] = stat_bytes if stat_bytes
+
+          default_glyphs = @font.glyphs.values
+          glyph_order = default_glyphs.map(&:name)
+
+          gvar_masters = @masters.map do |m|
+            {
+              axes: m[:axes],
+              glyphs: glyphs_for_master(m[:font], glyph_order),
+            }
+          end
+          tables["gvar"] = Gvar.build(
+            default_glyphs: default_glyphs,
+            masters: gvar_masters,
+            axis_count: axis_count,
+          )
+
+          default_widths = default_glyphs.map { |g| g.width.to_i }
+          master_widths = @masters.map do |m|
+            glyphs_for_master(m[:font], glyph_order).map { |g| g.width.to_i }
+          end
+          tables["HVAR"] = Hvar.build(
+            default_widths: default_widths,
+            master_widths: master_widths,
+            axis_count: axis_count,
+          )
+
+          if @default_metrics && @master_metrics
+            mvar = Mvar.build(
+              default_metrics: @default_metrics,
+              master_metrics: @master_metrics,
+              axis_count: axis_count,
+            )
+            tables["MVAR"] = mvar if mvar
+          end
+
+          tables
+        end
+
+        # Project a master's glyphs onto the default master's glyph order
+        # so deltas align by index. Missing glyphs default to the master's
+        # .notdef (index 0).
+        def glyphs_for_master(master_font, glyph_order)
+          by_name = master_font.glyphs
+          notdef = by_name.values.first
+          glyph_order.map { |name| by_name[name] || notdef }
+        end
+
+        # STAT design-axis records derived from @axes. Each axis may
+        # supply :name_id and :ordering; missing values default sensibly.
+        def stat_axes
+          @axes.each_with_index.map do |axis, i|
+            {
+              tag: axis[:tag] || axis["tag"],
+              name_id: axis[:name_id] || axis["name_id"] || 0,
+              ordering: axis[:ordering] || axis["ordering"] || i,
+            }
+          end
+        end
+
+        def write(tables_hash, output_path)
+          dir = File.dirname(output_path)
+          FileUtils.mkpath(dir) unless dir == "."
+          Fontisan::FontWriter.write_to_file(
+            tables_hash.transform_values { |t| serialize_table(t) },
+            output_path,
+            sfnt_version: SFNT_VERSION,
+          )
+        end
+
+        # BinData records respond to to_binary_s; raw String values pass through.
+        def serialize_table(table)
+          case table
+          when String then table
+          else table.to_binary_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile_avar_spec.rb
+++ b/spec/fontisan/ufo/compile_avar_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+
+RSpec.describe Fontisan::Ufo::Compile::Avar do
+  describe ".build" do
+    it "returns nil when axes is nil" do
+      expect(described_class.build(axes: nil)).to be_nil
+    end
+
+    it "returns nil when axes is empty" do
+      expect(described_class.build(axes: [])).to be_nil
+    end
+
+    it "emits version 1.0" do
+      bytes = described_class.build(axes: [{ tag: "wght" }])
+      version = bytes.unpack1("N")
+      expect(version).to eq(0x00010000)
+    end
+
+    it "emits reserved uint16 = 0 after version" do
+      bytes = described_class.build(axes: [{ tag: "wght" }])
+      reserved = bytes.unpack1("@4 n")
+      expect(reserved).to eq(0)
+    end
+
+    it "emits the correct axis count" do
+      bytes = described_class.build(
+        axes: [
+          { tag: "wght" },
+          { tag: "wdth" },
+        ],
+      )
+      axis_count = bytes.unpack1("@6 n")
+      expect(axis_count).to eq(2)
+    end
+
+    it "emits 3 default maps per axis when no maps are supplied" do
+      bytes = described_class.build(axes: [{ tag: "wght" }])
+      # After 8-byte header, each axis starts with a uint16 mapCount.
+      map_count = bytes.unpack1("@8 n")
+      expect(map_count).to eq(3)
+    end
+
+    it "encodes default maps -1/-1, 0/0, 1/1 as f2dot14" do
+      bytes = described_class.build(axes: [{ tag: "wght" }])
+      # header(8) + mapCount(2) = 10, then 3 pairs of int16.
+      pairs = bytes[10, 12].unpack("n6")
+      # f2dot14(-1.0) = -16384 = 0xC000 (uint16)
+      # f2dot14(0.0)  = 0
+      # f2dot14(1.0)  = 16384 = 0x4000
+      expect(pairs[0]).to eq(0xC000) # -1.0
+      expect(pairs[1]).to eq(0xC000) # -1.0
+      expect(pairs[2]).to eq(0)      # 0.0
+      expect(pairs[3]).to eq(0)      # 0.0
+      expect(pairs[4]).to eq(0x4000) # 1.0
+      expect(pairs[5]).to eq(0x4000) # 1.0
+    end
+
+    it "emits custom maps when supplied" do
+      bytes = described_class.build(
+        axes: [
+          {
+            tag: "wght",
+            maps: [[-1.0, -0.5], [0.0, 0.0], [1.0, 0.8]],
+          },
+        ],
+      )
+      map_count = bytes.unpack1("@8 n")
+      expect(map_count).to eq(3)
+
+      pairs = bytes[10, 12].unpack("n6")
+      # -1.0 → -16384 → 0xC000; -0.5 → -8192 → 0xE000 (as uint16)
+      # 1.0 → 16384 → 0x4000; 0.8 → 13107 → 0x3333
+      expect(pairs[0]).to eq(0xC000) # from -1.0
+      expect(pairs[1]).to eq(0xE000) # to   -0.5
+      expect(pairs[4]).to eq(0x4000) # from  1.0
+      expect(pairs[5]).to eq(0x3333) # to    0.8
+    end
+
+    it "emits multiple axis segments back-to-back" do
+      bytes = described_class.build(
+        axes: [
+          { tag: "wght" },
+          { tag: "wdth" },
+        ],
+      )
+      # header(8) + axis0 (2 + 12) = 22; axis1 mapCount starts at offset 22.
+      map_count_axis1 = bytes.unpack1("@22 n")
+      expect(map_count_axis1).to eq(3)
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile_hvar_spec.rb
+++ b/spec/fontisan/ufo/compile_hvar_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+
+RSpec.describe Fontisan::Ufo::Compile::Hvar do
+  describe ".build" do
+    it "emits version 1.0" do
+      bytes = described_class.build(
+        default_widths: [500], master_widths: [[600]], axis_count: 1,
+      )
+      version = bytes.unpack1("N")
+      expect(version).to eq(0x00010000)
+    end
+
+    it "emits itemVariationStoreOffset at byte 20" do
+      bytes = described_class.build(
+        default_widths: [500], master_widths: [[600]], axis_count: 1,
+      )
+      store_offset = bytes.unpack1("@4 N")
+      # HVAR header = version(4) + itemVariationStoreOffset(4) +
+      # advanceWidthMappingOffset(4) + lsbMappingOffset(4) + rsbMappingOffset(4) = 20
+      expect(store_offset).to eq(20)
+    end
+
+    it "leaves advance/lsb/rsb mapping offsets as 0 (implicit identity)" do
+      bytes = described_class.build(
+        default_widths: [500], master_widths: [[600]], axis_count: 1,
+      )
+      adv = bytes.unpack1("@8 N")
+      lsb = bytes.unpack1("@12 N")
+      rsb = bytes.unpack1("@16 N")
+      expect(adv).to eq(0)
+      expect(lsb).to eq(0)
+      expect(rsb).to eq(0)
+    end
+
+    it "passes the ItemVariationStore through" do
+      bytes = described_class.build(
+        default_widths: [500, 600], master_widths: [[550, 700]], axis_count: 1,
+      )
+      store_offset = bytes.unpack1("@4 N")
+      # ItemVariationStore format = 1 (uint16) at the start of the store block.
+      format = bytes.unpack1("@#{store_offset} n")
+      expect(format).to eq(1)
+    end
+
+    it "computes deltas as master_width - default_width" do
+      bytes = described_class.build(
+        default_widths: [500, 600],
+        master_widths: [[550, 700]],
+        axis_count: 1,
+      )
+      store_offset = bytes.unpack1("@4 N")
+      data_offset_rel = bytes.unpack1("@#{store_offset + 8} N")
+      data_offset = store_offset + data_offset_rel
+
+      # ItemVariationData: itemCount(2) + shortDeltaCount(2) + regionIndexCount(2)
+      # + regionIndices(2 × region_count) + delta sets.
+      # 2 glyphs × 1 region, deltas 50 and 100 → both fit in int8.
+      item_count = bytes.unpack1("@#{data_offset} n")
+      short_count = bytes.unpack1("@#{data_offset + 2} n")
+      region_index_count = bytes.unpack1("@#{data_offset + 4} n")
+      expect(item_count).to eq(2)
+      expect(short_count).to eq(0)
+      expect(region_index_count).to eq(1)
+
+      # Data header (6) + regionIndices (2) = 8 bytes, then 2 int8 deltas
+      deltas = bytes[data_offset + 8, 2].unpack("c2")
+      expect(deltas).to eq([50, 100])
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile_item_variation_store_spec.rb
+++ b/spec/fontisan/ufo/compile_item_variation_store_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+
+RSpec.describe Fontisan::Ufo::Compile::ItemVariationStore do
+  describe ".build" do
+    it "emits format = 1" do
+      bytes = described_class.build(
+        axis_count: 1, master_count: 1, item_count: 1, deltas: [[10]],
+      )
+      format = bytes.unpack1("n")
+      expect(format).to eq(1)
+    end
+
+    it "emits a single ItemVariationData block (count = 1)" do
+      bytes = described_class.build(
+        axis_count: 1, master_count: 1, item_count: 1, deltas: [[10]],
+      )
+      data_count = bytes.unpack1("@6 n")
+      expect(data_count).to eq(1)
+    end
+
+    it "writes variationRegionListOffset pointing at byte 12" do
+      bytes = described_class.build(
+        axis_count: 1, master_count: 1, item_count: 1, deltas: [[10]],
+      )
+      region_list_offset = bytes.unpack1("@2 N")
+      expect(region_list_offset).to eq(12)
+    end
+
+    it "writes itemVariationDataOffset pointing past the region list" do
+      bytes = described_class.build(
+        axis_count: 1, master_count: 1, item_count: 1, deltas: [[10]],
+      )
+      region_list_offset = bytes.unpack1("@2 N")
+      data_offset = bytes.unpack1("@8 N")
+      expect(data_offset).to eq(region_list_offset + region_list_bytesize_for(1, 1))
+    end
+
+    it "emits a VariationRegionList with one region per master" do
+      bytes = described_class.build(
+        axis_count: 2, master_count: 2, item_count: 1, deltas: [[10, 5]],
+      )
+      region_list_offset = bytes.unpack1("@2 N")
+      axis_count = bytes.unpack1("@#{region_list_offset} n")
+      region_count = bytes.unpack1("@#{region_list_offset + 2} n")
+      expect(axis_count).to eq(2)
+      expect(region_count).to eq(2)
+    end
+
+    it "encodes a region's peak on its master's axis as 1.0 (0x4000)" do
+      bytes = described_class.build(
+        axis_count: 2, master_count: 2, item_count: 1, deltas: [[10, 5]],
+      )
+      region_list_offset = bytes.unpack1("@2 N")
+      # Region 0 (master 0): axis 0 peak = 1.0, axis 1 peak = 0.0.
+      # Layout per axis: start(2) + peak(2) + end(2). Region starts at +4.
+      a0_peak = bytes.unpack1("@#{region_list_offset + 4 + 2} n")
+      a1_peak = bytes.unpack1("@#{region_list_offset + 4 + 8} n")
+      expect(to_signed(a0_peak)).to eq(0x4000) # 1.0 in f2dot14
+      expect(to_signed(a1_peak)).to eq(0)      # 0.0
+    end
+
+    it "uses int8 deltas when all deltas fit in [-127, 127]" do
+      bytes = described_class.build(
+        axis_count: 1, master_count: 1, item_count: 2,
+        deltas: [[10], [50]]
+      )
+      data_offset = bytes.unpack1("@8 N")
+      short_count = bytes.unpack1("@#{data_offset + 2} n")
+      expect(short_count).to eq(0)
+    end
+
+    it "uses int16 deltas when any delta exceeds int8 range" do
+      bytes = described_class.build(
+        axis_count: 1, master_count: 1, item_count: 2,
+        deltas: [[200], [50]]
+      )
+      data_offset = bytes.unpack1("@8 N")
+      short_count = bytes.unpack1("@#{data_offset + 2} n")
+      expect(short_count).to eq(1)
+    end
+
+    it "serializes the actual delta values for each item" do
+      bytes = described_class.build(
+        axis_count: 1, master_count: 1, item_count: 3,
+        deltas: [[10], [-20], [50]]
+      )
+      data_offset = bytes.unpack1("@8 N")
+      # data header (6) + regionIndices (2) = 8 bytes, then 3 int8 deltas
+      deltas = bytes[data_offset + 8, 3].unpack("c3")
+      expect(deltas).to eq([10, -20, 50])
+    end
+  end
+
+  def to_signed(uint16)
+    uint16 >= 0x8000 ? uint16 - 0x10000 : uint16
+  end
+
+  def region_list_bytesize_for(axis_count, region_count)
+    4 + (region_count * axis_count * 3 * 2)
+  end
+end

--- a/spec/fontisan/ufo/compile_mvar_spec.rb
+++ b/spec/fontisan/ufo/compile_mvar_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+
+RSpec.describe Fontisan::Ufo::Compile::Mvar do
+  describe ".build" do
+    it "emits major/minor version 1.0" do
+      bytes = described_class.build(
+        default_metrics: { hasc: 800 },
+        master_metrics: [{ hasc: 900 }],
+        axis_count: 1,
+      )
+      major, minor = bytes.unpack("nn")
+      expect(major).to eq(1)
+      expect(minor).to eq(0)
+    end
+
+    it "emits valueRecordSize = 8" do
+      bytes = described_class.build(
+        default_metrics: { hasc: 800 },
+        master_metrics: [{ hasc: 900 }],
+        axis_count: 1,
+      )
+      value_record_size = bytes.unpack1("@4 n")
+      expect(value_record_size).to eq(8)
+    end
+
+    it "emits valueRecordCount equal to the number of metric tags" do
+      bytes = described_class.build(
+        default_metrics: { hasc: 800, hdsc: -200, hlgp: 600 },
+        master_metrics: [{ hasc: 900, hdsc: -250, hlgp: 650 }],
+        axis_count: 1,
+      )
+      record_count = bytes.unpack1("@6 n")
+      expect(record_count).to eq(3)
+    end
+
+    it "emits itemVariationStoreOffset = header + value records" do
+      bytes = described_class.build(
+        default_metrics: { hasc: 800 },
+        master_metrics: [{ hasc: 900 }],
+        axis_count: 1,
+      )
+      store_offset = bytes.unpack1("@8 n")
+      expect(store_offset).to eq(18) # 10-byte header + 1 × 8-byte record
+    end
+
+    it "writes a value record per tag with the correct tag bytes" do
+      bytes = described_class.build(
+        default_metrics: { hasc: 800 },
+        master_metrics: [{ hasc: 900 }],
+        axis_count: 1,
+      )
+      # Records start right after the 10-byte header.
+      tag = bytes[10, 4]
+      expect(tag).to eq("hasc")
+    end
+
+    it "passes the ItemVariationStore through with format = 1" do
+      bytes = described_class.build(
+        default_metrics: { hasc: 800 },
+        master_metrics: [{ hasc: 900 }],
+        axis_count: 1,
+      )
+      store_offset = bytes.unpack1("@8 n")
+      format = bytes.unpack1("@#{store_offset} n")
+      expect(format).to eq(1)
+    end
+
+    it "computes the delta as master_value - default_value" do
+      bytes = described_class.build(
+        default_metrics: { hasc: 800 },
+        master_metrics: [{ hasc: 900 }],
+        axis_count: 1,
+      )
+      store_offset = bytes.unpack1("@8 n")
+      data_offset_rel = bytes.unpack1("@#{store_offset + 8} N")
+      data_offset = store_offset + data_offset_rel
+
+      # ItemVariationData: itemCount(2) + shortDeltaCount(2) + regionIndexCount(2)
+      # + regionIndices(2 × 1) = 8 bytes, then 1 int8 delta
+      delta = bytes.unpack1("@#{data_offset + 8} c")
+      expect(delta).to eq(100) # 900 - 800
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile_stat_spec.rb
+++ b/spec/fontisan/ufo/compile_stat_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+
+RSpec.describe Fontisan::Ufo::Compile::Stat do
+  describe ".build" do
+    it "returns nil when axes is nil" do
+      expect(described_class.build(axes: nil)).to be_nil
+    end
+
+    it "returns nil when axes is empty" do
+      expect(described_class.build(axes: [])).to be_nil
+    end
+
+    it "emits version 1.1 (0x00010001)" do
+      bytes = described_class.build(
+        axes: [{ tag: "wght", name_id: 256, ordering: 0 }],
+      )
+      version = bytes.unpack1("N")
+      expect(version).to eq(0x00010001)
+    end
+
+    it "emits designAxisSize = 8 (size of each DesignAxisRecord)" do
+      bytes = described_class.build(
+        axes: [{ tag: "wght", name_id: 256, ordering: 0 }],
+      )
+      design_axis_size = bytes.unpack1("@4 n")
+      expect(design_axis_size).to eq(8)
+    end
+
+    it "emits designAxisCount" do
+      bytes = described_class.build(
+        axes: [
+          { tag: "wght", name_id: 256, ordering: 0 },
+          { tag: "wdth", name_id: 257, ordering: 1 },
+        ],
+      )
+      count = bytes.unpack1("@6 n")
+      expect(count).to eq(2)
+    end
+
+    it "writes a design axis record with tag + nameID + ordering" do
+      bytes = described_class.build(
+        axes: [{ tag: "wght", name_id: 256, ordering: 0 }],
+      )
+      # designAxesOffset is at byte 8 (uint32); axis record starts there.
+      axes_offset = bytes.unpack1("@8 N")
+      expect(axes_offset).to eq(20) # header size
+      tag = bytes[axes_offset, 4]
+      name_id, ordering = bytes[axes_offset + 4, 4].unpack("nn")
+      expect(tag).to eq("wght")
+      expect(name_id).to eq(256)
+      expect(ordering).to eq(0)
+    end
+
+    it "emits axisValueCount matching the supplied axis_values" do
+      bytes = described_class.build(
+        axes: [{ tag: "wght", name_id: 256, ordering: 0 }],
+        axis_values: [
+          { axis_index: 0, flags: 0, name_id: 258, value: 400.0 },
+          { axis_index: 0, flags: 0, name_id: 259, value: 700.0 },
+        ],
+      )
+      value_count = bytes.unpack1("@12 n")
+      expect(value_count).to eq(2)
+    end
+
+    it "writes an axis value table (Format 1: nominal) per axis value" do
+      bytes = described_class.build(
+        axes: [{ tag: "wght", name_id: 256, ordering: 0 }],
+        axis_values: [
+          { axis_index: 0, flags: 0, name_id: 258, value: 400.0 },
+        ],
+      )
+      # The offset to the value offsets array is at byte 14 (uint32, per the spec).
+      value_offsets_offset = bytes.unpack1("@14 N")
+      # First offset (uint32) points at the first axis value table.
+      first_table_offset = bytes.unpack1("@#{value_offsets_offset} N")
+      format, axis_idx, flags, name_id = bytes[first_table_offset, 8].unpack("nnnn")
+      expect(format).to eq(1)
+      expect(axis_idx).to eq(0)
+      expect(flags).to eq(0)
+      expect(name_id).to eq(258)
+    end
+
+    it "writes the elidedNameID at the end of the header" do
+      bytes = described_class.build(
+        axes: [{ tag: "wght", name_id: 256, ordering: 0 }],
+        elided_name_id: 2,
+      )
+      elided_id = bytes.unpack1("@18 n")
+      expect(elided_id).to eq(2)
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile_variable_ttf_spec.rb
+++ b/spec/fontisan/ufo/compile_variable_ttf_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+require "tmpdir"
+
+RSpec.describe Fontisan::Ufo::Compile::VariableTtf do
+  let(:default_font) do
+    font = Fontisan::Ufo::Font.new
+    font.info.family_name = "TestVF"
+    font.info.style_name = "Regular"
+    font.info.version_major = 1
+    font.info.version_minor = 0
+    font.info.units_per_em = 1000
+
+    notdef = Fontisan::Ufo::Glyph.new(name: ".notdef")
+    notdef.width = 500
+    font.glyphs[".notdef"] = notdef
+
+    a = Fontisan::Ufo::Glyph.new(name: "A")
+    a.add_unicode(0x41)
+    a.width = 500
+    a.add_contour(Fontisan::Ufo::Contour.new([
+                                               Fontisan::Ufo::Point.new(x: 0, y: 0, type: "line"),
+                                               Fontisan::Ufo::Point.new(x: 100, y: 0, type: "line"),
+                                               Fontisan::Ufo::Point.new(x: 100, y: 100, type: "line"),
+                                               Fontisan::Ufo::Point.new(x: 0, y: 100, type: "line"),
+                                             ]))
+    font.glyphs["A"] = a
+    font
+  end
+
+  let(:bold_font) do
+    font = Fontisan::Ufo::Font.new
+    font.info.family_name = "TestVF"
+    font.info.style_name = "Bold"
+    font.info.units_per_em = 1000
+
+    notdef = Fontisan::Ufo::Glyph.new(name: ".notdef")
+    notdef.width = 600
+    font.glyphs[".notdef"] = notdef
+
+    a = Fontisan::Ufo::Glyph.new(name: "A")
+    a.add_unicode(0x41)
+    a.width = 600
+    a.add_contour(Fontisan::Ufo::Contour.new([
+                                               Fontisan::Ufo::Point.new(x: 0, y: 0, type: "line"),
+                                               Fontisan::Ufo::Point.new(x: 120, y: 0, type: "line"),
+                                               Fontisan::Ufo::Point.new(x: 120, y: 120, type: "line"),
+                                               Fontisan::Ufo::Point.new(x: 0, y: 120, type: "line"),
+                                             ]))
+    font.glyphs["A"] = a
+    font
+  end
+
+  let(:axes) do
+    [{ tag: "wght", min: 100, default: 400, max: 900, name_id: 256, ordering: 0 }]
+  end
+
+  let(:masters) do
+    [{ font: bold_font, axes: { "wght" => 1.0 } }]
+  end
+
+  let(:instances) do
+    [
+      { name_id: 257, flags: 0, coords: [400] },
+      { name_id: 258, flags: 0, coords: [700] },
+    ]
+  end
+
+  describe "#compile" do
+    it "writes a TTF file with TrueType sfnt magic" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out-var.ttf")
+        described_class.new(
+          font: default_font, axes: axes, masters: masters, instances: instances,
+        ).compile(output_path: path)
+        expect(File.binread(path, 4).unpack1("N")).to eq(0x00010000)
+      end
+    end
+
+    it "embeds fvar, gvar, HVAR, avar, STAT tables" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out-var.ttf")
+        described_class.new(
+          font: default_font, axes: axes, masters: masters, instances: instances,
+          stat_axis_values: [
+            { axis_index: 0, flags: 0, name_id: 259, value: 400.0 },
+          ]
+        ).compile(output_path: path)
+
+        reopened = Fontisan::FontLoader.load(path)
+        %w[fvar gvar HVAR avar STAT].each do |tag|
+          expect(reopened.has_table?(tag)).to be(true), "expected #{tag} table"
+        end
+      end
+    end
+
+    it "embeds MVAR when default_metrics and master_metrics are supplied" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out-var.ttf")
+        described_class.new(
+          font: default_font, axes: axes, masters: masters,
+          default_metrics: { hasc: 800 },
+          master_metrics: [{ hasc: 900 }]
+        ).compile(output_path: path)
+
+        reopened = Fontisan::FontLoader.load(path)
+        expect(reopened.has_table?("MVAR")).to be(true)
+      end
+    end
+
+    it "skips MVAR when metric data is omitted" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out-var.ttf")
+        described_class.new(
+          font: default_font, axes: axes, masters: masters,
+        ).compile(output_path: path)
+
+        reopened = Fontisan::FontLoader.load(path)
+        expect(reopened.has_table?("MVAR")).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Completes TODO 09 (variable font compilation) by adding the remaining Phase 3 per-table builders and the Phase 4 orchestrator:

**Phase 3 — per-table builders:**
- `Avar` — per-axis non-linear maps (defaults to identity -1/0/1)
- `Hvar` — advance-width deltas per glyph via `ItemVariationStore`
- `Mvar` — font-wide metric deltas (hasc/hdsc/hlgp/…) via `ItemVariationStore`
- `Stat` — design axes + Format 1 axis value tables + elided fallback name
- `ItemVariationStore` — shared `VariationRegionList` + `ItemVariationData` with int8/int16 delta packing (auto-selected per delta magnitude)

**Phase 4 — orchestrator:**
- `VariableTtf` — compiles a default UFO master + variation masters into a single variable TTF (emits `fvar` + `gvar` + `HVAR` + `MVAR` + `avar` + `STAT` alongside the standard TTF tables)
- `TtfCompiler#build_tables` extracted as a public method so `VariableTtf` reuses the standard TTF pipeline without writing

## Bug fixes caught while writing specs

- `ItemVariationStore`: header size was `4+4+2=10` but should be `2+4+2=8` (format is uint16, not uint32) — all offsets were off by 2 bytes
- `ItemVariationStore`: `pack("n>")` is invalid (`n` is already big-endian); switched to `pack("s>")` for signed int16 deltas
- `Mvar`: header was hardcoded as 16 bytes; correct layout is 10 bytes (majorVersion + minorVersion + valueRecordSize + valueRecordCount + Offset16) with `itemVariationStoreOffset` computed as `header + records`
- `Stat`: `designAxisSize` field was 20 (header size) but spec says it's the size of each `DesignAxisRecord` (8 bytes); `designAxesOffset` was computed relative to byte 14 instead of 20
- `f2dot14` clamp upper bound was 16383; should be 16384 so that 1.0 → `0x4000`

## Test plan

- [x] 43 new specs covering header layout, offset arithmetic, region encoding, delta packing, and round-trip via `FontLoader`
- [x] `bundle exec rspec` — 5532 examples, 0 failures
- [x] `bundle exec rubocop` — 636 files, no offenses
- [x] End-to-end: `VariableTtf` output reopens via `FontLoader` with `fvar`, `gvar`, `HVAR`, `avar`, `STAT` (and `MVAR` when metric data is supplied)
