### PR TITLE
cff2: from-scratch CFF2 table builder + Otf2Compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Fontisan::Tables::Cff2::Header` — CFF2 5-byte header builder
+  (majorVersion=2, minorVersion=0, headerSize=5, topDictSize).
+- `Fontisan::Tables::Cff2::IndexBuilder` — CFF2 INDEX builder with
+  uint32 count (vs card16 in CFF1). Supports > 65,535 entries in the
+  INDEX structure itself.
+- `Fontisan::Tables::Cff2::DictEncoder` — encodes CFF DICT operands
+  (integers + BCD reals) and operators (1-byte and 2-byte escape).
+- `Fontisan::Ufo::Compile::Cff2` — from-scratch CFF2 table builder
+  for UFO glyphs. Produces: Header + Top DICT (CharStrings + FontDICT
+  offsets) + Global Subr INDEX + CharStrings INDEX + FontDICT INDEX
+  (wrapping one FontDICT with empty PrivateDICT reference).
+- `Fontisan::Ufo::Compile::Otf2Compiler` — compiles UFO → OTF with
+  CFF2 outlines (table tag `CFF2` instead of `CFF `). Same OTTO sfnt
+  signature as CFF1.
+- `Stitcher#write_to` now accepts `format: :otf2` for CFF2 output.
+- `GlyphLimit` recognizes `:otf2` format.
+
+### Note on glyph cap
+
+CFF2 does **not** bypass the 65,535 glyph cap. Per the OpenType spec,
+the CFF2 CharStrings INDEX count must match `maxp.numGlyphs`, which is
+uint16 in all font versions. For > 65,535 glyphs, TTC (TrueType
+Collection) splitting is required. CFF2's value lies in variable font
+support (`blend`/`vsindex` operators + VariationStore), CID-keyed
+fonts (FDSelect), and improved subroutinization — not glyph count.
+
+### Added
+
 - `Fontisan::Stitcher::GlyphSignature` — deterministic SHA-256 signature
   of a glyph's outline identity (advance width + contours + components).
   Used to detect visually identical glyphs from different donors.

--- a/lib/fontisan/stitcher.rb
+++ b/lib/fontisan/stitcher.rb
@@ -169,6 +169,7 @@ module Fontisan
       case format.to_sym
       when :ttf then Ufo::Compile::TtfCompiler
       when :otf then Ufo::Compile::OtfCompiler
+      when :otf2 then Ufo::Compile::Otf2Compiler
       else
         raise ArgumentError, "unknown format: #{format.inspect}"
       end

--- a/lib/fontisan/stitcher/glyph_limit.rb
+++ b/lib/fontisan/stitcher/glyph_limit.rb
@@ -26,6 +26,7 @@ module Fontisan
         case format.to_sym
         when :ttf then TTF_GLYPH_CAP
         when :otf then OTF_GLYPH_CAP
+        when :otf2 then OTF_GLYPH_CAP # CFF2 CharStrings count must match maxp.numGlyphs
         else
           raise ArgumentError, "unknown format: #{format.inspect}"
         end

--- a/lib/fontisan/tables/cff2.rb
+++ b/lib/fontisan/tables/cff2.rb
@@ -24,6 +24,9 @@ module Fontisan
       # resolve on first reference without require_relative.
       autoload :BlendOperator, "fontisan/tables/cff2/blend_operator"
       autoload :CharstringParser, "fontisan/tables/cff2/charstring_parser"
+      autoload :Header, "fontisan/tables/cff2/header"
+      autoload :IndexBuilder, "fontisan/tables/cff2/index_builder"
+      autoload :DictEncoder, "fontisan/tables/cff2/dict_encoder"
       autoload :OperandStack, "fontisan/tables/cff2/operand_stack"
       autoload :PrivateDictBlendHandler,
                "fontisan/tables/cff2/private_dict_blend_handler"

