### PR TITLE
svg-to-glyf: SVG path → Ufo::Glyph converter for chart-extracted glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Fontisan::SvgToGlyf` — converts SVG path data (from ucode code-chart
+  extraction) into `Ufo::Glyph` objects that feed directly into the
+  existing Stitcher + TtfCompiler pipeline. The converter handles SVG
+  path commands (M/L/H/V/C/S/Q/T/Z), relative and absolute coordinates,
+  smooth-curve reflection, SVG `<g transform>` accumulation, viewBox
+  coordinate normalization, and Y-axis flipping. Cubic-to-quadratic
+  conversion and contour winding correction are handled automatically
+  by the existing `Ufo::Compile::Filters` when compiling to TTF.
+- `Fontisan::SvgToGlyf::Geometry::AffineTransform` — 2×3 matrix with
+  compose/apply, used uniformly for all coordinate operations.
+- `Fontisan::SvgToGlyf::Geometry::TransformParser` — parses SVG
+  `transform="..."` attribute (translate, scale, rotate, matrix, skew).
+- `Fontisan::SvgToGlyf::Geometry::Normalizer` — composes the viewBox →
+  font UPM normalization (Y-flip + scale) with group transforms.
+- `Fontisan::SvgToGlyf::Path::Parser` — tokenizes and parses SVG path
+  `d` strings into typed Command objects with implicit-repetition support.
+- `Fontisan::SvgToGlyf::Path::ContourBuilder` — converts commands to
+  `Ufo::Contour` objects, tracking current-point, subpath-start, and
+  control-point state for smooth-curve reflection.
+- `Fontisan::SvgToGlyf::Document` — walks SVG XML (via Nokogiri),
+  accumulating ancestor `<g>` transforms per `<path>`.
 - `Fontisan::Ufo::Compile::Avar` — builds the OpenType `avar` (Axis
   Variation) table with per-axis non-linear maps (defaults to identity
   -1/0/1 mapping).

--- a/lib/fontisan.rb
+++ b/lib/fontisan.rb
@@ -86,6 +86,7 @@ module Fontisan
   autoload :Pipeline, "fontisan/pipeline"
   autoload :Subset, "fontisan/subset"
   autoload :Svg, "fontisan/svg"
+  autoload :SvgToGlyf, "fontisan/svg_to_glyf"
   autoload :Tables, "fontisan/tables"
   autoload :Type1, "fontisan/type1"
   autoload :Ufo, "fontisan/ufo"

--- a/lib/fontisan/svg_to_glyf.rb
+++ b/lib/fontisan/svg_to_glyf.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Autoload hub for the Fontisan::SvgToGlyf namespace.
+#
+# SvgToGlyf converts SVG path data (as produced by ucode's code-chart
+# extraction) into Ufo::Glyph objects that feed directly into the
+# existing UFO → TTF compile pipeline.
+#
+# The cubic-to-quadratic conversion and contour winding correction
+# are handled automatically by Ufo::Compile::Filters::CubicToQuadratic
+# and ReverseContourDirection when the glyph is compiled to TTF.
+# SvgToGlyf only needs to parse the SVG and emit cubic contours.
+module Fontisan
+  module SvgToGlyf
+    autoload :Geometry, "fontisan/svg_to_glyf/geometry"
+    autoload :Path, "fontisan/svg_to_glyf/path"
+    autoload :Document, "fontisan/svg_to_glyf/document"
+    autoload :Assembler, "fontisan/svg_to_glyf/assembler"
+
+    DEFAULT_UPM = 1000
+
+    # Convert an SVG path `d` string into a Ufo::Glyph.
+    #
+    # @param path_data [String] SVG path commands (e.g., "M 0 0 L 100 100 Z")
+    # @param upm [Integer] target font units-per-em
+    # @param codepoint [Integer, nil] Unicode codepoint to assign
+    # @param name [String, nil] glyph name (defaults to uni{codepoint.hex})
+    # @param viewbox [Hash{Symbol=>Float}, nil] SVG viewbox with :width, :height
+    # @param transform [Fontisan::SvgToGlyf::Geometry::AffineTransform, nil]
+    #   accumulated group transform
+    # @return [Fontisan::Ufo::Glyph]
+    def self.convert(path_data, upm: DEFAULT_UPM, codepoint: nil, name: nil,
+                     viewbox: nil, transform: nil)
+      Assembler.new(upm: upm).build_from_path_data(
+        path_data, codepoint: codepoint, name: name,
+                   viewbox: viewbox, transform: transform
+      )
+    end
+
+    # Convert an SVG file into a Ufo::Glyph.
+    #
+    # @param file_path [String] path to an .svg file
+    # @param upm [Integer] target font units-per-em
+    # @param codepoint [Integer, nil] override the codepoint (otherwise
+    #   derived from the filename if it matches U+XXXX.svg)
+    # @return [Fontisan::Ufo::Glyph]
+    def self.from_svg_file(file_path, upm: DEFAULT_UPM, codepoint: nil)
+      Assembler.new(upm: upm).build_from_file(file_path, codepoint: codepoint)
+    end
+
+    # Convert a directory of SVG files into a Ufo::Font, one glyph per file.
+    #
+    # Filenames must encode a codepoint: U+XXXX.svg or hexcode.svg.
+    #
+    # @param dir [String] directory containing .svg files
+    # @param upm [Integer] target font units-per-em
+    # @return [Fontisan::Ufo::Font]
+    def self.from_directory(dir, upm: DEFAULT_UPM)
+      Assembler.new(upm: upm).build_from_directory(dir)
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/assembler.rb
+++ b/lib/fontisan/svg_to_glyf/assembler.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    # Orchestrates the full SVG → Ufo::Glyph pipeline:
+    #
+    #   path data + transforms
+    #     → Path::Parser.parse → [Command]
+    #     → Path::ContourBuilder.build → [Ufo::Contour]
+    #     → apply final transform (normalization · group transform)
+    #     → round to Integer
+    #     → Ufo::Glyph
+    #
+    # For SVG files and directories, the Document class extracts the
+    # viewBox, accumulated transforms, and path data; the Assembler
+    # composes the normalizer with the group transform and runs the
+    # pipeline once per path.
+    class Assembler
+      attr_reader :upm
+
+      # @param upm [Integer] font units-per-em
+      def initialize(upm: SvgToGlyf::DEFAULT_UPM)
+        @upm = upm.to_i
+      end
+
+      # Build a glyph directly from a path data string.
+      #
+      # @param path_data [String] SVG path d= attribute
+      # @param codepoint [Integer, nil] Unicode codepoint
+      # @param name [String, nil] glyph name
+      # @param viewbox [Hash{Symbol=>Float}, nil] :width, :height
+      # @param transform [Geometry::AffineTransform, nil] group transform
+      # @return [Fontisan::Ufo::Glyph]
+      def build_from_path_data(path_data, codepoint: nil, name: nil,
+                               viewbox: nil, transform: nil)
+        viewbox ||= { width: @upm, height: @upm }
+        final = normalizer_for(**viewbox).final_transform(transform || Geometry::AffineTransform.identity)
+        contours = build_contours(path_data, final)
+        assemble_glyph(name || glyph_name_for(codepoint), contours, codepoint)
+      end
+
+      # Build a glyph from an SVG file.
+      #
+      # @param file_path [String]
+      # @param codepoint [Integer, nil] override; otherwise derived from filename
+      # @return [Fontisan::Ufo::Glyph]
+      def build_from_file(file_path, codepoint: nil)
+        doc = Document.from_file(file_path)
+        codepoint ||= codepoint_from_filename(File.basename(file_path))
+
+        doc.each_path.with_object(nil) do |(data, transform), _|
+          return build_from_doc_path(data, transform, doc, codepoint)
+        end
+
+        empty_glyph(codepoint)
+      end
+
+      # Build a font from a directory of SVG files.
+      #
+      # @param dir [String]
+      # @return [Fontisan::Ufo::Font]
+      def build_from_directory(dir)
+        font = Fontisan::Ufo::Font.new
+        font.info.units_per_em = @upm
+
+        Dir.glob(File.join(dir, "*.svg")).each do |path|
+          glyph = build_from_file(path)
+          font.glyphs[glyph.name] = glyph
+        end
+
+        font
+      end
+
+      private
+
+      def build_from_doc_path(data, group_transform, doc, codepoint)
+        final = normalizer_for(width: doc.viewbox_width, height: doc.viewbox_height)
+          .final_transform(group_transform)
+        contours = build_contours(data, final)
+        assemble_glyph(glyph_name_for(codepoint), contours, codepoint)
+      end
+
+      def build_contours(path_data, final_transform)
+        commands = Path::Parser.parse(path_data)
+        contours = Path::ContourBuilder.new.build(commands)
+        contours.map { |c| transform_contour(c, final_transform) }
+      end
+
+      def transform_contour(contour, transform)
+        points = contour.points.map do |pt|
+          x, y = transform.apply(pt.x, pt.y)
+          Fontisan::Ufo::Point.new(x: x.round, y: y.round, type: pt.type, smooth: pt.smooth)
+        end
+        Fontisan::Ufo::Contour.new(points)
+      end
+
+      def normalizer_for(width:, height:)
+        Geometry::Normalizer.new(viewbox_width: width, viewbox_height: height, upm: @upm)
+      end
+
+      def assemble_glyph(name, contours, codepoint)
+        glyph = Fontisan::Ufo::Glyph.new(name: name)
+        glyph.width = @upm
+        contours.each { |c| glyph.add_contour(c) }
+        glyph.add_unicode(codepoint) if codepoint
+        glyph
+      end
+
+      def empty_glyph(codepoint)
+        glyph = Fontisan::Ufo::Glyph.new(name: glyph_name_for(codepoint))
+        glyph.width = @upm
+        glyph.add_unicode(codepoint) if codepoint
+        glyph
+      end
+
+      # UFO convention: uniXXXX for BMP, uXXXXX for supplementary planes.
+      def glyph_name_for(codepoint)
+        return "glyph" unless codepoint
+
+        codepoint < 0x10000 ? "uni%04X" % codepoint : "u%05X" % codepoint
+      end
+
+      # Derive a codepoint from a filename like "U+10940.svg" or "10940.svg".
+      def codepoint_from_filename(basename)
+        match = basename.match(/(?:U\+)?([0-9A-Fa-f]{4,6})\.svg\z/)
+        return nil unless match
+
+        match[1].to_i(16)
+      end
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/document.rb
+++ b/lib/fontisan/svg_to_glyf/document.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+
+module Fontisan
+  module SvgToGlyf
+    # Walks an SVG XML document to extract path data and accumulated
+    # transforms. The Document is the single source of truth for which
+    # transforms apply to which paths and what coordinate space the
+    # SVG defines (via viewBox).
+    class Document
+      attr_reader :viewbox_width, :viewbox_height, :source
+
+      # @param xml [String] raw SVG XML
+      def self.from_xml(xml)
+        new(Nokogiri::XML(xml))
+      end
+
+      # @param path [String] file path to an .svg file
+      def self.from_file(path)
+        from_xml(File.read(path))
+      end
+
+      # @param doc [Nokogiri::XML::Document]
+      def initialize(doc)
+        @doc = doc
+        @source = doc
+        extract_viewbox
+      end
+
+      # Yield each <path> element's d= string along with the accumulated
+      # AffineTransform from all ancestor <g> transform= attributes.
+      #
+      # @yieldparam path_data [String] the d= attribute value
+      # @yieldparam transform [Geometry::AffineTransform] accumulated group transform
+      def each_path(&)
+        return enum_for(:each_path) unless block_given?
+
+        walk(@doc.root, Geometry::AffineTransform.identity, &)
+      end
+
+      private
+
+      def extract_viewbox
+        root = @doc.root
+        vb = root&.attribute("viewBox")&.value
+        if vb
+          _, _, w, h = vb.split(/\s+/).map(&:to_f)
+          @viewbox_width = w
+          @viewbox_height = h
+        else
+          @viewbox_width = (root&.attribute("width")&.value || DEFAULT_UPM).to_f
+          @viewbox_height = (root&.attribute("height")&.value || DEFAULT_UPM).to_f
+        end
+      end
+
+      # Recursively walk the XML tree. When a <g> has a transform=,
+      # compose it into the running accumulated transform. When a <path>
+      # is found, yield its d= with the current accumulated transform.
+      def walk(node, accumulated, &)
+        return unless node
+
+        node.children.each do |child|
+          next unless child.element?
+
+          case child.name
+          when "g"
+            child_transform = parse_transform(child)
+            walk(child, accumulated.compose(child_transform), &)
+          when "path"
+            data = child.attribute("d")&.value
+            yield(data, accumulated) if data
+          end
+        end
+      end
+
+      def parse_transform(element)
+        raw = element.attribute("transform")&.value
+        Geometry::TransformParser.parse(raw)
+      end
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/geometry.rb
+++ b/lib/fontisan/svg_to_glyf/geometry.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    # Geometry primitives for SvgToGlyf: affine transforms, SVG
+    # transform attribute parsing, and coordinate normalization.
+    module Geometry
+      autoload :AffineTransform, "fontisan/svg_to_glyf/geometry/affine_transform"
+      autoload :TransformParser, "fontisan/svg_to_glyf/geometry/transform_parser"
+      autoload :Normalizer, "fontisan/svg_to_glyf/geometry/normalizer"
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/geometry/affine_transform.rb
+++ b/lib/fontisan/svg_to_glyf/geometry/affine_transform.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    module Geometry
+      # A 2×3 affine transform representing:
+      #
+      #   x' = a·x + c·y + e
+      #   y' = b·x + d·y + f
+      #
+      # Every coordinate operation in SvgToGlyf (SVG group transforms,
+      # viewBox mapping, Y-flip, UPM scaling) is modeled as an
+      # AffineTransform so they can be composed into a single matrix
+      # applied once per point.
+      class AffineTransform
+        attr_reader :a, :b, :c, :d, :e, :f
+
+        # @param a [Float] x-scale
+        # @param b [Float] y-skew-x
+        # @param c [Float] x-skew-y
+        # @param d [Float] y-scale
+        # @param e [Float] x-translate
+        # @param f [Float] y-translate
+        def initialize(a, b, c, d, e, f)
+          @a = a.to_f
+          @b = b.to_f
+          @c = c.to_f
+          @d = d.to_f
+          @e = e.to_f
+          @f = f.to_f
+        end
+
+        def self.identity
+          new(1, 0, 0, 1, 0, 0)
+        end
+
+        def self.translate(tx, ty = 0)
+          new(1, 0, 0, 1, tx, ty)
+        end
+
+        def self.scale(sx, sy = nil)
+          sy = sx if sy.nil?
+          new(sx, 0, 0, sy, 0, 0)
+        end
+
+        def self.rotate_radians(angle)
+          cos = Math.cos(angle)
+          sin = Math.sin(angle)
+          new(cos, sin, -sin, cos, 0, 0)
+        end
+
+        def self.rotate_degrees(angle)
+          rotate_radians(angle.to_f * Math::PI / 180.0)
+        end
+
+        def self.skew_x_radians(angle)
+          new(1, 0, Math.tan(angle), 1, 0, 0)
+        end
+
+        def self.skew_y_radians(angle)
+          new(1, Math.tan(angle), 0, 1, 0, 0)
+        end
+
+        # Reflect across a horizontal line at y = axis.
+        # Points above the axis map below it and vice versa.
+        def self.flip_y(axis)
+          new(1, 0, 0, -1, 0, 2 * axis)
+        end
+
+        # Compose this transform with `other`, returning a new
+        # AffineTransform equivalent to applying `other` first,
+        # then `self`. This matches SVG's `transform="self other"`
+        # convention.
+        #
+        #   result.apply(x, y) == self.apply(*other.apply(x, y))
+        def compose(other)
+          AffineTransform.new(
+            @a * other.a + @c * other.b,
+            @b * other.a + @d * other.b,
+            @a * other.c + @c * other.d,
+            @b * other.c + @d * other.d,
+            @a * other.e + @c * other.f + @e,
+            @b * other.e + @d * other.f + @f,
+          )
+        end
+
+        # @param x [Numeric]
+        # @param y [Numeric]
+        # @return [Array(Float, Float)] transformed [x', y']
+        def apply(x, y)
+          [@a * x + @c * y + @e, @b * x + @d * y + @f]
+        end
+
+        def identity?
+          @a == 1 && @b.zero? && @c.zero? && @d == 1 && @e.zero? && @f.zero?
+        end
+
+        def ==(other)
+          other.is_a?(AffineTransform) &&
+            @a == other.a && @b == other.b && @c == other.c &&
+            @d == other.d && @e == other.e && @f == other.f
+        end
+
+        alias eql? ==
+
+        def hash
+          [@a, @b, @c, @d, @e, @f].hash
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/geometry/normalizer.rb
+++ b/lib/fontisan/svg_to_glyf/geometry/normalizer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    module Geometry
+      # Computes the affine transform that maps SVG viewBox coordinates
+      # (Y-down, origin at top-left) into font coordinates (Y-up, origin
+      # at bottom-left, scaled to UPM).
+      #
+      # The normalization combines a Y-flip across the viewBox midline
+      # with a uniform scale from viewBox units to font units. The
+      # resulting matrix is then composed with the SVG document's
+      # accumulated group transform to produce the final per-point
+      # transform.
+      class Normalizer
+        attr_reader :viewbox_width, :viewbox_height, :upm
+
+        # @param viewbox_width [Float] SVG viewBox width
+        # @param viewbox_height [Float] SVG viewBox height
+        # @param upm [Integer] font units-per-em
+        def initialize(viewbox_width:, viewbox_height:, upm:)
+          @viewbox_width = viewbox_width.to_f
+          @viewbox_height = viewbox_height.to_f
+          @upm = upm.to_f
+        end
+
+        # @return [AffineTransform] the viewBox→font normalization
+        def matrix
+          sx = @upm / @viewbox_width
+          sy = @upm / @viewbox_height
+          AffineTransform.new(sx, 0, 0, -sy, 0, @upm)
+        end
+
+        # Compose the normalization with an SVG group transform,
+        # producing the final per-point transform.
+        #
+        # @param group_transform [AffineTransform] accumulated <g> transforms
+        # @return [AffineTransform] final transform: font_point = N · T · path_point
+        def final_transform(group_transform = AffineTransform.identity)
+          matrix.compose(group_transform)
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/geometry/transform_parser.rb
+++ b/lib/fontisan/svg_to_glyf/geometry/transform_parser.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    module Geometry
+      # Parses an SVG `transform="..."` attribute string into a single
+      # AffineTransform representing the accumulated composition.
+      #
+      # Supports all six SVG transform functions:
+      #   translate, scale, rotate, matrix, skewX, skewY
+      #
+      # Multiple functions compose left-to-right (leftmost is applied
+      # last to the point), matching the SVG specification.
+      module TransformParser
+        FUNCTION_RE = /(\w+)\s*\(([^)]*)\)/
+
+        # @param transform_string [String, nil] the SVG transform attribute
+        # @return [AffineTransform]
+        def self.parse(transform_string)
+          return AffineTransform.identity if transform_string.nil? || transform_string.strip.empty?
+
+          transforms = transform_string.scan(FUNCTION_RE).map do |name, args|
+            build_transform(name, args)
+          end
+          transforms.reduce(AffineTransform.identity) { |acc, t| acc.compose(t) }
+        end
+
+        def self.build_transform(name, args_string)
+          args = parse_args(args_string)
+          case name
+          when "translate" then build_translate(args)
+          when "scale" then build_scale(args)
+          when "rotate" then build_rotate(args)
+          when "matrix" then build_matrix(args)
+          when "skewX" then AffineTransform.skew_x_radians(degrees_to_radians(args.fetch(0)))
+          when "skewY" then AffineTransform.skew_y_radians(degrees_to_radians(args.fetch(0)))
+          else
+            raise ArgumentError, "unknown SVG transform function: #{name.inspect}"
+          end
+        end
+
+        def self.build_translate(args)
+          AffineTransform.translate(args.fetch(0, 0), args.fetch(1, 0))
+        end
+
+        def self.build_scale(args)
+          sx = args.fetch(0, 1)
+          sy = args.fetch(1, sx)
+          AffineTransform.scale(sx, sy)
+        end
+
+        def self.build_rotate(args)
+          angle = args.fetch(0)
+          return AffineTransform.rotate_degrees(angle) if args.size < 3
+
+          cx = args.fetch(1)
+          cy = args.fetch(2)
+          around_point(AffineTransform.rotate_degrees(angle), cx, cy)
+        end
+
+        def self.build_matrix(args)
+          raise ArgumentError, "matrix() requires 6 arguments, got #{args.size}" if args.size != 6
+
+          AffineTransform.new(args[0], args[1], args[2], args[3], args[4], args[5])
+        end
+
+        # Rotate around a specific point: translate to origin, rotate,
+        # translate back.
+        def self.around_point(rotation, cx, cy)
+          AffineTransform.translate(cx, cy)
+            .compose(rotation)
+            .compose(AffineTransform.translate(-cx, -cy))
+        end
+
+        # Parse comma/whitespace-separated numbers from a function arg list.
+        def self.parse_args(args_string)
+          args_string.to_s.scan(/[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?/)
+            .map(&:to_f)
+        end
+
+        def self.degrees_to_radians(degrees)
+          degrees.to_f * Math::PI / 180.0
+        end
+
+        private_class_method :build_transform, :build_translate, :build_scale,
+                             :build_rotate, :build_matrix, :around_point,
+                             :parse_args, :degrees_to_radians
+      end
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/path.rb
+++ b/lib/fontisan/svg_to_glyf/path.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    # SVG path parsing: tokenize the `d` attribute and produce typed
+    # Command value objects ready for contour assembly.
+    module Path
+      autoload :Command, "fontisan/svg_to_glyf/path/command"
+      autoload :Parser, "fontisan/svg_to_glyf/path/parser"
+      autoload :State, "fontisan/svg_to_glyf/path/state"
+      autoload :ContourBuilder, "fontisan/svg_to_glyf/path/contour_builder"
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/path/command.rb
+++ b/lib/fontisan/svg_to_glyf/path/command.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    module Path
+      # A single parsed SVG path command.
+      #
+      # @attr type [Symbol] one of :M, :L, :H, :V, :C, :S, :Q, :T, :Z
+      # @attr absolute [Boolean] true for uppercase (absolute), false for lowercase (relative)
+      # @attr args [Array<Float>] the numeric arguments in order
+      Command = Struct.new(:type, :absolute, :args, keyword_init: true) do
+        def relative?
+          !absolute
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/path/contour_builder.rb
+++ b/lib/fontisan/svg_to_glyf/path/contour_builder.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    module Path
+      # Converts an array of Path::Command objects into an array of
+      # Fontisan::Ufo::Contour objects.
+      #
+      # Tracks current-point, subpath-start, and previous-control-point
+      # state to resolve relative coordinates and smooth-curve reflections.
+      #
+      # Point type mapping (Ufo::Point types):
+      #   M (first in subpath) → first point of contour, type "line"
+      #   L / H / V            → "line"
+      #   C                    → "offcurve", "offcurve", "curve"
+      #   S                    → reflected "offcurve", "offcurve", "curve"
+      #   Q                    → "offcurve", "qcurve"
+      #   T                    → reflected "offcurve", "qcurve"
+      #   Z                    → closes the contour (no point emitted)
+      class ContourBuilder
+        # @param commands [Array<Path::Command>]
+        # @return [Array<Fontisan::Ufo::Contour>]
+        def build(commands)
+          state = State.new
+          commands.each { |cmd| apply(cmd, state) }
+          state.finalize_contour
+          state.contours
+        end
+
+        private
+
+        def apply(cmd, state)
+          case cmd.type
+          when :M then handle_move(cmd, state)
+          when :L then handle_line(cmd, state)
+          when :H then handle_horizontal(cmd, state)
+          when :V then handle_vertical(cmd, state)
+          when :C then handle_cubic(cmd, state)
+          when :S then handle_smooth_cubic(cmd, state)
+          when :Q then handle_quadratic(cmd, state)
+          when :T then handle_smooth_quadratic(cmd, state)
+          when :Z then state.close_contour
+          end
+        end
+
+        def handle_move(cmd, state)
+          x, y = resolve_pair(cmd, state.current)
+          state.start_contour(x, y)
+        end
+
+        def handle_line(cmd, state)
+          x, y = resolve_pair(cmd, state.current)
+          state.add_point(x, y, "line")
+          state.reset_controls
+        end
+
+        def handle_horizontal(cmd, state)
+          dx = cmd.absolute ? cmd.args[0] - state.current[0] : cmd.args[0]
+          x = state.current[0] + dx
+          y = state.current[1]
+          state.add_point(x, y, "line")
+          state.reset_controls
+        end
+
+        def handle_vertical(cmd, state)
+          dy = cmd.absolute ? cmd.args[0] - state.current[1] : cmd.args[0]
+          x = state.current[0]
+          y = state.current[1] + dy
+          state.add_point(x, y, "line")
+          state.reset_controls
+        end
+
+        def handle_cubic(cmd, state)
+          base = state.current
+          c1 = resolve_pair_at(cmd, base, 0)
+          c2 = resolve_pair_at(cmd, base, 2)
+          endpoint = resolve_pair_at(cmd, base, 4)
+
+          state.add_point(c1[0], c1[1], "offcurve")
+          state.add_point(c2[0], c2[1], "offcurve")
+          state.add_point(endpoint[0], endpoint[1], "curve")
+          state.cubic_control = c2
+        end
+
+        def handle_smooth_cubic(cmd, state)
+          base = state.current
+          reflected = reflect(state.cubic_control, base)
+          c2 = resolve_pair_at(cmd, base, 0)
+          endpoint = resolve_pair_at(cmd, base, 2)
+
+          state.add_point(reflected[0], reflected[1], "offcurve")
+          state.add_point(c2[0], c2[1], "offcurve")
+          state.add_point(endpoint[0], endpoint[1], "curve")
+          state.cubic_control = c2
+        end
+
+        def handle_quadratic(cmd, state)
+          base = state.current
+          control = resolve_pair_at(cmd, base, 0)
+          endpoint = resolve_pair_at(cmd, base, 2)
+
+          state.add_point(control[0], control[1], "offcurve")
+          state.add_point(endpoint[0], endpoint[1], "qcurve")
+          state.quad_control = control
+        end
+
+        def handle_smooth_quadratic(cmd, state)
+          base = state.current
+          reflected = reflect(state.quad_control, base)
+          endpoint = resolve_pair_at(cmd, base, 0)
+
+          state.add_point(reflected[0], reflected[1], "offcurve")
+          state.add_point(endpoint[0], endpoint[1], "qcurve")
+          state.quad_control = reflected
+        end
+
+        # Resolve an (x,y) pair from a command at the given arg offset.
+        # Absolute: use args directly. Relative: add to base point.
+        def resolve_pair_at(cmd, base, offset)
+          if cmd.absolute
+            [cmd.args[offset], cmd.args[offset + 1]]
+          else
+            [base[0] + cmd.args[offset], base[1] + cmd.args[offset + 1]]
+          end
+        end
+
+        def resolve_pair(cmd, base)
+          resolve_pair_at(cmd, base, 0)
+        end
+
+        # Reflect a control point through the current point.
+        def reflect(control, current)
+          return current unless control
+
+          [2 * current[0] - control[0], 2 * current[1] - control[1]]
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/path/parser.rb
+++ b/lib/fontisan/svg_to_glyf/path/parser.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    module Path
+      # Tokenizes an SVG path `d` attribute string and groups the
+      # tokens into typed Command objects, handling implicit command
+      # repetition.
+      #
+      # Arc (A/a) is not supported — ucode chart SVGs use cubic
+      # curves exclusively. Encountering A raises a clear ArgumentError.
+      module Parser
+        COMMAND_RE = /[MmLlHhVvCcSsQqTtAaZz]/
+        NUMBER_RE = /[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?/
+        TOKEN_RE = /#{COMMAND_RE}|#{NUMBER_RE}/
+
+        # Expected argument count per command letter.
+        ARITY = {
+          "M" => 2, "L" => 2, "H" => 1, "V" => 1,
+          "C" => 6, "S" => 4, "Q" => 4, "T" => 2,
+          "Z" => 0
+        }.freeze
+
+        # @param d_string [String] SVG path data
+        # @return [Array<Command>]
+        def self.parse(d_string)
+          tokens = tokenize(d_string)
+          group_into_commands(tokens)
+        end
+
+        def self.tokenize(d_string)
+          d_string.to_s.scan(TOKEN_RE).map do |tok|
+            COMMAND_RE.match?(tok) ? [:command, tok] : [:number, tok.to_f]
+          end
+        end
+
+        # Walk the token stream. After a command letter, consume its
+        # arity's worth of numbers per command; extra numbers repeat
+        # the command. After M/m, subsequent pairs become implicit L/l.
+        def self.group_into_commands(tokens)
+          commands = []
+          current = nil
+          args = []
+
+          tokens.each do |type, value|
+            if type == :command
+              check_arc!(value)
+              if value.upcase == "Z"
+                commands << build_command(value, [])
+                current = nil
+              else
+                current = value
+              end
+              args = []
+              next
+            end
+
+            next unless current
+
+            arity = ARITY.fetch(current.upcase)
+            args << value
+
+            next unless args.size >= arity
+
+            commands << build_command(current, args.shift(arity))
+            current = implicit_repeat_letter(current) if current.upcase == "M"
+          end
+
+          commands
+        end
+
+        def self.build_command(letter, args)
+          Command.new(
+            type: letter.upcase.to_sym,
+            absolute: letter == letter.upcase,
+            args: args,
+          )
+        end
+
+        # After M/m, subsequent coordinate pairs become L/l (SVG spec).
+        def self.implicit_repeat_letter(letter)
+          letter == letter.upcase ? "L" : "l"
+        end
+
+        def self.check_arc!(letter)
+          return unless letter && letter.upcase == "A"
+
+          raise ArgumentError,
+                "SVG arc command (A/a) is not supported by SvgToGlyf. " \
+                "Convert arcs to cubic curves first."
+        end
+
+        private_class_method :tokenize, :group_into_commands, :build_command,
+                             :implicit_repeat_letter, :check_arc!
+      end
+    end
+  end
+end

--- a/lib/fontisan/svg_to_glyf/path/state.rb
+++ b/lib/fontisan/svg_to_glyf/path/state.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    module Path
+      # Mutable state carried through the contour-building walk.
+      # Tracks the current pen position, the subpath start (for Z
+      # closure), the last cubic and quadratic control points (for
+      # smooth-curve reflection), and the contour being assembled.
+      class State
+        attr_reader :contours, :current, :subpath_start,
+                    :cubic_control, :quad_control
+
+        def initialize
+          @contours = []
+          @current = nil
+          @subpath_start = nil
+          @cubic_control = nil
+          @quad_control = nil
+          @pending = nil
+        end
+
+        # Start a new subpath at (x, y). Flushes any in-progress contour.
+        def start_contour(x, y)
+          finalize_contour
+          @pending = []
+          add_point(x, y, "line")
+          @subpath_start = [x, y]
+          @cubic_control = nil
+          @quad_control = nil
+        end
+
+        # Append a point to the current contour and advance current position
+        # for on-curve points (off-curve control points do not advance).
+        def add_point(x, y, type)
+          return unless @pending
+
+          @pending << Fontisan::Ufo::Point.new(x: x, y: y, type: type)
+          return if type == "offcurve"
+
+          @current = [x, y]
+        end
+
+        # Mark the end of the current subpath. The contour is closed
+        # implicitly (UFO contours wrap around). Reset current to the
+        # subpath start so a subsequent M picks up from the right place.
+        def close_contour
+          return unless @pending
+
+          finalize_contour
+          @current = @subpath_start
+        end
+
+        # Flush the in-progress contour into the contours list if it
+        # has more than one point (a lone M with nothing else is
+        # degenerate and dropped).
+        def finalize_contour
+          return unless @pending
+
+          @contours << Fontisan::Ufo::Contour.new(@pending) if @pending.size > 1
+          @pending = nil
+        end
+
+        def cubic_control=(value)
+          @cubic_control = value
+        end
+
+        def quad_control=(value)
+          @quad_control = value
+        end
+
+        def reset_controls
+          @cubic_control = nil
+          @quad_control = nil
+        end
+      end
+    end
+  end
+end

--- a/spec/fontisan/svg_to_glyf/affine_transform_spec.rb
+++ b/spec/fontisan/svg_to_glyf/affine_transform_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/svg_to_glyf"
+
+RSpec.describe Fontisan::SvgToGlyf::Geometry::AffineTransform do
+  let(:identity) { described_class.identity }
+
+  describe ".identity" do
+    it "returns a no-op transform" do
+      expect(identity.apply(100, 200)).to eq([100.0, 200.0])
+    end
+
+    it "reports itself as identity" do
+      expect(identity.identity?).to be(true)
+    end
+  end
+
+  describe ".translate" do
+    it "shifts points by (tx, ty)" do
+      t = described_class.translate(10, 20)
+      expect(t.apply(5, 5)).to eq([15.0, 25.0])
+    end
+
+    it "defaults ty to 0" do
+      t = described_class.translate(10)
+      expect(t.apply(5, 5)).to eq([15.0, 5.0])
+    end
+  end
+
+  describe ".scale" do
+    it "scales both axes by the same factor when sy is omitted" do
+      t = described_class.scale(3)
+      expect(t.apply(2, 4)).to eq([6.0, 12.0])
+    end
+
+    it "scales axes independently when both are given" do
+      t = described_class.scale(2, 0.5)
+      expect(t.apply(4, 4)).to eq([8.0, 2.0])
+    end
+  end
+
+  describe ".rotate_degrees" do
+    it "rotates 90 degrees counter-clockwise around origin" do
+      t = described_class.rotate_degrees(90)
+      x, y = t.apply(1, 0)
+      expect(x).to be_within(0.0001).of(0.0)
+      expect(y).to be_within(0.0001).of(1.0)
+    end
+  end
+
+  describe ".flip_y" do
+    it "reflects points across the given horizontal axis" do
+      t = described_class.flip_y(500)
+      expect(t.apply(100, 400)).to eq([100.0, 600.0])
+      expect(t.apply(100, 500)).to eq([100.0, 500.0])
+      expect(t.apply(100, 600)).to eq([100.0, 400.0])
+    end
+  end
+
+  describe "#compose" do
+    it "applies the other transform first, then self" do
+      scale = described_class.scale(2)
+      translate = described_class.translate(10, 0)
+      combined = translate.compose(scale)
+
+      # scale first: (5, 0) → (10, 0), then translate: → (20, 0)
+      expect(combined.apply(5, 0)).to eq([20.0, 0.0])
+    end
+
+    it "is not commutative" do
+      scale = described_class.scale(2)
+      translate = described_class.translate(10, 0)
+
+      ab = scale.compose(translate).apply(5, 0)
+      ba = translate.compose(scale).apply(5, 0)
+      expect(ab).not_to eq(ba)
+    end
+
+    it "returns identity when composing with identity" do
+      t = described_class.translate(5, 5)
+      expect(t.compose(identity)).to eq(t)
+      expect(identity.compose(t)).to eq(t)
+    end
+  end
+
+  describe "#==" do
+    it "compares component-by-component" do
+      expect(described_class.translate(1, 2)).to eq(described_class.translate(1.0, 2.0))
+      expect(described_class.translate(1, 2)).not_to eq(described_class.translate(1, 3))
+    end
+  end
+end

--- a/spec/fontisan/svg_to_glyf/contour_builder_spec.rb
+++ b/spec/fontisan/svg_to_glyf/contour_builder_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/svg_to_glyf"
+
+RSpec.describe Fontisan::SvgToGlyf::Path::ContourBuilder do
+  let(:parser) { Fontisan::SvgToGlyf::Path::Parser }
+  let(:builder) { described_class.new }
+
+  def build(path_string)
+    builder.build(parser.parse(path_string))
+  end
+
+  def points_of(contour)
+    contour.points.map { |p| [p.x, p.y, p.type] }
+  end
+
+  describe "#build" do
+    it "produces one contour for a simple rectangle" do
+      contours = build("M 0 0 L 100 0 L 100 100 L 0 100 Z")
+      expect(contours.size).to eq(1)
+      expect(contours.first.points.size).to eq(4)
+      expect(contours.first.points.all? { |p| p.type == "line" }).to be(true)
+    end
+
+    it "emits two offcurve + one curve for a cubic segment" do
+      contours = build("M 0 0 C 50 100 100 100 100 0 Z")
+      points = contours.first.points
+      expect(points.map(&:type)).to eq(%w[line offcurve offcurve curve])
+    end
+
+    it "emits one offcurve + one qcurve for a quadratic segment" do
+      contours = build("M 0 0 Q 50 100 100 0 Z")
+      points = contours.first.points
+      expect(points.map(&:type)).to eq(%w[line offcurve qcurve])
+    end
+
+    it "resolves relative lowercase commands against current point" do
+      absolute = build("M 0 0 L 100 100 Z")
+      relative = build("M 0 0 l 100 100 Z")
+      expect(points_of(absolute.first)).to eq(points_of(relative.first))
+    end
+
+    it "resolves relative cubic controls against current point" do
+      absolute = build("M 0 0 C 50 50 100 50 100 0 Z")
+      relative = build("M 0 0 c 50 50 100 50 100 0 Z")
+      expect(points_of(absolute.first)).to eq(points_of(relative.first))
+    end
+
+    it "handles H and V commands" do
+      contours = build("M 0 0 H 100 V 50 L 0 50 Z")
+      pts = contours.first.points
+      expect(pts.map { |p| [p.x, p.y] }).to eq([[0, 0], [100, 0], [100, 50], [0, 50]])
+    end
+
+    it "handles relative H and V" do
+      contours = build("M 0 0 h 100 v 50 Z")
+      pts = contours.first.points
+      expect(pts.map { |p| [p.x, p.y] }).to eq([[0, 0], [100, 0], [100, 50]])
+    end
+
+    it "produces multiple contours for multiple subpaths" do
+      contours = build("M 0 0 L 10 10 Z M 20 20 L 30 30 Z")
+      expect(contours.size).to eq(2)
+    end
+
+    it "reflects control for S after C" do
+      contours = build("M 0 0 C 25 50 75 50 100 0 S 175 -50 200 0 Z")
+      pts = contours.first.points
+      # M(0,0,line), C1(25,50,off), C2(75,50,off), P3(100,0,curve),
+      # reflected C1(125,-50,off), C2(175,-50,off), P3(200,0,curve)
+      expect(pts.map { |p| [p.x, p.y] }).to eq(
+        [[0, 0], [25, 50], [75, 50], [100, 0], [125, -50], [175, -50], [200, 0]],
+      )
+    end
+
+    it "uses current point as control for S with no preceding C" do
+      contours = build("M 0 0 S 50 50 100 0 Z")
+      pts = contours.first.points
+      # No prior C, so reflected control = current point = (0,0)
+      expect(pts.map { |p| [p.x, p.y] }).to eq(
+        [[0, 0], [0, 0], [50, 50], [100, 0]],
+      )
+    end
+
+    it "reflects control for T after Q" do
+      contours = build("M 0 0 Q 50 100 100 0 T 200 0 Z")
+      pts = contours.first.points
+      # M(0,0,line), control(50,100,off), P2(100,0,qcurve),
+      # reflected control(150, -100, off), P2(200,0,qcurve)
+      expect(pts.map { |p| [p.x, p.y] }).to eq(
+        [[0, 0], [50, 100], [100, 0], [150, -100], [200, 0]],
+      )
+    end
+
+    it "drops a degenerate subpath with only a move" do
+      contours = build("M 50 50 Z")
+      expect(contours).to be_empty
+    end
+
+    it "keeps a contour that has move + one drawing command" do
+      contours = build("M 0 0 L 100 100 Z")
+      expect(contours.size).to eq(1)
+      expect(contours.first.points.size).to eq(2)
+    end
+  end
+end

--- a/spec/fontisan/svg_to_glyf/document_spec.rb
+++ b/spec/fontisan/svg_to_glyf/document_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/svg_to_glyf"
+
+RSpec.describe Fontisan::SvgToGlyf::Document do
+  let(:affine) { Fontisan::SvgToGlyf::Geometry::AffineTransform }
+
+  describe "viewbox extraction" do
+    it "reads viewBox attribute" do
+      doc = described_class.from_xml(<<~SVG)
+        <svg viewBox="0 0 1000 1000"><path d="M 0 0"/></svg>
+      SVG
+      expect(doc.viewbox_width).to eq(1000.0)
+      expect(doc.viewbox_height).to eq(1000.0)
+    end
+
+    it "falls back to width/height when viewBox is absent" do
+      doc = described_class.from_xml(<<~SVG)
+        <svg width="500" height="700"><path d="M 0 0"/></svg>
+      SVG
+      expect(doc.viewbox_width).to eq(500.0)
+      expect(doc.viewbox_height).to eq(700.0)
+    end
+  end
+
+  describe "#each_path" do
+    it "yields path data with identity transform when no group" do
+      doc = described_class.from_xml(<<~SVG)
+        <svg viewBox="0 0 1000 1000"><path d="M 0 0 L 1 1"/></svg>
+      SVG
+      doc.each_path do |data, transform|
+        expect(data).to eq("M 0 0 L 1 1")
+        expect(transform).to eq(affine.identity)
+      end
+    end
+
+    it "accumulates transform from a single <g>" do
+      doc = described_class.from_xml(<<~SVG)
+        <svg viewBox="0 0 1000 1000">
+          <g transform="translate(50, 60)"><path d="M 0 0"/></g>
+        </svg>
+      SVG
+      doc.each_path do |_data, transform|
+        expect(transform.apply(0, 0)).to eq([50.0, 60.0])
+      end
+    end
+
+    it "composes nested <g> transforms" do
+      doc = described_class.from_xml(<<~SVG)
+        <svg viewBox="0 0 1000 1000">
+          <g transform="scale(2)">
+            <g transform="translate(10, 0)">
+              <path d="M 5 0"/>
+            </g>
+          </g>
+        </svg>
+      SVG
+      doc.each_path do |_data, transform|
+        # translate first: (5,0)→(15,0), then scale: →(30,0)
+        expect(transform.apply(5, 0)).to eq([30.0, 0.0])
+      end
+    end
+
+    it "yields each sibling <path> separately with the same transform" do
+      doc = described_class.from_xml(<<~SVG)
+        <svg viewBox="0 0 1000 1000">
+          <g transform="scale(2)">
+            <path d="M 0 0"/>
+            <path d="M 1 1"/>
+          </g>
+        </svg>
+      SVG
+      paths = doc.each_path.to_a
+      expect(paths.size).to eq(2)
+      expect(paths[0][0]).to eq("M 0 0")
+      expect(paths[1][0]).to eq("M 1 1")
+    end
+
+    it "handles the real ucode fixture" do
+      fixture = "/Users/mulgogi/src/fontist/ucode/tmp/sample_output_17.0.0/blocks/Basic_Latin/U+0052/glyph.svg"
+      skip "fixture not available" unless File.exist?(fixture)
+
+      doc = described_class.from_file(fixture)
+      expect(doc.viewbox_width).to eq(1000.0)
+      paths = doc.each_path.to_a
+      expect(paths.size).to eq(1)
+      expect(paths[0][0]).to start_with("M ")
+    end
+  end
+end

--- a/spec/fontisan/svg_to_glyf/integration_spec.rb
+++ b/spec/fontisan/svg_to_glyf/integration_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/svg_to_glyf"
+require "tmpdir"
+
+RSpec.describe "SvgToGlyf integration" do
+  let(:ucode_fixture) do
+    "/Users/mulgogi/src/fontist/ucode/tmp/sample_output_17.0.0/blocks/Basic_Latin/U+0052/glyph.svg"
+  end
+
+  describe Fontisan::SvgToGlyf do
+    describe ".convert" do
+      it "produces a Ufo::Glyph from a simple path" do
+        glyph = described_class.convert(
+          "M 0 0 L 500 0 L 500 700 L 0 700 Z",
+          upm: 1000,
+          codepoint: 0x41,
+          viewbox: { width: 1000, height: 1000 },
+        )
+        expect(glyph).to be_a(Fontisan::Ufo::Glyph)
+        expect(glyph.unicodes).to include(0x41)
+        expect(glyph.contours.size).to eq(1)
+        expect(glyph.contours.first.points.size).to eq(4)
+      end
+
+      it "flips Y so SVG top maps to font top" do
+        glyph = described_class.convert(
+          "M 0 1000 L 100 1000 Z",
+          upm: 1000,
+          viewbox: { width: 1000, height: 1000 },
+        )
+        first_point = glyph.contours.first.points.first
+        expect(first_point.y).to eq(0)
+      end
+
+      it "rounds all points to integers" do
+        glyph = described_class.convert(
+          "M 0.5 0.5 L 100.7 200.3 Z",
+          upm: 1000,
+          viewbox: { width: 1000, height: 1000 },
+        )
+        glyph.contours.first.points.each do |pt|
+          expect(pt.x).to eq(pt.x.to_i)
+          expect(pt.y).to eq(pt.y.to_i)
+        end
+      end
+
+      it "applies a group transform" do
+        affine = Fontisan::SvgToGlyf::Geometry::AffineTransform
+
+        no_transform = described_class.convert(
+          "M 100 0 L 200 0 Z",
+          upm: 1000,
+          viewbox: { width: 1000, height: 1000 },
+        )
+        with_scale = described_class.convert(
+          "M 100 0 L 200 0 Z",
+          upm: 1000,
+          viewbox: { width: 1000, height: 1000 },
+          transform: affine.scale(2),
+        )
+        plain_x = no_transform.contours.first.points.first.x
+        scaled_x = with_scale.contours.first.points.first.x
+        expect(scaled_x).to eq(plain_x * 2)
+      end
+
+      it "emits cubic offcurve/curve points that the TtfCompiler filter can convert" do
+        glyph = described_class.convert(
+          "M 0 0 C 250 700 750 700 1000 0 Z",
+          upm: 1000,
+          viewbox: { width: 1000, height: 1000 },
+        )
+        types = glyph.contours.first.points.map(&:type)
+        expect(types).to include("offcurve")
+        expect(types).to include("curve")
+      end
+    end
+
+    describe ".from_svg_file" do
+      it "converts the real ucode R-glyph fixture into a multi-contour glyph" do
+        skip "ucode fixture not available" unless File.exist?(ucode_fixture)
+
+        glyph = described_class.from_svg_file(ucode_fixture, upm: 1000)
+        expect(glyph).to be_a(Fontisan::Ufo::Glyph)
+        # The R glyph has 3 subpaths (outer outline + two counters)
+        expect(glyph.contours.size).to eq(3)
+        glyph.contours.each do |contour|
+          expect(contour.points.size).to be > 2
+        end
+      end
+
+      it "derives the codepoint from the filename" do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, "U+10940.svg")
+          File.write(path, <<~SVG)
+            <svg viewBox="0 0 1000 1000"><path d="M 0 0 L 100 100 Z"/></svg>
+          SVG
+          glyph = described_class.from_svg_file(path, upm: 1000)
+          expect(glyph.unicodes).to include(0x10940)
+        end
+      end
+
+      it "produces font-space coordinates for a controlled SVG with scale transform" do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, "U+0041.svg")
+          # Path in a 10×10 coordinate space, scaled to fill a 1000×1000 viewBox
+          File.write(path, <<~SVG)
+            <svg viewBox="0 0 1000 1000">
+              <g transform="scale(100)">
+                <path d="M 1 1 L 9 1 L 5 9 Z"/>
+              </g>
+            </svg>
+          SVG
+          glyph = described_class.from_svg_file(path, upm: 1000)
+          pts = glyph.contours.first.points
+          # scale(100) maps (1,1) → (100,100) in viewBox space.
+          # Y-flip + UPM normalization: (100, 100) → (100, 1000-100) = (100, 900)
+          expect(pts.map { |p| [p.x, p.y] }).to eq([[100, 900], [900, 900], [500, 100]])
+        end
+      end
+    end
+
+    describe ".from_directory" do
+      it "produces a Ufo::Font with one glyph per SVG file" do
+        Dir.mktmpdir do |dir|
+          %w[U+10940 U+10941 U+10942].each do |cp|
+            File.write(File.join(dir, "#{cp}.svg"), <<~SVG)
+              <svg viewBox="0 0 1000 1000"><path d="M 0 0 L 100 100 Z"/></svg>
+            SVG
+          end
+          font = described_class.from_directory(dir, upm: 1000)
+          expect(font).to be_a(Fontisan::Ufo::Font)
+          expect(font.glyphs.size).to eq(3)
+          expect(font.info.units_per_em).to eq(1000)
+        end
+      end
+    end
+  end
+
+  describe "compilation through TtfCompiler" do
+    it "converts an SVG glyph to a valid TTF via the UFO pipeline" do
+      glyph = Fontisan::SvgToGlyf.convert(
+        "M 100 0 L 900 0 L 500 900 Z",
+        upm: 1000,
+        codepoint: 0x41,
+        viewbox: { width: 1000, height: 1000 },
+      )
+
+      font = Fontisan::Ufo::Font.new
+      font.info.family_name = "Test"
+      font.info.units_per_em = 1000
+      font.glyphs[".notdef"] = Fontisan::Ufo::Glyph.new(name: ".notdef")
+      font.glyphs[glyph.name] = glyph
+
+      Dir.mktmpdir do |dir|
+        output_path = File.join(dir, "out.ttf")
+        Fontisan::Ufo::Compile::TtfCompiler.new(font).compile(output_path: output_path)
+
+        reopened = Fontisan::FontLoader.load(output_path)
+        expect(reopened.table("maxp").num_glyphs).to eq(2)
+        expect(reopened.table("cmap").unicode_mappings.key?(0x41)).to be(true)
+      end
+    end
+
+    it "feeds into the Stitcher as a UFO source" do
+      glyph = Fontisan::SvgToGlyf.convert(
+        "M 100 0 L 900 0 L 500 900 Z",
+        upm: 1000,
+        codepoint: 0x42,
+        viewbox: { width: 1000, height: 1000 },
+      )
+      chart_font = Fontisan::Ufo::Font.new
+      chart_font.info.units_per_em = 1000
+      chart_font.glyphs[".notdef"] = Fontisan::Ufo::Glyph.new(name: ".notdef")
+      chart_font.glyphs[glyph.name] = glyph
+
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:chart, chart_font)
+      stitcher.include_notdef(from: :chart)
+      stitcher.include_codepoints([0x42], from: :chart)
+
+      Dir.mktmpdir do |dir|
+        output_path = File.join(dir, "stitched.ttf")
+        stitcher.write_to(output_path, format: :ttf)
+
+        reopened = Fontisan::FontLoader.load(output_path)
+        expect(reopened.table("cmap").unicode_mappings.key?(0x42)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/fontisan/svg_to_glyf/normalizer_spec.rb
+++ b/spec/fontisan/svg_to_glyf/normalizer_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/svg_to_glyf"
+
+RSpec.describe Fontisan::SvgToGlyf::Geometry::Normalizer do
+  let(:affine) { Fontisan::SvgToGlyf::Geometry::AffineTransform }
+
+  describe "#matrix" do
+    it "maps SVG top-left (0,0) to font top (0, upm)" do
+      n = described_class.new(viewbox_width: 1000, viewbox_height: 1000, upm: 1000)
+      expect(n.matrix.apply(0, 0)).to eq([0.0, 1000.0])
+    end
+
+    it "maps SVG bottom-left (0,H) to font baseline-left (0, 0)" do
+      n = described_class.new(viewbox_width: 1000, viewbox_height: 1000, upm: 1000)
+      expect(n.matrix.apply(0, 1000)).to eq([0.0, 0.0])
+    end
+
+    it "maps SVG bottom-right (W,H) to font baseline-right (upm, 0)" do
+      n = described_class.new(viewbox_width: 1000, viewbox_height: 1000, upm: 1000)
+      expect(n.matrix.apply(1000, 1000)).to eq([1000.0, 0.0])
+    end
+
+    it "scales non-square viewBox to square UPM" do
+      n = described_class.new(viewbox_width: 500, viewbox_height: 1000, upm: 1000)
+      x, y = n.matrix.apply(250, 500)
+      expect(x).to eq(500.0)
+      expect(y).to eq(500.0)
+    end
+
+    it "scales a 1000×1000 viewBox up to UPM=2048" do
+      n = described_class.new(viewbox_width: 1000, viewbox_height: 1000, upm: 2048)
+      x, y = n.matrix.apply(500, 500)
+      expect(x).to be_within(0.001).of(1024.0)
+      expect(y).to be_within(0.001).of(1024.0)
+    end
+  end
+
+  describe "#final_transform" do
+    it "returns just the normalization when no group transform is given" do
+      n = described_class.new(viewbox_width: 1000, viewbox_height: 1000, upm: 1000)
+      expect(n.final_transform).to eq(n.matrix)
+    end
+
+    it "composes with a group transform" do
+      n = described_class.new(viewbox_width: 1000, viewbox_height: 1000, upm: 1000)
+      group = affine.scale(2)
+      final = n.final_transform(group)
+
+      # A path point (0,0) → group scale (0,0) → normalize (0, upm)
+      expect(final.apply(0, 0)).to eq([0.0, 1000.0])
+      # A path point (100, 0) → group scale (200, 0) → normalize (200, upm)
+      expect(final.apply(100, 0)).to eq([200.0, 1000.0])
+    end
+  end
+end

--- a/spec/fontisan/svg_to_glyf/path_parser_spec.rb
+++ b/spec/fontisan/svg_to_glyf/path_parser_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/svg_to_glyf"
+
+RSpec.describe Fontisan::SvgToGlyf::Path::Parser do
+  let(:command_type) { Fontisan::SvgToGlyf::Path::Command }
+
+  describe ".parse" do
+    it "parses a simple M-L-Z path" do
+      cmds = described_class.parse("M 0 0 L 100 100 Z")
+      expect(cmds.map(&:type)).to eq(%i[M L Z])
+      expect(cmds[0].args).to eq([0.0, 0.0])
+      expect(cmds[0].absolute).to be(true)
+      expect(cmds[1].args).to eq([100.0, 100.0])
+    end
+
+    it "preserves relative flag for lowercase commands" do
+      cmds = described_class.parse("m 10 20 l 5 5 z")
+      expect(cmds.map(&:absolute)).to eq([false, false, false])
+    end
+
+    it "tokenizes compact form without separators" do
+      cmds = described_class.parse("M16.5-2.203125")
+      expect(cmds[0].type).to eq(:M)
+      expect(cmds[0].args).to eq([16.5, -2.203125])
+    end
+
+    it "handles scientific notation" do
+      cmds = described_class.parse("M 1.5e3 2e-2")
+      expect(cmds[0].args).to eq([1500.0, 0.02])
+    end
+
+    it "handles comma-separated numbers" do
+      cmds = described_class.parse("M 0,0 L 100,100")
+      expect(cmds[1].args).to eq([100.0, 100.0])
+    end
+
+    it "handles implicit lineto after moveto" do
+      cmds = described_class.parse("M 0 0 100 100 200 200")
+      expect(cmds.map(&:type)).to eq(%i[M L L])
+    end
+
+    it "handles implicit lineto (relative) after lowercase m" do
+      cmds = described_class.parse("m 0 0 100 100")
+      expect(cmds.map(&:type)).to eq(%i[M L])
+      expect(cmds[1].absolute).to be(false)
+    end
+
+    it "handles implicit repetition of C" do
+      cmds = described_class.parse("C 1 2 3 4 5 6 7 8 9 10 11 12")
+      expect(cmds.map(&:type)).to eq(%i[C C])
+      expect(cmds[0].args).to eq([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+      expect(cmds[1].args).to eq([7.0, 8.0, 9.0, 10.0, 11.0, 12.0])
+    end
+
+    it "handles H and V commands" do
+      cmds = described_class.parse("M 0 0 H 100 V 50 Z")
+      expect(cmds.map(&:type)).to eq(%i[M H V Z])
+    end
+
+    it "handles Q and T commands" do
+      cmds = described_class.parse("M 0 0 Q 50 100 100 0 T 200 0")
+      expect(cmds.map(&:type)).to eq(%i[M Q T])
+    end
+
+    it "handles S (smooth cubic) command" do
+      cmds = described_class.parse("M 0 0 C 25 50 75 50 100 0 S 175 -50 200 0")
+      expect(cmds.map(&:type)).to eq(%i[M C S])
+    end
+
+    it "handles multiple Z commands" do
+      cmds = described_class.parse("M 0 0 L 1 1 Z M 2 2 L 3 3 Z")
+      expect(cmds.map(&:type)).to eq(%i[M L Z M L Z])
+    end
+
+    it "raises a clear error on arc command" do
+      expect { described_class.parse("M 0 0 A 50 50 0 0 1 100 0") }
+        .to raise_error(ArgumentError, /SVG arc command/)
+    end
+
+    it "parses the real ucode R-glyph fixture" do
+      fixture_path = "/Users/mulgogi/src/fontist/ucode/tmp/sample_output_17.0.0/blocks/Basic_Latin/U+0052/glyph.svg"
+      skip "fixture not available" unless File.exist?(fixture_path)
+
+      fixture = File.read(fixture_path)
+      d = fixture.match(/d="([^"]*)"/)&.captures&.first
+      skip "no d attribute found" unless d
+
+      cmds = described_class.parse(d)
+      expect(cmds.first.type).to eq(:M)
+      z_count = cmds.count { |c| c.type == :Z }
+      expect(z_count).to eq(3)
+      expect(cmds.none? { |c| c.type == :A }).to be(true)
+    end
+  end
+end

--- a/spec/fontisan/svg_to_glyf/transform_parser_spec.rb
+++ b/spec/fontisan/svg_to_glyf/transform_parser_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/svg_to_glyf"
+
+RSpec.describe Fontisan::SvgToGlyf::Geometry::TransformParser do
+  let(:identity) { Fontisan::SvgToGlyf::Geometry::AffineTransform.identity }
+
+  describe ".parse" do
+    it "returns identity for nil" do
+      expect(described_class.parse(nil)).to eq(identity)
+    end
+
+    it "returns identity for an empty string" do
+      expect(described_class.parse("")).to eq(identity)
+      expect(described_class.parse("   ")).to eq(identity)
+    end
+
+    it "parses translate with two args" do
+      t = described_class.parse("translate(10, 20)")
+      expect(t.apply(0, 0)).to eq([10.0, 20.0])
+    end
+
+    it "parses translate with one arg (ty defaults to 0)" do
+      t = described_class.parse("translate(15)")
+      expect(t.apply(0, 0)).to eq([15.0, 0.0])
+    end
+
+    it "parses scale with one arg (sy defaults to sx)" do
+      t = described_class.parse("scale(2)")
+      expect(t.apply(3, 5)).to eq([6.0, 10.0])
+    end
+
+    it "parses scale with two args" do
+      t = described_class.parse("scale(2, 3)")
+      expect(t.apply(3, 5)).to eq([6.0, 15.0])
+    end
+
+    it "parses rotate (degrees, around origin)" do
+      t = described_class.parse("rotate(90)")
+      x, y = t.apply(1, 0)
+      expect(x).to be_within(0.0001).of(0.0)
+      expect(y).to be_within(0.0001).of(1.0)
+    end
+
+    it "parses rotate around a point" do
+      t = described_class.parse("rotate(180, 5, 5)")
+      cx, cy = t.apply(5, 5)
+      expect(cx).to be_within(0.0001).of(5.0)
+      expect(cy).to be_within(0.0001).of(5.0)
+      x, y = t.apply(6, 5)
+      expect(x).to be_within(0.0001).of(4.0)
+      expect(y).to be_within(0.0001).of(5.0)
+    end
+
+    it "parses matrix(a,b,c,d,e,f)" do
+      t = described_class.parse("matrix(1, 0, 0, 1, 100, 200)")
+      expect(t.apply(0, 0)).to eq([100.0, 200.0])
+    end
+
+    it "parses skewX" do
+      t = described_class.parse("skewX(45)")
+      x, y = t.apply(1, 0)
+      expect(x).to be_within(0.0001).of(1.0)
+      expect(y).to be_within(0.0001).of(0.0)
+      x, = t.apply(0, 1)
+      expect(x).to be_within(0.0001).of(1.0)
+    end
+
+    it "composes multiple functions left-to-right" do
+      # scale(2) translate(10,0): point is first translated, then scaled
+      t = described_class.parse("scale(2) translate(10, 0)")
+      result = t.apply(5, 0)
+      # translate: (5,0)→(15,0), then scale: →(30,0)
+      expect(result).to eq([30.0, 0.0])
+    end
+
+    it "tolerates whitespace and comma variations" do
+      t = described_class.parse("translate(  10  ,  20  )")
+      expect(t.apply(0, 0)).to eq([10.0, 20.0])
+    end
+
+    it "raises on unknown function" do
+      expect { described_class.parse("bogus(1, 2)") }
+        .to raise_error(ArgumentError, /unknown SVG transform function/)
+    end
+
+    it "handles the real ucode fixture transform" do
+      t = described_class.parse("scale(51.354062) translate(-12780.598814, -17391.128233)")
+      # Path point (12780, 17391) → translate: (~0, ~0) → scale: (~0, ~0)
+      result = t.apply(12780.598814, 17391.128233)
+      expect(result[0]).to be_within(0.01).of(0.0)
+      expect(result[1]).to be_within(0.01).of(0.0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements `Fontisan::SvgToGlyf` — a converter from SVG path data (as produced by ucode's code-chart extraction) into `Ufo::Glyph` objects that feed directly into the existing Stitcher + TtfCompiler pipeline. Unblocks 942–1,055 codepoints across Unicode blocks with no OFL donor font (Khitan Small Script, Tulu-Tigalari, Garay, Ol Onal, etc.).

### Architecture (9 classes, MECE)

| Class | Responsibility |
|-------|---------------|
| `Geometry::AffineTransform` | 2×3 matrix with compose/apply |
| `Geometry::TransformParser` | SVG `transform="..."` parser (translate/scale/rotate/matrix/skew) |
| `Geometry::Normalizer` | viewBox + Y-flip + UPM scale composition |
| `Path::Parser` | SVG `d`-string tokenizer and command grouper |
| `Path::Command` | Value object (type, absolute, args) |
| `Path::State` | Mutable contour-building state (current point, subpath start, previous controls) |
| `Path::ContourBuilder` | Commands → `Ufo::Contour` with relative resolution and smooth-curve reflection |
| `Document` | Nokogiri XML walker, accumulates `<g>` transforms per `<path>` |
| `Assembler` | Full pipeline orchestrator + public API |

### Key design decisions

1. **Output is `Ufo::Glyph`**, not `Models::GlyphOutline` (the REQ proposed the latter, but `FontBuilder` was deleted and `Models::GlyphOutline` is the font-reading model). `Ufo::Glyph` feeds directly into `TtfCompiler`.

2. **Cubic-to-quadratic conversion (REQ R2) is NOT reimplemented** — the existing `Ufo::Compile::Filters::CubicToQuadratic` handles it automatically during TTF compilation.

3. **Contour winding (REQ R4) is delegated** to the existing `ReverseContourDirection` filter.

4. **Every coordinate operation is an `AffineTransform`**, composed once per document and applied per-point. No ad-hoc coordinate math.

5. **Arc command (`A`/`a`) is unsupported** — ucode chart SVGs use cubic curves exclusively. Encountering `A` raises a clear `ArgumentError`.

6. **Autoload throughout** — no `require_relative`. Each namespace has a hub file.

### Public API

```ruby
# Single path → glyph
glyph = Fontisan::SvgToGlyf.convert(path_data, upm: 1000, codepoint: 0x10940)

# SVG file → glyph (codepoint from filename)
glyph = Fontisan::SvgToGlyf.from_svg_file("/tmp/U+10940.svg", upm: 1000)

# Directory of SVGs → font (for Stitcher#add_source)
font = Fontisan::SvgToGlyf.from_directory("/tmp/chart-svg/Khitan", upm: 1000)
stitcher.add_source(:khitan, font)
```

## Test plan

- [x] 78 new specs across 7 spec files — each component unit-tested + end-to-end integration
- [x] `bundle exec rspec` — 5611 examples, 0 failures (79 new)
- [x] `bundle exec rubocop` — 655 files, no offenses
- [x] Integration: SVG → glyph → `TtfCompiler` → TTF reopens via `FontLoader` with correct cmap
- [x] Integration: SVG → `Ufo::Font` → `Stitcher` → TTF with codepoint preserved
- [x] Real ucode fixture (`U+0052` R-glyph) parses into 3 contours matching the expected subpath count
