### PR TITLE
fix(stitcher): flatten compound TrueType glyphs instead of dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   TTF table hash without writing, so `VariableTtf` can reuse the
   standard table pipeline.
 
+### Fixed
+
+- `Stitcher` silently dropped compound (composite) TrueType glyphs
+  from TTF donors. The O(1) extraction path only handled `simple?`
+  glyphs and returned `nil` for compounds. Compound glyphs are now
+  recursively flattened (with affine transforms applied) into simple
+  contours, making them self-contained. Affected donors include
+  NotoSansCuneiform (U+12399), NotoSansTaiTham (594 glyphs),
+  NotoSerifDivesAkuru (414), NotoSerifTaiYo (1007), and others.
+
 ### Removed
 
 - Audit subsystem (`Fontisan::Audit`, `Fontisan::Commands::Audit*`,

--- a/lib/fontisan/stitcher/source.rb
+++ b/lib/fontisan/stitcher/source.rb
@@ -16,6 +16,8 @@ module Fontisan
     # the raw CBDT/CBLC tables into the output instead of extracting
     # outlines. The glyph data lives in the bitmap tables, not in glyf.
     class Source
+      MAX_COMPOUND_DEPTH = 32
+
       attr_reader :font
 
       def initialize(font)
@@ -219,14 +221,19 @@ module Fontisan
       end
 
       def extract_truetype_glyph(gid, cache)
-        simple = cache[:glyf].glyph_for(gid, cache[:loca], cache[:head])
-        return nil unless simple
-        return nil unless simple.respond_to?(:simple?) && simple.simple?
+        raw = cache[:glyf].glyph_for(gid, cache[:loca], cache[:head])
+        return nil unless raw
 
         name = gid.zero? ? ".notdef" : "gid#{gid}"
         glyph = Fontisan::Ufo::Glyph.new(name: name)
         glyph.width = glyph_width(gid)
-        copy_simple_contours(simple, glyph)
+
+        if raw.respond_to?(:simple?) && raw.simple?
+          copy_simple_contours(raw, glyph)
+        elsif raw.respond_to?(:compound?) && raw.compound?
+          flatten_compound_into(raw, glyph, cache, Set.new)
+        end
+
         add_cmap_unicodes(gid, glyph)
         glyph
       rescue StandardError
@@ -248,6 +255,62 @@ module Fontisan
             on_curve = pt[:on_curve].nil? || pt[:on_curve]
             type = on_curve ? "line" : "offcurve"
             Fontisan::Ufo::Point.new(x: x.to_f, y: y.to_f, type: type)
+          end
+          ufo_glyph.add_contour(Fontisan::Ufo::Contour.new(ufo_points))
+        end
+      end
+
+      # Recursively flatten a CompoundGlyph's components into the UFO
+      # glyph as contours (with transforms applied). This makes the
+      # extracted glyph self-contained — it doesn't depend on the
+      # component glyphs being present in the target font.
+      #
+      # Only components with ARGS_ARE_XY_VALUES are flattened by offset.
+      # Point-index alignment (rare) is skipped — those components
+      # contribute nothing, but the rest of the compound is preserved.
+      def flatten_compound_into(compound, ufo_glyph, cache, visited, depth = 0)
+        return if depth > MAX_COMPOUND_DEPTH
+        return if visited.include?(compound.glyph_id)
+
+        visited = visited.dup.add(compound.glyph_id)
+
+        compound.components.each do |component|
+          next unless component.args_are_xy?
+
+          raw = cache[:glyf].glyph_for(component.glyph_index, cache[:loca], cache[:head])
+          next unless raw
+
+          matrix = component.transformation_matrix
+
+          if raw.respond_to?(:simple?) && raw.simple?
+            flatten_simple_component(raw, ufo_glyph, matrix)
+          elsif raw.respond_to?(:compound?) && raw.compound?
+            flatten_compound_into(raw, ufo_glyph, cache, visited, depth + 1)
+          end
+        end
+      end
+
+      # Apply a 2×3 affine matrix [a, b, c, d, e, f] to each point of
+      # a simple component, appending the transformed contours.
+      #   x' = a*x + c*y + e
+      #   y' = b*x + d*y + f
+      def flatten_simple_component(simple, ufo_glyph, matrix)
+        a, b, c, d, e, f = matrix
+        num_contours = simple.end_pts_of_contours&.size || 0
+        return if num_contours.zero?
+
+        num_contours.times do |ci|
+          points = simple.points_for_contour(ci)
+          next unless points && !points.empty?
+
+          ufo_points = points.map do |pt|
+            x = (pt[:x] || pt["x"]).to_f
+            y = (pt[:y] || pt["y"]).to_f
+            tx = a * x + c * y + e
+            ty = b * x + d * y + f
+            on_curve = pt[:on_curve].nil? || pt[:on_curve]
+            type = on_curve ? "line" : "offcurve"
+            Fontisan::Ufo::Point.new(x: tx, y: ty, type: type)
           end
           ufo_glyph.add_contour(Fontisan::Ufo::Contour.new(ufo_points))
         end

--- a/spec/fontisan/stitcher/cmap_preservation_spec.rb
+++ b/spec/fontisan/stitcher/cmap_preservation_spec.rb
@@ -97,4 +97,46 @@ RSpec.describe "Stitcher cmap preservation (regression)", :donors do
                                  "expected #{tangut.size} Tangut cps from OTF source, got #{out_tangut.size}"
     end
   end
+
+  # Regression for BUG-stitcher-drops-isolated-cps.md: the O(1)
+  # extraction path returned nil for compound (composite) TrueType
+  # glyphs, silently dropping them. NotoSansCuneiform's U+12399
+  # (gid 925) is a compound glyph composed of two references to
+  # gid 783 at different x-offsets. Many Noto donors use compound
+  # glyphs heavily (TaiTham: 594, DivesAkuru: 414, TaiYo: 1007).
+  it "flattens and preserves compound glyphs from a TTF source" do
+    cuneiform_path = "/Users/mulgogi/src/essenfont/essenfont/references/input-fonts/NotoSansCuneiform-Regular.ttf"
+    skip "NotoSansCuneiform not present" unless File.exist?(cuneiform_path)
+
+    src = Fontisan::FontLoader.load(cuneiform_path)
+
+    stitcher = Fontisan::Stitcher.new
+    stitcher.add_source(:cuneiform, src)
+    stitcher.include_notdef(from: :cuneiform)
+    stitcher.include_codepoints([0x12399], from: :cuneiform)
+
+    Dir.mktmpdir do |dir|
+      out_path = File.join(dir, "out.ttf")
+      stitcher.write_to(out_path, format: :ttf)
+
+      out = Fontisan::FontLoader.load(out_path)
+      out_cmap = out.table("cmap").unicode_mappings
+      expect(out_cmap.key?(0x12399)).to be(true),
+                                        "U+12399 (compound glyph) was silently dropped"
+
+      out_glyf = out.table("glyf")
+      out_loca = out.table("loca")
+      out_head = out.table("head")
+      out_maxp = out.table("maxp")
+      if out_loca.respond_to?(:parse_with_context)
+        out_loca.parse_with_context(out_head.index_to_loc_format, out_maxp.num_glyphs)
+      end
+      glyph = out_glyf.glyph_for(1, out_loca, out_head)
+      expect(glyph).not_to be_nil
+      is_simple = glyph.respond_to?(:simple?) && glyph.simple?
+      expect(is_simple).to be(true), "flattened compound should be a simple glyph in the output"
+      contour_count = glyph.end_pts_of_contours&.size || 0
+      expect(contour_count).to be > 0, "flattened compound has no contours"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes the silent drop of compound (composite) TrueType glyphs reported in `BUG-stitcher-drops-isolated-cps.md`.

**Root cause:** `Stitcher::Source#extract_truetype_glyph` had an early return that skipped any glyph where `simple?` was false. Compound glyphs (e.g. Cuneiform U+12399, which is two references to gid 783 at different x-offsets) were silently dropped — the Stitcher produced a font missing those codepoints entirely.

**Fix:** Detect compound glyphs and recursively flatten their components into simple contours, applying each component's 2×3 affine transformation matrix:

```
x' = a*x + c*y + e
y' = b*x + d*y + f
```

The flattened glyph is self-contained — it doesn't depend on the component glyphs being present in the target font. Recursion is bounded by `MAX_COMPOUND_DEPTH` (32) with circular-reference detection via a visited-set.

## Impact

Many Noto donors use compound glyphs heavily. Before this fix, they were silently losing codepoints:

| Donor | Compound glyphs dropped |
|-------|------------------------|
| NotoSansCuneiform | 1 (U+12399 — the reported case) |
| NotoSansTaiTham | 594 |
| NotoSerifDivesAkuru | 414 |
| NotoSerifTaiYo | 1007 |
| EgyptianText | 6105 |

## Design notes

- Components using point-index alignment (rare; `ARGS_ARE_XY_VALUES` not set) are skipped — they contribute nothing, but the rest of the compound is preserved rather than dropping the whole glyph.
- Flattening at extraction time (rather than preserving UFO component references) is the right choice for the Stitcher because the component glyphs from the donor might not be included in the target font.

## Test plan

- [x] New regression spec: stitches U+12399 from NotoSansCuneiform, asserts the output cmap contains it, the glyph is simple (flattened), and has non-zero contours
- [x] All 9 existing stitcher specs still pass
- [x] `bundle exec rubocop` clean on modified files
- [x] Reproducer from the bug report now outputs 2 glyphs (.notdef + U+12399) instead of 1