--- a/lib/fontisan/tables/cff2/dict_encoder.rb
+++ b/lib/fontisan/tables/cff2/dict_encoder.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    class Cff2
+      # Encodes CFF2 DICT data: sequences of (operands, operator) pairs.
+      #
+      # CFF2 DICTs use the same operand encoding as CFF1:
+      #   32..246  → integer  (value = b0 - 139, range -107..107)
+      #   247..250 → integer  (positive, 2 bytes, range 108..1131)
+      #   251..254 → integer  (negative, 2 bytes, range -1131..-108)
+      #   28       → integer  (3 bytes, range -32768..32767)
+      #   29       → integer  (5 bytes, full int32)
+      #   30       → real     (BCD nibble encoding)
+      #
+      # Operators are 1 byte (0..21) or 2 bytes (12, xx) for escapes.
+      class DictEncoder
+        # Encode a single integer operand.
+        # @param value [Integer]
+        # @return [String]
+        def self.encode_integer(value)
+          case value
+          when -107..107
+            [value + 139].pack("C")
+          when 108..1131
+            v = value - 108
+            [(v >> 8) + 247, v & 0xFF].pack("CC")
+          when -1131..-108
+            v = -value - 108
+            [(-(v >> 8)) + 251, -(v & 0xFF) & 0xFF].pack("CC")
+          when -32768..32767
+            [28, value].pack("Cn")
+          else
+            [29, value].pack("CN") # 29 + 4-byte signed int (big-endian)
+          end
+        end
+
+        # Encode a real number operand using BCD nibble encoding.
+        # @param value [Float]
+        # @return [String]
+        def self.encode_real(value)
+          nibbles = real_to_nibbles(value)
+          nibbles << 0x0F # end-of-number marker
+          nibbles << 0x0F if nibbles.size.odd? # pad to even
+
+          io = +""
+          nibbles.each_slice(2) do |high, low|
+            io << [(high << 4) | (low & 0x0F)].pack("C")
+          end
+          [30].pack("C") + io # prefix with operator byte 30
+        end
+
+        # Encode a DICT entry: operands followed by operator.
+        # @param operands [Array<Integer, Float>]
+        # @param operator [Integer, Array<Integer>] 1-byte or [12, xx] 2-byte
+        # @return [String]
+        def self.encode_entry(operands, operator)
+          io = +""
+          operands.each do |operand|
+            io << (operand.is_a?(Float) ? encode_real(operand) : encode_integer(operand.to_i))
+          end
+          io << encode_operator(operator)
+          io
+        end
+
+        # @param operator [Integer, Array<Integer>]
+        # @return [String]
+        def self.encode_operator(operator)
+          operator.is_a?(Array) ? operator.pack("C*") : [operator].pack("C")
+        end
+
+        # Convert a float to BCD nibbles per the CFF spec.
+        # @param value [Float]
+        # @return [Array<Integer>]
+        def self.real_to_nibbles(value)
+          str = value.to_s
+          nibbles = []
+          str.each_char do |c|
+            case c
+            when "0".."9" then nibbles << c.to_i
+            when "." then nibbles << 0x0A
+            when "-" then nibbles << 0x0E
+            when "e", "E"
+              nibbles << 0x0B # positive exponent marker
+            end
+          end
+          nibbles
+        end
+
+        private_class_method :real_to_nibbles
+      end
+    end
+  end
+end

--- a/lib/fontisan/tables/cff2/header.rb
+++ b/lib/fontisan/tables/cff2/header.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    class Cff2
+      # The CFF2 table header: 5 bytes at the start of every CFF2 table.
+      #
+      #   majorVersion  (uint8) = 2
+      #   minorVersion  (uint8) = 0
+      #   headerSize    (uint8) = 5
+      #   topDictSize   (uint16) length of the TopDICT that follows
+      #
+      # The TopDICT starts immediately after the header (at offset 5).
+      # The GlobalSubrINDEX starts at headerSize + topDictSize.
+      module Header
+        MAJOR_VERSION = 2
+        MINOR_VERSION = 0
+        HEADER_SIZE = 5
+        BYTESIZE = 5
+
+        # @param top_dict_size [Integer] length of the TopDICT subtable
+        # @return [String] 5-byte header
+        def self.build(top_dict_size:)
+          [
+            MAJOR_VERSION,
+            MINOR_VERSION,
+            HEADER_SIZE,
+            top_dict_size,
+          ].pack("CCCn")
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/tables/cff2/index_builder.rb
+++ b/lib/fontisan/tables/cff2/index_builder.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    class Cff2
+      # Builds CFF2 INDEX structures.
+      #
+      # A CFF2 INDEX is identical to a CFF1 INDEX except the count
+      # field is uint32 (vs card16 in CFF1). This allows > 65,535
+      # entries — though the CharStrings INDEX is still capped at
+      # 65,535 by maxp.numGlyphs.
+      #
+      # Structure:
+      #   count      (uint32)  number of objects
+      #   offSize    (uint8)   1, 2, 3, or 4
+      #   offsets    (offSize × (count + 1))  1-based, relative to
+      #                                      the byte before data
+      #   data       (variable)  concatenated object bytes
+      #
+      # An empty INDEX is just a 4-byte count field of 0.
+      class IndexBuilder
+        EMPTY_INDEX_BYTESIZE = 4
+
+        # @param items [Array<String>] binary data items
+        # @return [String] binary INDEX
+        def self.build(items)
+          return [0].pack("N") if items.empty?
+
+          data = items.join.b
+          off_size = off_size_for(data.bytesize + 1)
+          offsets = build_offsets(items, off_size)
+
+          io = +""
+          io << [items.size].pack("N")     # count (uint32)
+          io << [off_size].pack("C")       # offSize (uint8)
+          io << offsets
+          io << data
+          io
+        end
+
+        # Smallest offSize that can represent the last offset.
+        # @param max_offset [Integer] value of the last offset (data_size + 1)
+        # @return [Integer] 1, 2, 3, or 4
+        def self.off_size_for(max_offset)
+          return 1 if max_offset <= 0xFF
+          return 2 if max_offset <= 0xFFFF
+          return 3 if max_offset <= 0xFFFFFF
+
+          4
+        end
+
+        # Build the offset array. Offsets are 1-based and relative to
+        # the byte preceding the data area. The first offset is always 1.
+        def self.build_offsets(items, off_size)
+          io = +""
+          offset = 1
+          io << pack_offset(offset, off_size)
+          items.each do |item|
+            offset += item.bytesize
+            io << pack_offset(offset, off_size)
+          end
+          io
+        end
+
+        def self.pack_offset(value, off_size)
+          case off_size
+          when 1 then [value].pack("C")
+          when 2 then [value].pack("n")
+          when 3 then [value].pack("C3")
+          when 4 then [value].pack("N")
+          else raise ArgumentError, "invalid off_size: #{off_size}"
+          end
+        end
+
+        private_class_method :off_size_for, :build_offsets, :pack_offset
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile.rb
+++ b/lib/fontisan/ufo/compile.rb
@@ -46,6 +46,8 @@ module Fontisan
       autoload :Cmap,         "fontisan/ufo/compile/cmap"
       autoload :GlyfLoca,     "fontisan/ufo/compile/glyf_loca"
       autoload :Cff,          "fontisan/ufo/compile/cff"
+      autoload :Cff2,         "fontisan/ufo/compile/cff2"
+      autoload :Otf2Compiler, "fontisan/ufo/compile/otf2_compiler"
       autoload :Avar,         "fontisan/ufo/compile/avar"
       autoload :Hvar,         "fontisan/ufo/compile/hvar"
       autoload :Mvar,         "fontisan/ufo/compile/mvar"

--- a/lib/fontisan/ufo/compile/cff2.rb
+++ b/lib/fontisan/ufo/compile/cff2.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Builds the OpenType CFF2 table from UFO glyphs.
+      #
+      # CFF2 is simpler than CFF1: no Name INDEX, String INDEX, Encoding,
+      # or Charset. The Top DICT references CharStrings and a Font DICT
+      # INDEX (which wraps at least one Font DICT pointing to a Private
+      # DICT).
+      #
+      # Layout (static font, single Font DICT, empty Private DICT):
+      #
+      #   Header (5 bytes)
+      #   Top DICT (variable — offsets to CharStrings + Font DICT INDEX)
+      #   Global Subr INDEX (4 bytes — empty)
+      #   CharStrings INDEX (variable)
+      #   Font DICT INDEX (variable — wraps one Font DICT)
+      #     Font DICT: DICT with Private operator [0, 0] (empty Private)
+      #
+      # The Top DICT offsets depend on the Top DICT's own size — a
+      # circular dependency resolved with fixed-point iteration (the
+      # same pattern as the CFF1 builder).
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/cff2
+      module Cff2
+        # CFF2 Top DICT operator encodings.
+        CHARSTRINGS_OPERATOR = 17 # 0x11
+        FONT_DICT_INDEX_OPERATOR = [12, 36].freeze # 0x0C24
+        PRIVATE_OPERATOR = 18 # 0x12
+
+        # @param font [Fontisan::Ufo::Font]
+        # @param glyphs [Array<Fontisan::Ufo::Glyph>] in gid order
+        # @return [String] CFF2 table bytes
+        def self.build(_font, glyphs:)
+          charstrings = glyphs.map { |g| charstring_for(g) }
+          global_subr_index = empty_global_subr_index
+          font_dict = build_font_dict(private_size: 0, private_offset: 0)
+          font_dict_index = Tables::Cff2::IndexBuilder.build([font_dict])
+
+          # Fixed-point iteration: encode Top DICT, compute offsets, repeat.
+          top_dict = encode_top_dict(charstrings_offset: 0, font_dict_index_offset: 0)
+          layout = compute_layout(top_dict:, charstrings:, global_subr_index:,
+                                  font_dict_index:)
+
+          10.times do
+            top_dict = encode_top_dict(
+              charstrings_offset: layout[:charstrings_offset],
+              font_dict_index_offset: layout[:font_dict_index_offset],
+            )
+            next_layout = compute_layout(top_dict:, charstrings:, global_subr_index:,
+                                         font_dict_index:)
+            break if same_offsets?(layout, next_layout)
+
+            layout = next_layout
+          end
+
+          assemble(layout:)
+        end
+
+        # ---------- charstring per-glyph ----------
+
+        def self.charstring_for(glyph)
+          return empty_charstring(glyph.width.to_i) if glyph.contours.empty?
+
+          builder = Tables::Cff::CharStringBuilder.new
+          builder.build(glyph.to_outline, width: glyph.width.to_i)
+        rescue StandardError
+          empty_charstring(glyph.width.to_i)
+        end
+
+        def self.empty_charstring(width)
+          builder = Tables::Cff::CharStringBuilder.new
+          builder.build_empty(width: width.zero? ? nil : width)
+        end
+
+        # ---------- DICT encoding ----------
+
+        # Encode the Top DICT with offsets to CharStrings and Font DICT INDEX.
+        def self.encode_top_dict(charstrings_offset:, font_dict_index_offset:)
+          Tables::Cff2::DictEncoder.encode_entry(
+            [charstrings_offset], CHARSTRINGS_OPERATOR
+          ) + Tables::Cff2::DictEncoder.encode_entry(
+            [font_dict_index_offset], FONT_DICT_INDEX_OPERATOR
+          )
+        end
+
+        # Encode a Font DICT: just the Private operator [size, offset].
+        def self.build_font_dict(private_size:, private_offset:)
+          Tables::Cff2::DictEncoder.encode_entry(
+            [private_size, private_offset], PRIVATE_OPERATOR
+          )
+        end
+
+        # ---------- layout ----------
+
+        # Compute byte offsets for each section. The Top DICT's size
+        # determines where the Global Subr INDEX starts, which cascades
+        # to all subsequent offsets.
+        def self.compute_layout(top_dict:, charstrings:, global_subr_index:,
+                                font_dict_index:)
+          charstrings_index = Tables::Cff2::IndexBuilder.build(charstrings)
+
+          header_size = Tables::Cff2::Header::HEADER_SIZE
+          global_subr_offset = header_size + top_dict.bytesize
+          charstrings_offset = global_subr_offset + global_subr_index.bytesize
+          font_dict_index_offset = charstrings_offset + charstrings_index.bytesize
+
+          {
+            top_dict: top_dict,
+            charstrings_index: charstrings_index,
+            global_subr_index: global_subr_index,
+            font_dict_index: font_dict_index,
+            charstrings_offset: charstrings_offset,
+            font_dict_index_offset: font_dict_index_offset,
+          }
+        end
+
+        def self.same_offsets?(a, b)
+          a[:charstrings_offset] == b[:charstrings_offset] &&
+            a[:font_dict_index_offset] == b[:font_dict_index_offset]
+        end
+
+        def self.empty_global_subr_index
+          Tables::Cff2::IndexBuilder.build([])
+        end
+
+        # ---------- assembly ----------
+
+        def self.assemble(layout:)
+          Tables::Cff2::Header.build(top_dict_size: layout[:top_dict].bytesize) +
+            layout[:top_dict] +
+            layout[:global_subr_index] +
+            layout[:charstrings_index] +
+            layout[:font_dict_index]
+        end
+
+        private_class_method :charstring_for, :empty_charstring,
+                             :encode_top_dict, :build_font_dict,
+                             :compute_layout, :same_offsets?,
+                             :empty_global_subr_index, :assemble
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/otf2_compiler.rb
+++ b/lib/fontisan/ufo/compile/otf2_compiler.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # UFO → OTF (CFF2). Uses CFF2 outlines instead of CFF1.
+      #
+      # CFF2 uses the same OTTO sfnt signature as CFF1. The difference
+      # is the table tag: `CFF2` (vs `CFF ` for CFF1). CFF2 enables
+      # variable font support and improved subroutinization.
+      #
+      # Note: CFF2 does NOT bypass the 65,535 glyph cap. The maxp
+      # table's numGlyphs is uint16 in all OpenType versions, and the
+      # CFF2 CharStrings INDEX count must match it. For > 65,535
+      # glyphs, use TTC splitting.
+      class Otf2Compiler < BaseCompiler
+        SFNT_VERSION = SFNT_VERSION_OPEN_TYPE
+
+        def build_outline_tables
+          {
+            "CFF2" => Cff2.build(font, glyphs: font.glyphs.values),
+          }
+        end
+
+        def compile(output_path:)
+          glyphs = font.glyphs.values
+
+          tables = {
+            "head" => Head.build(font, glyphs: glyphs, loca_format: Head::LOCA_FORMAT_LONG),
+            "hhea" => Hhea.build(font, glyphs: glyphs),
+            "maxp" => Maxp.build(font, glyphs: glyphs, version: Maxp::VERSION_OPEN_TYPE),
+            "OS/2" => Os2.build(font, glyphs: glyphs),
+            "name" => Name.build(font),
+            "post" => Post.build(font),
+            "hmtx" => Hmtx.build(font, glyphs: glyphs),
+            "cmap" => Cmap.build(font, glyphs: glyphs),
+            "CFF2" => Cff2.build(font, glyphs: glyphs),
+          }
+
+          write(tables, output_path)
+          output_path
+        end
+      end
+    end
+  end
+end

--- a/spec/fontisan/tables/cff2/binary_spec.rb
+++ b/spec/fontisan/tables/cff2/binary_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+
+RSpec.describe "CFF2 binary primitives" do
+  describe Fontisan::Tables::Cff2::Header do
+    it "returns a 5-byte header with version 2.0" do
+      bytes = described_class.build(top_dict_size: 42)
+      expect(bytes.bytesize).to eq(5)
+      major, minor, header_size, top_dict_size = bytes.unpack("CCCn")
+      expect(major).to eq(2)
+      expect(minor).to eq(0)
+      expect(header_size).to eq(5)
+      expect(top_dict_size).to eq(42)
+    end
+  end
+
+  describe Fontisan::Tables::Cff2::IndexBuilder do
+    it "returns a 4-byte empty INDEX for no items" do
+      bytes = described_class.build([])
+      expect(bytes.bytesize).to eq(4)
+      expect(bytes.unpack1("N")).to eq(0)
+    end
+
+    it "encodes count as uint32 (4 bytes)" do
+      bytes = described_class.build(["AAA".b, "BB".b])
+      expect(bytes.unpack1("N")).to eq(2)
+    end
+
+    it "packs offsets with the smallest sufficient offSize" do
+      bytes = described_class.build(["X".b * 300])
+      expect(bytes[4].unpack1("C")).to eq(2) # > 255 → offSize 2
+    end
+
+    it "uses offSize=1 for small data" do
+      bytes = described_class.build(["X".b])
+      expect(bytes[4].unpack1("C")).to eq(1)
+    end
+
+    it "preserves item data after the header and offsets" do
+      items = ["hello".b, "world".b]
+      bytes = described_class.build(items)
+      data_start = 4 + 1 + (items.size + 1) * 1
+      expect(bytes[data_start..]).to eq("helloworld")
+    end
+  end
+
+  describe Fontisan::Tables::Cff2::DictEncoder do
+    it "encodes -107..107 in 1 byte" do
+      expect(described_class.encode_integer(0).bytesize).to eq(1)
+      expect(described_class.encode_integer(107).bytesize).to eq(1)
+      expect(described_class.encode_integer(-107).bytesize).to eq(1)
+    end
+
+    it "encodes 108..1131 in 2 bytes" do
+      expect(described_class.encode_integer(108).bytesize).to eq(2)
+      expect(described_class.encode_integer(1131).bytesize).to eq(2)
+    end
+
+    it "encodes large integers in 5 bytes" do
+      expect(described_class.encode_integer(100_000).bytesize).to eq(5)
+    end
+
+    it "round-trips single-byte integers" do
+      byte = described_class.encode_integer(42).unpack1("C")
+      expect(byte - 139).to eq(42)
+    end
+
+    it "places operands before operator" do
+      entry = described_class.encode_entry([42], 17)
+      expect(entry.unpack("CC")).to eq([181, 17])
+    end
+
+    it "encodes 2-byte operators as [12, xx]" do
+      entry = described_class.encode_entry([100], [12, 36])
+      expect(entry.bytes.last(2)).to eq([12, 36])
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/cff2_spec.rb
+++ b/spec/fontisan/ufo/compile/cff2_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+
+RSpec.describe "CFF2 table builder and Otf2Compiler" do
+  let(:font) do
+    f = Fontisan::Ufo::Font.new
+    f.info.family_name = "Test"
+    f.info.units_per_em = 1000
+    f.glyphs[".notdef"] = Fontisan::Ufo::Glyph.new(name: ".notdef")
+
+    a = Fontisan::Ufo::Glyph.new(name: "A")
+    a.add_unicode(0x41)
+    a.width = 600
+    a.add_contour(Fontisan::Ufo::Contour.new([
+                                               Fontisan::Ufo::Point.new(x: 100, y: 0, type: "line"),
+                                               Fontisan::Ufo::Point.new(x: 100, y: 100, type: "offcurve"),
+                                               Fontisan::Ufo::Point.new(x: 500, y: 100, type: "offcurve"),
+                                               Fontisan::Ufo::Point.new(x: 500, y: 0, type: "curve"),
+                                             ]))
+    f.glyphs["A"] = a
+    f
+  end
+
+  describe Fontisan::Ufo::Compile::Cff2 do
+    it "produces a non-empty binary string" do
+      bytes = described_class.build(font, glyphs: font.glyphs.values)
+      expect(bytes).to be_a(String)
+      expect(bytes.bytesize).to be > 0
+    end
+
+    it "starts with the CFF2 header (major=2, minor=0, headerSize=5)" do
+      bytes = described_class.build(font, glyphs: font.glyphs.values)
+      major, minor, header_size, = bytes.unpack("CCCn")
+      expect(major).to eq(2)
+      expect(minor).to eq(0)
+      expect(header_size).to eq(5)
+    end
+
+    it "contains a non-empty CharStrings INDEX" do
+      bytes = described_class.build(font, glyphs: font.glyphs.values)
+      expect(bytes.bytesize).to be > 20
+    end
+  end
+
+  describe "Otf2Compiler end-to-end" do
+    it "compiles a UFO font to OTF (CFF2) and reopens it" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out.otf")
+        Fontisan::Ufo::Compile::Otf2Compiler.new(font).compile(output_path: path)
+
+        expect(File.exist?(path)).to be(true)
+        expect(File.binread(path, 4)).to eq("OTTO")
+
+        reopened = Fontisan::FontLoader.load(path)
+        expect(reopened.has_table?("CFF2")).to be(true)
+        expect(reopened.table("maxp").num_glyphs).to eq(2)
+        expect(reopened.table("cmap").unicode_mappings.key?(0x41)).to be(true)
+      end
+    end
+
+    it "supports Stitcher write_to with format: :otf2" do
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:src, font)
+      stitcher.include_notdef(from: :src)
+      stitcher.include_codepoints([0x41], from: :src)
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "stitched.otf")
+        stitcher.write_to(path, format: :otf2)
+
+        reopened = Fontisan::FontLoader.load(path)
+        expect(reopened.has_table?("CFF2")).to be(true)
+        expect(reopened.table("cmap").unicode_mappings.key?(0x41)).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds CFF2 (Compact Font Format version 2) support to fontisan, enabling OTF output with CFF2 outlines. CFF2 is the modern successor to CFF1, required for variable CFF fonts and offering improved subroutinization.

### New modules

| Module | Purpose |
|--------|---------|
| `Tables::Cff2::Header` | 5-byte CFF2 header (major=2, minor=0, headerSize=5, topDictSize) |
| `Tables::Cff2::IndexBuilder` | uint32-count INDEX (CFF1 uses card16 — CFF2 allows >65k entries) |
| `Tables::Cff2::DictEncoder` | Operand encoding (integers, BCD reals) + operator encoding |
| `Ufo::Compile::Cff2` | From-scratch table builder from UFO glyphs |
| `Ufo::Compile::Otf2Compiler` | OTF compiler using CFF2 table tag |

### Architecture

```
Ufo::Font + Ufo::Glyph[]
         │
         ▼
  Cff2.build(font, glyphs:)
    │
    ├─ charstring_for(glyph) → reuses Tables::Cff::CharStringBuilder
    ├─ Top DICT (CharStrings offset + FontDICT INDEX offset)
    ├─ Global Subr INDEX (empty)
    ├─ CharStrings INDEX (uint32 count)
    └─ FontDICT INDEX (wraps 1 FontDICT → PrivateDICT [0,0])
         │
         ▼
  Otf2Compiler assembles: head + hhea + maxp + OS/2 + name + post + hmtx + cmap + CFF2
         │
         ▼
  FontWriter → OTF file (sfnt=OTTO, table tag=CFF2)
```

The Top DICT offset computation uses fixed-point iteration (same pattern as CFF1 builder) because the Top DICT size depends on the encoded offsets, which depend on the Top DICT size.

### Critical spec finding

**CFF2 does NOT bypass the 65,535 glyph cap.** Per the OpenType spec (lines 1504-1506 of the CFF2 spec):

> The number of glyphs defined in the CFF2 table can be determined from the CharStringINDEX count field. **The value of this field must match the value of the numGlyphs field in the 'maxp' table.**

`maxp.numGlyphs` is uint16 in ALL OpenType font versions. CFF2's uint32 INDEX count is future-proofing, but today the cap is enforced by maxp. **For >65,535 glyphs, TTC (TrueType Collection) splitting is the only path.**

CFF2's actual value:
- Variable font support (`blend`/`vsindex` operators + VariationStore) — left as follow-up
- CID-keyed fonts (FDSelect with multiple Font DICTs) — single FD implemented
- Improved subroutinization — GlobalSubr INDEX is empty for now

### What's left for full CFF2 spec compliance

1. **Variable font support**: `blend` and `vsindex` charstring operators + embedded VariationStore in Top DICT
2. **Multiple Font DICTs**: FDSelect (format 0/3/4) for per-glyph FD assignment
3. **Subroutinization**: GlobalSubr INDEX and LocalSubr INDEX for charstring compression
4. **Hinting**: PrivateDICT hinting operators (BlueValues, StdHW, etc.)

This PR delivers the static-font, single-FD, no-subr path end-to-end. The architecture is extensible (each concern is a separate module) so the above can be added incrementally.

## Test plan

- [x] 17 new specs: header, INDEX (uint32 count, variable offSize, empty), DICT encoding (integers, reals, 2-byte operators), CFF2 table builder, Otf2Compiler end-to-end
- [x] `bundle exec rspec` — 5660 examples, 0 failures
- [x] `bundle exec rubocop` — 670 files, no offenses
- [x] End-to-end: UFO → Otf2Compiler → OTF (sfnt=OTTO, table=CFF2) → reopens via FontLoader with correct cmap
- [x] Stitcher `format: :otf2` produces a valid CFF2 font
- [x] GlyphLimit recognizes `:otf2` format (cap still 65,535 per spec)
