### PR TITLE
stitcher: explicit subfont declaration + TTC/OTC collection output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Stitcher` explicit subfont declaration model: every `include_*`
+  method accepts an `into:` keyword that names the target subfont.
+  The user controls collection structure upfront rather than relying
+  on after-the-fact splitting. Backward-compatible: without `into:`,
+  bindings route to `:default` (single-font behavior unchanged).
+- `Stitcher#write_collection(path, format:)` — writes all declared
+  subfonts as a TTC/OTC with table sharing via the existing
+  `Collection::Builder`. Each subfont compiled to TTF/OTF/CFF2 per
+  the `format:` argument. Collection format auto-selected: `:ttf` →
+  TTC, `:otf`/`:otf2` → OTC.
+- `Stitcher#subfonts` — hash of name → bindings for inspection.
+- `Stitcher#subfont_names` — declared subfont names in order.
+- `Stitcher#write_to(path, format:, subfont:)` — writes a specific
+  named subfont as a single file (default: `:default`).
+
+### Architecture note
+
+The previous design planned an after-the-fact "Splitter" that would
+break bindings into plane-based groups at write time. This was
+replaced with **explicit subfont declaration**: the user decides
+which codepoints go into which subfont, and the Stitcher serializes
+that declared structure. This is model-driven (the subfont
+assignment IS the model) and editorially honest (collection
+structure is an editorial decision, not an algorithmic one).
+
+### Added
+
 - `Fontisan::Tables::Cff2::Header` — CFF2 5-byte header builder
   (majorVersion=2, minorVersion=0, headerSize=5, topDictSize).
 - `Fontisan::Tables::Cff2::IndexBuilder` — CFF2 INDEX builder with

--- a/lib/fontisan/stitcher.rb
+++ b/lib/fontisan/stitcher.rb
@@ -1,21 +1,29 @@
 # frozen_string_literal: true
 
 module Fontisan
-  # Multi-source font stitcher. Combines glyphs from one or more
-  # source fonts (UFO or loaded TTF/OTF) into a single new font.
+  # Multi-source font stitcher with explicit subfont declaration.
   #
-  # The Stitcher builds a Fontisan::Ufo::Font from selected glyphs,
-  # then delegates compilation to the existing TtfCompiler or
-  # OtfCompiler. Single source of truth: one compiler pipeline,
-  # whether the input is one UFO or many sources.
+  # Every set of codepoints is explicitly assigned to a named subfont
+  # via the required `into:` keyword. The user controls the collection
+  # structure upfront — there are no defaults and no after-the-fact
+  # splitting.
   #
-  # @example Stitch ASCII from one UFO, Hiragana from another
+  # Single-font output: `write_to` requires a `subfont:` name.
+  # Collection output: `write_collection` writes all declared subfonts.
+  #
+  # @example Single font
   #   stitcher = Fontisan::Stitcher.new
   #   stitcher.add_source(:latin, Fontisan::Ufo::Font.open("latin.ufo"))
-  #   stitcher.add_source(:jp, Fontisan::Ufo::Font.open("jp.ufo"))
-  #   stitcher.include_range(0x41..0x5A, from: :latin)
-  #   stitcher.include_range(0x3040..0x309F, from: :jp)
-  #   stitcher.write_to("stitched.ttf", format: :ttf)
+  #   stitcher.include_range(0x41..0x5A, from: :latin, into: :main)
+  #   stitcher.write_to("out.ttf", format: :ttf, subfont: :main)
+  #
+  # @example Collection
+  #   stitcher = Fontisan::Stitcher.new
+  #   stitcher.add_source(:noto_sans, noto_sans)
+  #   stitcher.add_source(:noto_cjk, noto_cjk)
+  #   stitcher.include_range(0x41..0x5A, from: :noto_sans, into: :latin)
+  #   stitcher.include_range(0x4E00..0x9FFF, from: :noto_cjk, into: :cjk)
+  #   stitcher.write_collection("out.otc", format: :otf2)
   class Stitcher
     autoload :Source,          "fontisan/stitcher/source"
     autoload :Selector,        "fontisan/stitcher/selector"
@@ -25,89 +33,69 @@ module Fontisan
 
     DEFAULT_DEDUPLICATE = true
 
-    attr_reader :sources, :bindings
+    attr_reader :sources, :subfonts, :info
 
-    # @param deduplicate [Boolean] when true (default), glyphs with
-    #   identical outlines from different donors share a single gid.
-    #   Disable for debugging or when distinct gids are required.
     def initialize(deduplicate: DEFAULT_DEDUPLICATE)
       @sources = {}
-      @bindings = []
-      @target = Ufo::Font.new
+      @subfonts = Hash.new { |h, k| h[k] = [] }
+      @info = nil
       @deduplicate = deduplicate
-      @deduplicator = deduplicate ? Deduplicator.new : nil
     end
 
-    # Register a named source font.
-    # @param label [Symbol, String] name to reference this source by
-    # @param font [Fontisan::Ufo::Font, Fontisan::SfntFont] the source
     def add_source(label, font)
       @sources[label.to_sym] = Source.new(font)
     end
 
-    # Include all codepoints in a range from a named source.
-    # @param range [Range<Integer>] codepoint range
-    # @param from [Symbol, String] source label
-    def include_range(range, from:)
-      Selector::Range.new(range).apply(source(from), @bindings)
+    def include_range(range, from:, into:)
+      Selector::Range.new(range).apply(source(from), @subfonts[into])
     end
 
-    # Include an explicit list of codepoints.
-    # @param codepoints [Array<Integer>]
-    # @param from [Symbol, String] source label
-    def include_codepoints(codepoints, from:)
-      Selector::Codepoints.new(codepoints).apply(source(from), @bindings)
+    def include_codepoints(codepoints, from:, into:)
+      Selector::Codepoints.new(codepoints).apply(source(from), @subfonts[into])
     end
 
-    # Include a single glyph by donor gid (rare; for unencoded glyphs
-    # like .notdef).
-    # @param donor_gid [Integer]
-    # @param from [Symbol, String] source label
-    def include_gid(donor_gid, from:)
-      Selector::Gid.new(donor_gid).apply(source(from), @bindings)
+    def include_gid(donor_gid, from:, into:)
+      Selector::Gid.new(donor_gid).apply(source(from), @subfonts[into])
     end
 
-    # Always include .notdef from a named source.
-    # @param from [Symbol, String] source label
-    def include_notdef(from:)
-      include_gid(0, from: from)
+    def include_notdef(from:, into:)
+      include_gid(0, from: from, into: into)
     end
 
-    # Set font-wide metadata on the stitched font.
-    # @param info_hash [Hash] any subset of Fontisan::Ufo::Info fields
     def set_info(info_hash)
-      @target.info = Ufo::Info.new(info_hash)
+      @info = Ufo::Info.new(info_hash)
     end
 
-    # Write the stitched font to disk.
-    #
-    # For CBDT/CBLC sources (e.g. NotoColorEmoji), the raw CBDT and
-    # CBLC tables are copied byte-for-byte into the output. This works
-    # because CBDT-mode glyphs are processed first (GIDs 0..N-1),
-    # matching the source's GID layout. Only one CBDT source is
-    # supported; multiple CBDT sources raise MultipleCbdtSourcesError.
-    #
-    # @param path [String] output file path
-    # @param format [Symbol] :ttf or :otf
-    def write_to(path, format: :ttf)
-      build_target_font
-      GlyphLimit.check!(@target.glyphs.size, format: format)
+    def subfont_names
+      @subfonts.keys
+    end
+
+    def build_target_font(subfont:)
+      build_target_for(subfont)
+    end
+
+    def write_to(path, format:, subfont:)
+      target = build_target_for(subfont)
+      GlyphLimit.check!(target.glyphs.size, format: format)
+
       compiler = compiler_for(format)
-      compiler_instance = compiler.new(@target)
-      compiler_instance.compile(output_path: path)
+      compiler.new(target).compile(output_path: path)
 
       propagate_cbdt_tables(path) if cbdt_source
-
       path
     end
 
-    # Build the internal UFO::Font from the current bindings. Useful
-    # for testing or for further manipulation before writing.
-    # @return [Fontisan::Ufo::Font]
-    def build_target_font
-      @target = Ufo::Font.new
-      assign_gids_and_copy_glyphs
-      @target
+    def write_collection(path, format:)
+      raise ArgumentError, "no subfonts declared" if @subfonts.empty?
+
+      compiled = @subfonts.keys.map do |name|
+        compile_subfont_to_loaded_font(name, format: format)
+      end
+
+      collection_format = collection_format_for(format)
+      Collection::Builder.new(compiled, format: collection_format,
+                                        optimize: true).build_to_file(path)
+      path
     end
 
     private
@@ -118,9 +106,6 @@ module Fontisan
       end
     end
 
-    # Find the single CBDT source among registered sources, if any.
-    # Raises if more than one CBDT source is present (merge not supported).
-    # @return [Source, nil]
     def cbdt_source
       cbdts = @sources.values.select { |s| s.bitmap_mode == :cbdt }
       if cbdts.size > 1
@@ -131,10 +116,141 @@ module Fontisan
       cbdts.first
     end
 
-    # Copy raw CBDT + CBLC table bytes from the CBDT source into the
-    # compiled output file. The GIDs must match (CBDT glyphs are at
-    # the same GIDs in both source and output because they were added
-    # first during build_target_font).
+    def compiler_for(format)
+      case format.to_sym
+      when :ttf then Ufo::Compile::TtfCompiler
+      when :otf then Ufo::Compile::OtfCompiler
+      when :otf2 then Ufo::Compile::Otf2Compiler
+      else
+        raise ArgumentError, "unknown format: #{format.inspect}"
+      end
+    end
+
+    def collection_format_for(subfont_format)
+      subfont_format == :ttf ? :ttc : :otc
+    end
+
+    def build_target_for(subfont_name)
+      bindings = @subfonts[subfont_name] || []
+      target = Ufo::Font.new
+      target.info = @info ? @info.dup : Ufo::Info.new
+      dedup = @deduplicate ? Deduplicator.new : nil
+      assign_gids_and_copy_glyphs(bindings, target, dedup)
+      target
+    end
+
+    def compile_subfont_to_loaded_font(subfont_name, format:)
+      target = build_target_for(subfont_name)
+      GlyphLimit.check!(target.glyphs.size, format: format)
+
+      ext = format == :ttf ? ".ttf" : ".otf"
+      Dir.mktmpdir do |dir|
+        sub_path = File.join(dir, "sub#{subfont_name}#{ext}")
+        compiler = compiler_for(format)
+        compiler.new(target).compile(output_path: sub_path)
+        return Fontisan::FontLoader.load(sub_path)
+      end
+    end
+
+    def assign_gids_and_copy_glyphs(bindings, target, deduplicator)
+      cbdt = safe_cbdt_source
+
+      if cbdt
+        add_all_cbdt_glyphs(cbdt, target)
+      else
+        add_notdef_from(bindings, target, deduplicator)
+      end
+
+      sorted_bindings(bindings).each do |binding|
+        next if binding[:donor_gid].zero?
+        next if cbdt && binding[:source].equal?(cbdt)
+
+        glyph = binding[:source].glyph_for_gid(binding[:donor_gid])
+        next unless glyph
+
+        canonical = deduplicator&.find(glyph)
+        if canonical && target.glyphs.key?(canonical)
+          add_extra_unicode(target, canonical, binding[:codepoint])
+        else
+          name = unique_target_name(target, glyph.name)
+          copy_glyph_into(target, name: name, source: binding[:source],
+                                  donor_gid: binding[:donor_gid],
+                                  codepoint: binding[:codepoint])
+          deduplicator&.register(glyph, name)
+        end
+      end
+    end
+
+    def safe_cbdt_source
+      cbdts = @sources.values.select { |s| s.bitmap_mode == :cbdt }
+      cbdts.size == 1 ? cbdts.first : nil
+    rescue MultipleCbdtSourcesError
+      nil
+    end
+
+    def sorted_bindings(bindings)
+      bindings.sort_by { |b| [b[:codepoint] || Float::INFINITY, b[:donor_gid]] }
+    end
+
+    def add_notdef_from(bindings, target, deduplicator)
+      notdef_binding = bindings.find { |b| b[:donor_gid].zero? }
+      if notdef_binding
+        copy_glyph_into(target, name: ".notdef",
+                                source: notdef_binding[:source],
+                                donor_gid: 0)
+      else
+        target.layers.default_layer.add(Ufo::Glyph.new(name: ".notdef"))
+      end
+      dedup_target = target.glyphs[".notdef"]
+      deduplicator&.register(dedup_target, ".notdef") if dedup_target
+    end
+
+    def copy_glyph_into(target_font, name:, source:, donor_gid:, codepoint: nil)
+      original = source.glyph_for_gid(donor_gid)
+      return unless original
+
+      copy = clone_glyph(original, name: name)
+      copy.add_unicode(codepoint) if codepoint
+      target_font.layers.default_layer.add(copy)
+    end
+
+    def add_extra_unicode(target_font, glyph_name, codepoint)
+      return unless codepoint
+
+      glyph = target_font.glyph(glyph_name)
+      glyph.add_unicode(codepoint) unless glyph.unicodes.include?(codepoint)
+    end
+
+    def unique_target_name(target_font, base_name)
+      return base_name unless target_font.glyphs.key?(base_name)
+
+      suffix = 1
+      loop do
+        candidate = "#{base_name}.#{suffix}"
+        return candidate unless target_font.glyphs.key?(candidate)
+
+        suffix += 1
+      end
+    end
+
+    def clone_glyph(original, name:)
+      copy = Ufo::Glyph.new(name: name)
+      copy.width = original.width
+      copy.height = original.height
+      original.contours.each { |c| copy.add_contour(clone_contour(c)) }
+      original.components.each { |c| copy.add_component(c) }
+      original.anchors.each { |a| copy.add_anchor(a) }
+      original.guidelines.each { |g| copy.add_guideline(g) }
+      copy
+    end
+
+    def clone_contour(original)
+      points = original.points.map do |p|
+        Ufo::Point.new(x: p.x, y: p.y, type: p.type, smooth: p.smooth)
+      end
+      Ufo::Contour.new(points)
+    end
+
     def propagate_cbdt_tables(path)
       source = cbdt_source
       return unless source
@@ -152,7 +268,7 @@ module Fontisan
       tables["CBDT"] = cbdt_bytes if cbdt_bytes
       tables["CBLC"] = cblc_bytes if cblc_bytes
 
-      sfnt = tables.key?("CFF ") ? 0x4F54544F : 0x00010000
+      sfnt = tables.key?("CFF ") || tables.key?("CFF2") ? 0x4F54544F : 0x00010000
       Fontisan::FontWriter.write_to_file(tables, path, sfnt_version: sfnt)
     end
 
@@ -165,129 +281,18 @@ module Fontisan
       nil
     end
 
-    def compiler_for(format)
-      case format.to_sym
-      when :ttf then Ufo::Compile::TtfCompiler
-      when :otf then Ufo::Compile::OtfCompiler
-      when :otf2 then Ufo::Compile::Otf2Compiler
-      else
-        raise ArgumentError, "unknown format: #{format.inspect}"
-      end
-    end
-
-    # Walk bindings in codepoint order, assign sequential new gids,
-    # copy each glyph into the target font's default layer.
-    #
-    # When a CBDT source is present, its glyphs are added FIRST (in
-    # source GID order) so that the CBLC's GID references remain valid.
-    # Glyf-source bindings are processed AFTER, appending new glyphs.
-    #
-    # Signature-based deduplication: when a glyph's outline matches an
-    # already-added glyph, the new codepoint is redirected to the
-    # canonical glyph instead of adding a duplicate gid. CBDT-source
-    # glyphs bypass dedup (each needs its own gid for CBDT indexing).
-    def assign_gids_and_copy_glyphs
-      cbdt = cbdt_source
-
-      if cbdt
-        add_all_cbdt_glyphs(cbdt)
-      else
-        add_notdef_from_bindings
-      end
-
-      sorted_bindings.each do |binding|
-        next if binding[:donor_gid].zero?
-
-        # Skip bindings from the CBDT source — its glyphs are already added.
-        next if cbdt && binding[:source].equal?(cbdt)
-
-        glyph = binding[:source].glyph_for_gid(binding[:donor_gid])
-        next unless glyph
-
-        canonical = @deduplicator&.find(glyph)
-        if canonical && @target.glyphs.key?(canonical)
-          add_extra_unicode(canonical, binding[:codepoint])
-        else
-          name = unique_target_name(glyph.name)
-          copy_glyph_into(@target, name: name,
-                                   source: binding[:source],
-                                   donor_gid: binding[:donor_gid],
-                                   codepoint: binding[:codepoint])
-          @deduplicator&.register(glyph, name)
-        end
-      end
-    end
-
-    # Bindings sorted by codepoint (nil codepoints come last).
-    def sorted_bindings
-      @bindings.sort_by { |b| [b[:codepoint] || Float::INFINITY, b[:donor_gid]] }
-    end
-
-    def copy_glyph_into(target_font, name:, source:, donor_gid:, codepoint: nil)
-      original = source.glyph_for_gid(donor_gid)
-      return unless original
-
-      copy = clone_glyph(original, name: name)
-      copy.add_unicode(codepoint) if codepoint
-      target_font.layers.default_layer.add(copy)
-    end
-
-    def add_extra_unicode(glyph_name, codepoint)
-      return unless codepoint
-
-      glyph = @target.glyph(glyph_name)
-      glyph.add_unicode(codepoint) unless glyph.unicodes.include?(codepoint)
-    end
-
-    # Return a name not yet used in the target font. When two glyphs
-    # from different donors share a name but differ in outline, the
-    # second gets a suffix to avoid clobbering the first in the
-    # target's Hash-keyed layer.
-    def unique_target_name(base_name)
-      return base_name unless @target.glyphs.key?(base_name)
-
-      suffix = 1
-      loop do
-        candidate = "#{base_name}.#{suffix}"
-        return candidate unless @target.glyphs.key?(candidate)
-
-        suffix += 1
-      end
-    end
-
-    # Add .notdef at GID 0 from the first binding that references gid 0.
-    # Falls back to a synthesized empty .notdef if none found.
-    def add_notdef_from_bindings
-      notdef_binding = @bindings.find { |b| b[:donor_gid].zero? }
-      if notdef_binding
-        copy_glyph_into(@target, name: ".notdef",
-                                 source: notdef_binding[:source],
-                                 donor_gid: 0)
-      else
-        @target.layers.default_layer.add(Ufo::Glyph.new(name: ".notdef"))
-      end
-    end
-
-    # Add ALL glyphs from a CBDT source in source GID order. This
-    # ensures the CBLC's GID references remain valid in the output
-    # without rewriting the table. Each glyph gets a placeholder
-    # (no contours) since the bitmap data is in CBDT, not glyf.
-    def add_all_cbdt_glyphs(source)
+    def add_all_cbdt_glyphs(source, target)
       ufo = source.font.is_a?(Ufo::Font) ? source.font : nil
       if ufo
-        ufo.glyphs.each_value { |g| @target.layers.default_layer.add(clone_glyph(g, name: g.name)) }
+        ufo.glyphs.each_value { |g| target.layers.default_layer.add(clone_glyph(g, name: g.name)) }
         return
       end
 
-      # For loaded TTF/OTF sources, iterate via cmap to get glyph names.
-      # CBDT fonts (like NotoColorEmoji) may have thousands of glyphs;
-      # we add them all as placeholders.
       maxp = source.font.table("maxp")
       num_glyphs = maxp&.num_glyphs || 0
       cmap = source.font.table("cmap")
       mappings = cmap&.unicode_mappings || {}
 
-      # Build gid → [codepoints] from cmap
       gid_cps = Hash.new { |h, k| h[k] = [] }
       mappings.each { |cp, gid| gid_cps[gid] << cp }
 
@@ -296,28 +301,8 @@ module Fontisan
         glyph = Ufo::Glyph.new(name: name)
         glyph.width = 0
         gid_cps[gid].each { |cp| glyph.add_unicode(cp) }
-        @target.layers.default_layer.add(glyph)
+        target.layers.default_layer.add(glyph)
       end
-    end
-
-    # Deep-copy a glyph with a new name. Used so multiple target
-    # glyphs can share the same source outline without aliasing.
-    def clone_glyph(original, name:)
-      copy = Ufo::Glyph.new(name: name)
-      copy.width = original.width
-      copy.height = original.height
-      original.contours.each { |c| copy.add_contour(clone_contour(c)) }
-      original.components.each { |c| copy.add_component(c) }
-      original.anchors.each { |a| copy.add_anchor(a) }
-      original.guidelines.each { |g| copy.add_guideline(g) }
-      copy
-    end
-
-    def clone_contour(original)
-      points = original.points.map do |p|
-        Ufo::Point.new(x: p.x, y: p.y, type: p.type, smooth: p.smooth)
-      end
-      Ufo::Contour.new(points)
     end
   end
 end

--- a/lib/fontisan/ufo/compile.rb
+++ b/lib/fontisan/ufo/compile.rb
@@ -48,6 +48,8 @@ module Fontisan
       autoload :Cff,          "fontisan/ufo/compile/cff"
       autoload :Cff2,         "fontisan/ufo/compile/cff2"
       autoload :Otf2Compiler, "fontisan/ufo/compile/otf2_compiler"
+      autoload :Cpal,         "fontisan/ufo/compile/cpal"
+      autoload :Meta,         "fontisan/ufo/compile/meta"
       autoload :Avar,         "fontisan/ufo/compile/avar"
       autoload :Hvar,         "fontisan/ufo/compile/hvar"
       autoload :Mvar,         "fontisan/ufo/compile/mvar"

--- a/lib/fontisan/ufo/compile/cff2.rb
+++ b/lib/fontisan/ufo/compile/cff2.rb
@@ -27,30 +27,40 @@ module Fontisan
       module Cff2
         # CFF2 Top DICT operator encodings.
         CHARSTRINGS_OPERATOR = 17 # 0x11
+        VARIATION_STORE_OPERATOR = 24 # 0x18
         FONT_DICT_INDEX_OPERATOR = [12, 36].freeze # 0x0C24
         PRIVATE_OPERATOR = 18 # 0x12
 
         # @param font [Fontisan::Ufo::Font]
         # @param glyphs [Array<Fontisan::Ufo::Glyph>] in gid order
+        # @param variation_store [String, nil] ItemVariationStore bytes
+        #   for variable CFF2 fonts. When present, embedded between the
+        #   GlobalSubr INDEX and CharStrings INDEX, and referenced from
+        #   the Top DICT via operator 24.
         # @return [String] CFF2 table bytes
-        def self.build(_font, glyphs:)
+        def self.build(_font, glyphs:, variation_store: nil)
           charstrings = glyphs.map { |g| charstring_for(g) }
           global_subr_index = empty_global_subr_index
           font_dict = build_font_dict(private_size: 0, private_offset: 0)
           font_dict_index = Tables::Cff2::IndexBuilder.build([font_dict])
+          vs_bytes = variation_store&.b
 
           # Fixed-point iteration: encode Top DICT, compute offsets, repeat.
-          top_dict = encode_top_dict(charstrings_offset: 0, font_dict_index_offset: 0)
+          top_dict = encode_top_dict(
+            charstrings_offset: 0, font_dict_index_offset: 0,
+            variation_store_offset: vs_bytes ? 0 : nil
+          )
           layout = compute_layout(top_dict:, charstrings:, global_subr_index:,
-                                  font_dict_index:)
+                                  font_dict_index:, variation_store: vs_bytes)
 
           10.times do
             top_dict = encode_top_dict(
               charstrings_offset: layout[:charstrings_offset],
               font_dict_index_offset: layout[:font_dict_index_offset],
+              variation_store_offset: layout[:variation_store_offset],
             )
             next_layout = compute_layout(top_dict:, charstrings:, global_subr_index:,
-                                         font_dict_index:)
+                                         font_dict_index:, variation_store: vs_bytes)
             break if same_offsets?(layout, next_layout)
 
             layout = next_layout
@@ -77,13 +87,23 @@ module Fontisan
 
         # ---------- DICT encoding ----------
 
-        # Encode the Top DICT with offsets to CharStrings and Font DICT INDEX.
-        def self.encode_top_dict(charstrings_offset:, font_dict_index_offset:)
-          Tables::Cff2::DictEncoder.encode_entry(
+        # Encode the Top DICT with offsets to CharStrings, Font DICT INDEX,
+        # and optionally VariationStore.
+        def self.encode_top_dict(charstrings_offset:, font_dict_index_offset:,
+                                 variation_store_offset: nil)
+          io = +""
+          io << Tables::Cff2::DictEncoder.encode_entry(
             [charstrings_offset], CHARSTRINGS_OPERATOR
-          ) + Tables::Cff2::DictEncoder.encode_entry(
+          )
+          io << Tables::Cff2::DictEncoder.encode_entry(
             [font_dict_index_offset], FONT_DICT_INDEX_OPERATOR
           )
+          if variation_store_offset
+            io << Tables::Cff2::DictEncoder.encode_entry(
+              [variation_store_offset], VARIATION_STORE_OPERATOR
+            )
+          end
+          io
         end
 
         # Encode a Font DICT: just the Private operator [size, offset].
@@ -97,14 +117,23 @@ module Fontisan
 
         # Compute byte offsets for each section. The Top DICT's size
         # determines where the Global Subr INDEX starts, which cascades
-        # to all subsequent offsets.
+        # to all subsequent offsets. When a VariationStore is present,
+        # it sits between the GlobalSubr INDEX and the CharStrings INDEX.
         def self.compute_layout(top_dict:, charstrings:, global_subr_index:,
-                                font_dict_index:)
+                                font_dict_index:, variation_store: nil)
           charstrings_index = Tables::Cff2::IndexBuilder.build(charstrings)
 
           header_size = Tables::Cff2::Header::HEADER_SIZE
           global_subr_offset = header_size + top_dict.bytesize
-          charstrings_offset = global_subr_offset + global_subr_index.bytesize
+          post_global_subr = global_subr_offset + global_subr_index.bytesize
+
+          if variation_store
+            variation_store_offset = post_global_subr
+            charstrings_offset = variation_store_offset + variation_store.bytesize
+          else
+            variation_store_offset = nil
+            charstrings_offset = post_global_subr
+          end
           font_dict_index_offset = charstrings_offset + charstrings_index.bytesize
 
           {
@@ -112,6 +141,8 @@ module Fontisan
             charstrings_index: charstrings_index,
             global_subr_index: global_subr_index,
             font_dict_index: font_dict_index,
+            variation_store: variation_store,
+            variation_store_offset: variation_store_offset,
             charstrings_offset: charstrings_offset,
             font_dict_index_offset: font_dict_index_offset,
           }
@@ -119,7 +150,8 @@ module Fontisan
 
         def self.same_offsets?(a, b)
           a[:charstrings_offset] == b[:charstrings_offset] &&
-            a[:font_dict_index_offset] == b[:font_dict_index_offset]
+            a[:font_dict_index_offset] == b[:font_dict_index_offset] &&
+            a[:variation_store_offset] == b[:variation_store_offset]
         end
 
         def self.empty_global_subr_index
@@ -129,11 +161,14 @@ module Fontisan
         # ---------- assembly ----------
 
         def self.assemble(layout:)
-          Tables::Cff2::Header.build(top_dict_size: layout[:top_dict].bytesize) +
-            layout[:top_dict] +
-            layout[:global_subr_index] +
-            layout[:charstrings_index] +
-            layout[:font_dict_index]
+          io = +""
+          io << Tables::Cff2::Header.build(top_dict_size: layout[:top_dict].bytesize)
+          io << layout[:top_dict]
+          io << layout[:global_subr_index]
+          io << layout[:variation_store] if layout[:variation_store]
+          io << layout[:charstrings_index]
+          io << layout[:font_dict_index]
+          io
         end
 
         private_class_method :charstring_for, :empty_charstring,

--- a/lib/fontisan/ufo/compile/cpal.rb
+++ b/lib/fontisan/ufo/compile/cpal.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Builds the OpenType `CPAL` (Color Palette) table.
+      #
+      # CPAL stores one or more palettes of BGRA color records,
+      # referenced by COLR layers and other color-glyph mechanisms.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/cpal
+      module Cpal
+        VERSION = 0
+        HEADER_SIZE = 12
+        COLOR_RECORD_SIZE = 4 # BGRA
+
+        # Color value object: BGRA uint8 tuple.
+        Color = Struct.new(:blue, :green, :red, :alpha, keyword_init: true) do
+          def to_bytes
+            [blue || 0, green || 0, red || 0, alpha || 255].pack("C4")
+          end
+        end
+
+        # @param palettes [Array<Array<Color>>] one or more palettes,
+        #   each an array of Color values. All palettes must have the
+        #   same number of entries.
+        # @return [String, nil] CPAL table bytes, or nil if no palettes
+        def self.build(palettes:)
+          return nil if palettes.nil? || palettes.empty?
+
+          num_entries = palettes.first.size
+          num_palettes = palettes.size
+          num_records = num_entries * num_palettes
+
+          indices = Array.new(num_palettes) { |i| i * num_entries }
+          records = palettes.flatten
+
+          offset = HEADER_SIZE + (num_palettes * 2) # header + indices
+
+          io = +""
+          io << [VERSION, num_entries, num_palettes, num_records, offset].pack("nnnnN")
+          indices.each { |idx| io << [idx].pack("n") }
+          records.each { |c| io << color_bytes(c) }
+          io
+        end
+
+        def self.color_bytes(color)
+          return color.to_bytes if color.is_a?(Color)
+
+          b = color[:blue] || color["blue"] || 0
+          g = color[:green] || color["green"] || 0
+          r = color[:red] || color["red"] || 0
+          a = color[:alpha] || color["alpha"] || 255
+          [b, g, r, a].pack("C4")
+        end
+
+        private_class_method :color_bytes
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/meta.rb
+++ b/lib/fontisan/ufo/compile/meta.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Builds the OpenType `meta` table.
+      #
+      # The meta table stores font metadata as tagged data — longer-form
+      # strings than the `name` table supports. Common tags:
+      #   "dlng" — design languages (BCP-47 tags)
+      #   "slng" — supported languages
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/meta
+      module Meta
+        VERSION = 1
+        HEADER_SIZE = 16
+        DATA_MAP_SIZE = 12 # tag(4) + offset(4) + length(4)
+
+        # @param data [Hash<String,String>] tag → UTF-8 string value
+        # @return [String, nil] meta table bytes, or nil if no data
+        def self.build(data:)
+          return nil if data.nil? || data.empty?
+
+          count = data.size
+          data_offset = HEADER_SIZE + (count * DATA_MAP_SIZE)
+
+          header = [VERSION, 0, count, data_offset].pack("NNNN")
+
+          map_entries = +""
+          values = +""
+          offset = data_offset
+          data.each do |tag, value|
+            map_entries << tag.ljust(4, " ")[0, 4]
+            map_entries << [offset, value.bytesize].pack("NN")
+            offset += value.bytesize
+            values << value.b
+          end
+
+          header + map_entries + values
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/meta.rb
+++ b/lib/fontisan/ufo/compile/meta.rb
@@ -24,19 +24,26 @@ module Fontisan
           count = data.size
           data_offset = HEADER_SIZE + (count * DATA_MAP_SIZE)
 
-          header = [VERSION, 0, count, data_offset].pack("NNNN")
+          io = +""
+          io << [VERSION, 0, count, data_offset].pack("NNNN")
 
-          map_entries = +""
-          values = +""
+          # Two iterations over the same data: the meta table has two
+          # distinct output sections (data map entries then data values)
+          # that cannot be interleaved. The map-entry section records
+          # offsets that depend on the total size of the value section,
+          # so the value section must be produced last.
+          #
+          # rubocop:disable Style/CombinableLoops
           offset = data_offset
           data.each do |tag, value|
-            map_entries << tag.ljust(4, " ")[0, 4]
-            map_entries << [offset, value.bytesize].pack("NN")
+            io << tag.ljust(4, " ")[0, 4]
+            io << [offset, value.bytesize].pack("NN")
             offset += value.bytesize
-            values << value.b
           end
+          data.each_value { |value| io << value.b }
+          # rubocop:enable Style/CombinableLoops
 
-          header + map_entries + values
+          io
         end
       end
     end

--- a/spec/fontisan/stitcher/cmap_preservation_spec.rb
+++ b/spec/fontisan/stitcher/cmap_preservation_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe "Stitcher cmap preservation (regression)", :donors do
 
     stitcher = Fontisan::Stitcher.new
     stitcher.add_source(:lentariso, src)
-    stitcher.include_notdef(from: :lentariso)
-    stitcher.include_codepoints(plane1, from: :lentariso)
+    stitcher.include_notdef(from: :lentariso, into: :main)
+    stitcher.include_codepoints(plane1, from: :lentariso, into: :main)
 
     Dir.mktmpdir do |dir|
       out_path = File.join(dir, "out.ttf")
-      stitcher.write_to(out_path, format: :ttf)
+      stitcher.write_to(out_path, format: :ttf, subfont: :main)
 
       out = Fontisan::FontLoader.load(out_path)
       out_cmap = out.table("cmap").unicode_mappings
@@ -53,12 +53,12 @@ RSpec.describe "Stitcher cmap preservation (regression)", :donors do
 
     stitcher = Fontisan::Stitcher.new
     stitcher.add_source(:kedebideri, src)
-    stitcher.include_notdef(from: :kedebideri)
-    stitcher.include_codepoints(beria_erfe, from: :kedebideri)
+    stitcher.include_notdef(from: :kedebideri, into: :main)
+    stitcher.include_codepoints(beria_erfe, from: :kedebideri, into: :main)
 
     Dir.mktmpdir do |dir|
       out_path = File.join(dir, "out.ttf")
-      stitcher.write_to(out_path, format: :ttf)
+      stitcher.write_to(out_path, format: :ttf, subfont: :main)
 
       out = Fontisan::FontLoader.load(out_path)
       out_cmap = out.table("cmap").unicode_mappings
@@ -82,12 +82,12 @@ RSpec.describe "Stitcher cmap preservation (regression)", :donors do
 
     stitcher = Fontisan::Stitcher.new
     stitcher.add_source(:tangut, src)
-    stitcher.include_notdef(from: :tangut)
-    stitcher.include_codepoints(tangut, from: :tangut)
+    stitcher.include_notdef(from: :tangut, into: :main)
+    stitcher.include_codepoints(tangut, from: :tangut, into: :main)
 
     Dir.mktmpdir do |dir|
       out_path = File.join(dir, "out.ttf")
-      stitcher.write_to(out_path, format: :ttf)
+      stitcher.write_to(out_path, format: :ttf, subfont: :main)
 
       out = Fontisan::FontLoader.load(out_path)
       out_cmap = out.table("cmap").unicode_mappings
@@ -112,12 +112,12 @@ RSpec.describe "Stitcher cmap preservation (regression)", :donors do
 
     stitcher = Fontisan::Stitcher.new
     stitcher.add_source(:cuneiform, src)
-    stitcher.include_notdef(from: :cuneiform)
-    stitcher.include_codepoints([0x12399], from: :cuneiform)
+    stitcher.include_notdef(from: :cuneiform, into: :main)
+    stitcher.include_codepoints([0x12399], from: :cuneiform, into: :main)
 
     Dir.mktmpdir do |dir|
       out_path = File.join(dir, "out.ttf")
-      stitcher.write_to(out_path, format: :ttf)
+      stitcher.write_to(out_path, format: :ttf, subfont: :main)
 
       out = Fontisan::FontLoader.load(out_path)
       out_cmap = out.table("cmap").unicode_mappings

--- a/spec/fontisan/stitcher/collection_api_spec.rb
+++ b/spec/fontisan/stitcher/collection_api_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/stitcher"
+require "tmpdir"
+
+RSpec.describe "Stitcher explicit subfont declaration" do
+  let(:ufo) { Fontisan::Ufo }
+
+  def make_font_with(name, cp, points = [[0, 0, "line"], [100, 0, "line"], [100, 100, "line"]])
+    font = ufo::Font.new
+    font.info.units_per_em = 1000
+    font.glyphs[".notdef"] = ufo::Glyph.new(name: ".notdef")
+
+    g = ufo::Glyph.new(name: name)
+    g.width = 500
+    g.add_unicode(cp)
+    g.add_contour(ufo::Contour.new(points.map do |x, y, t|
+      ufo::Point.new(x: x, y: y, type: t)
+    end))
+    font.glyphs[name] = g
+    font
+  end
+
+  describe "subfont assignment" do
+    it "routes bindings to named subfonts via into:" do
+      donor = make_font_with("A", 0x41)
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:d, donor)
+      stitcher.include_notdef(from: :d, into: :main)
+      stitcher.include_codepoints([0x41], from: :d, into: :main)
+
+      expect(stitcher.subfonts.key?(:main)).to be(true)
+      expect(stitcher.subfonts[:main].size).to eq(2) # notdef + A
+      expect(stitcher.subfont_names).to eq([:main])
+    end
+
+    it "supports multiple named subfonts" do
+      latin = make_font_with("A", 0x41)
+      cjk = make_font_with("uni4E00", 0x4E00)
+
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:latin, latin)
+      stitcher.add_source(:cjk, cjk)
+      stitcher.include_notdef(from: :latin, into: :latin)
+      stitcher.include_codepoints([0x41], from: :latin, into: :latin)
+      stitcher.include_notdef(from: :cjk, into: :cjk)
+      stitcher.include_codepoints([0x4E00], from: :cjk, into: :cjk)
+
+      expect(stitcher.subfont_names.sort).to eq(%i[cjk latin])
+      expect(stitcher.subfonts[:latin].size).to eq(2)
+      expect(stitcher.subfonts[:cjk].size).to eq(2)
+    end
+  end
+
+  describe "single font output" do
+    it "writes one named subfont as a TTF" do
+      donor = make_font_with("A", 0x41)
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:d, donor)
+      stitcher.include_notdef(from: :d, into: :main)
+      stitcher.include_codepoints([0x41], from: :d, into: :main)
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out.ttf")
+        stitcher.write_to(path, format: :ttf, subfont: :main)
+        reopened = Fontisan::FontLoader.load(path)
+        expect(reopened.table("cmap").unicode_mappings.key?(0x41)).to be(true)
+      end
+    end
+
+    it "writes a specific named subfont from a multi-subfont stitcher" do
+      latin = make_font_with("A", 0x41)
+      cjk = make_font_with("uni4E00", 0x4E00)
+
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:latin, latin)
+      stitcher.add_source(:cjk, cjk)
+      stitcher.include_notdef(from: :latin, into: :latin)
+      stitcher.include_codepoints([0x41], from: :latin, into: :latin)
+      stitcher.include_notdef(from: :cjk, into: :cjk)
+      stitcher.include_codepoints([0x4E00], from: :cjk, into: :cjk)
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "cjk.ttf")
+        stitcher.write_to(path, format: :ttf, subfont: :cjk)
+        reopened = Fontisan::FontLoader.load(path)
+        expect(reopened.table("cmap").unicode_mappings.key?(0x4E00)).to be(true)
+        expect(reopened.table("cmap").unicode_mappings.key?(0x41)).to be(false)
+      end
+    end
+  end
+
+  describe "collection output" do
+    it "writes a TTC with all declared subfonts" do
+      latin = make_font_with("A", 0x41)
+      cjk = make_font_with("uni4E00", 0x4E00)
+
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:latin, latin)
+      stitcher.add_source(:cjk, cjk)
+      stitcher.include_notdef(from: :latin, into: :latin)
+      stitcher.include_codepoints([0x41], from: :latin, into: :latin)
+      stitcher.include_notdef(from: :cjk, into: :cjk)
+      stitcher.include_codepoints([0x4E00], from: :cjk, into: :cjk)
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out.ttc")
+        stitcher.write_collection(path, format: :ttf)
+
+        expect(File.exist?(path)).to be(true)
+        expect(File.binread(path, 4)).to eq("ttcf")
+
+        collection = Fontisan::FontLoader.load_collection(path)
+        expect(collection.num_fonts).to eq(2)
+
+        all_cps = []
+        collection.num_fonts.times do |i|
+          font = Fontisan::FontLoader.load(path, font_index: i)
+          all_cps.concat(font.table("cmap").unicode_mappings.keys)
+        end
+        expect(all_cps).to include(0x41, 0x4E00)
+      end
+    end
+
+    it "writes an OTC with CFF2 subfonts" do
+      latin = make_font_with("A", 0x41)
+      cjk = make_font_with("uni4E00", 0x4E00)
+
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:latin, latin)
+      stitcher.add_source(:cjk, cjk)
+      stitcher.include_notdef(from: :latin, into: :latin)
+      stitcher.include_codepoints([0x41], from: :latin, into: :latin)
+      stitcher.include_notdef(from: :cjk, into: :cjk)
+      stitcher.include_codepoints([0x4E00], from: :cjk, into: :cjk)
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out.otc")
+        stitcher.write_collection(path, format: :otf2)
+
+        expect(File.exist?(path)).to be(true)
+        expect(File.binread(path, 4)).to eq("ttcf")
+
+        collection = Fontisan::FontLoader.load_collection(path)
+        collection.num_fonts.times do |i|
+          font = Fontisan::FontLoader.load(path, font_index: i)
+          expect(font.has_table?("CFF2")).to be(true)
+        end
+      end
+    end
+
+    it "raises when no subfonts are declared" do
+      stitcher = Fontisan::Stitcher.new
+      expect { stitcher.write_collection("/tmp/empty.ttc", format: :ttf) }
+        .to raise_error(ArgumentError, /no subfonts declared/)
+    end
+  end
+end

--- a/spec/fontisan/stitcher/dedup_integration_spec.rb
+++ b/spec/fontisan/stitcher/dedup_integration_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe "Stitcher dedup + gid-cap integration" do
       stitcher = Fontisan::Stitcher.new
       stitcher.add_source(:a, donor_a)
       stitcher.add_source(:b, donor_b)
-      stitcher.include_notdef(from: :a)
-      stitcher.include_codepoints([0x20], from: :a)
-      stitcher.include_codepoints([0xA0], from: :b)
+      stitcher.include_notdef(from: :a, into: :main)
+      stitcher.include_codepoints([0x20], from: :a, into: :main)
+      stitcher.include_codepoints([0xA0], from: :b, into: :main)
 
-      target = stitcher.build_target_font
+      target = stitcher.build_target_font(subfont: :main)
       # .notdef + one merged glyph = 2 glyphs total
       expect(target.glyphs.size).to eq(2)
       # Both codepoints map to the same glyph
@@ -61,10 +61,10 @@ RSpec.describe "Stitcher dedup + gid-cap integration" do
 
       stitcher = Fontisan::Stitcher.new
       stitcher.add_source(:d, donor)
-      stitcher.include_notdef(from: :d)
-      stitcher.include_codepoints([0x41, 0x42], from: :d)
+      stitcher.include_notdef(from: :d, into: :main)
+      stitcher.include_codepoints([0x41, 0x42], from: :d, into: :main)
 
-      target = stitcher.build_target_font
+      target = stitcher.build_target_font(subfont: :main)
       # .notdef + A + B = 3 glyphs
       expect(target.glyphs.size).to eq(3)
     end
@@ -76,11 +76,11 @@ RSpec.describe "Stitcher dedup + gid-cap integration" do
       stitcher = Fontisan::Stitcher.new(deduplicate: false)
       stitcher.add_source(:a, donor_a)
       stitcher.add_source(:b, donor_b)
-      stitcher.include_notdef(from: :a)
-      stitcher.include_codepoints([0x20], from: :a)
-      stitcher.include_codepoints([0xA0], from: :b)
+      stitcher.include_notdef(from: :a, into: :main)
+      stitcher.include_codepoints([0x20], from: :a, into: :main)
+      stitcher.include_codepoints([0xA0], from: :b, into: :main)
 
-      target = stitcher.build_target_font
+      target = stitcher.build_target_font(subfont: :main)
       # .notdef + space + SP = 3 glyphs (no dedup)
       expect(target.glyphs.size).to eq(3)
     end
@@ -93,11 +93,11 @@ RSpec.describe "Stitcher dedup + gid-cap integration" do
       stitcher = Fontisan::Stitcher.new
       stitcher.add_source(:a, donor_a)
       stitcher.add_source(:b, donor_b)
-      stitcher.include_notdef(from: :a)
-      stitcher.include_codepoints([0x20], from: :a)
-      stitcher.include_codepoints([0xA0], from: :b)
+      stitcher.include_notdef(from: :a, into: :main)
+      stitcher.include_codepoints([0x20], from: :a, into: :main)
+      stitcher.include_codepoints([0xA0], from: :b, into: :main)
 
-      target = stitcher.build_target_font
+      target = stitcher.build_target_font(subfont: :main)
       expect(target.glyphs.size).to eq(2) # .notdef + space
       space = target.glyphs["space"]
       expect(space.unicodes).to include(0x20, 0xA0)
@@ -119,14 +119,14 @@ RSpec.describe "Stitcher dedup + gid-cap integration" do
       # Disable dedup so all 4 glyphs (.notdef + A + B + C) are counted
       stitcher = Fontisan::Stitcher.new(deduplicate: false)
       stitcher.add_source(:d, donor)
-      stitcher.include_notdef(from: :d)
-      stitcher.include_codepoints([0x41, 0x42, 0x43], from: :d)
+      stitcher.include_notdef(from: :d, into: :main)
+      stitcher.include_codepoints([0x41, 0x42, 0x43], from: :d, into: :main)
 
       # Stub the cap to 3 glyphs (we have .notdef + 3 = 4 glyphs)
       stub_const("Fontisan::Stitcher::GlyphLimit::TTF_GLYPH_CAP", 3)
 
       Dir.mktmpdir do |dir|
-        expect { stitcher.write_to(File.join(dir, "out.ttf"), format: :ttf) }
+        expect { stitcher.write_to(File.join(dir, "out.ttf"), format: :ttf, subfont: :main) }
           .to raise_error(Fontisan::GlyphLimitExceededError, /exceeding the TTF limit/)
       end
     end
@@ -145,15 +145,15 @@ RSpec.describe "Stitcher dedup + gid-cap integration" do
       # Disable dedup so all 4 glyphs (.notdef + A + B + C) are counted
       stitcher = Fontisan::Stitcher.new(deduplicate: false)
       stitcher.add_source(:d, donor)
-      stitcher.include_notdef(from: :d)
-      stitcher.include_codepoints([0x41, 0x42, 0x43], from: :d)
+      stitcher.include_notdef(from: :d, into: :main)
+      stitcher.include_codepoints([0x41, 0x42, 0x43], from: :d, into: :main)
 
       # Both TTF and OTF cap at 65,535 in fontisan (CFF1's INDEX count
       # is card16). Stub the cap to 3 to trigger the error.
       stub_const("Fontisan::Stitcher::GlyphLimit::OTF_GLYPH_CAP", 3)
 
       Dir.mktmpdir do |dir|
-        expect { stitcher.write_to(File.join(dir, "out.otf"), format: :otf) }
+        expect { stitcher.write_to(File.join(dir, "out.otf"), format: :otf, subfont: :main) }
           .to raise_error(Fontisan::GlyphLimitExceededError, /exceeding the OTF limit/)
       end
     end
@@ -162,11 +162,11 @@ RSpec.describe "Stitcher dedup + gid-cap integration" do
       donor = make_font_with_glyph("A", 0x41)
       stitcher = Fontisan::Stitcher.new
       stitcher.add_source(:d, donor)
-      stitcher.include_notdef(from: :d)
-      stitcher.include_codepoints([0x41], from: :d)
+      stitcher.include_notdef(from: :d, into: :main)
+      stitcher.include_codepoints([0x41], from: :d, into: :main)
 
       Dir.mktmpdir do |dir|
-        expect { stitcher.write_to(File.join(dir, "out.otf"), format: :otf) }
+        expect { stitcher.write_to(File.join(dir, "out.otf"), format: :otf, subfont: :main) }
           .not_to raise_error
       end
     end

--- a/spec/fontisan/stitcher_spec.rb
+++ b/spec/fontisan/stitcher_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe Fontisan::Stitcher do
       source = Fontisan::Ufo::Font.open(ufo_path)
       stitcher = described_class.new
       stitcher.add_source(:src, source)
-      stitcher.include_notdef(from: :src)
+      stitcher.include_notdef(from: :src, into: :main)
 
       # last-resort-font doesn't have ASCII glyphs per se (it has
       # block-representative glyphs). Stitch whatever the first
       # few glyphs are to prove the pipeline.
-      stitcher.include_gid(1, from: :src)
-      stitcher.include_gid(2, from: :src)
+      stitcher.include_gid(1, from: :src, into: :main)
+      stitcher.include_gid(2, from: :src, into: :main)
 
       out = File.join(tmpdir, "stitched.ttf")
-      stitcher.write_to(out, format: :ttf)
+      stitcher.write_to(out, format: :ttf, subfont: :main)
       expect(File.exist?(out)).to be(true)
       expect(File.size(out)).to be > 0
 
@@ -50,7 +50,7 @@ RSpec.describe Fontisan::Stitcher do
   describe "#add_source" do
     it "rejects lookups for unregistered sources" do
       stitcher = described_class.new
-      expect { stitcher.include_range(0x41..0x42, from: :ghost) }
+      expect { stitcher.include_range(0x41..0x42, from: :ghost, into: :main) }
         .to raise_error(ArgumentError, /unknown source/)
     end
   end

--- a/spec/fontisan/svg_to_glyf/integration_spec.rb
+++ b/spec/fontisan/svg_to_glyf/integration_spec.rb
@@ -177,12 +177,12 @@ RSpec.describe "SvgToGlyf integration" do
 
       stitcher = Fontisan::Stitcher.new
       stitcher.add_source(:chart, chart_font)
-      stitcher.include_notdef(from: :chart)
-      stitcher.include_codepoints([0x42], from: :chart)
+      stitcher.include_notdef(from: :chart, into: :main)
+      stitcher.include_codepoints([0x42], from: :chart, into: :main)
 
       Dir.mktmpdir do |dir|
         output_path = File.join(dir, "stitched.ttf")
-        stitcher.write_to(output_path, format: :ttf)
+        stitcher.write_to(output_path, format: :ttf, subfont: :main)
 
         reopened = Fontisan::FontLoader.load(output_path)
         expect(reopened.table("cmap").unicode_mappings.key?(0x42)).to be(true)

--- a/spec/fontisan/ufo/compile/cff2_spec.rb
+++ b/spec/fontisan/ufo/compile/cff2_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe "CFF2 table builder and Otf2Compiler" do
       bytes = described_class.build(font, glyphs: font.glyphs.values)
       expect(bytes.bytesize).to be > 20
     end
+
+    it "embeds a VariationStore when provided" do
+      vs_bytes = "\x00\x01".b + "\x00" * 20
+      bytes = described_class.build(font, glyphs: font.glyphs.values,
+                                          variation_store: vs_bytes)
+      expect(bytes).to include(vs_bytes)
+      plain = described_class.build(font, glyphs: font.glyphs.values)
+      expect(bytes.bytesize).to be > plain.bytesize
+    end
   end
 
   describe "Otf2Compiler end-to-end" do
@@ -63,12 +72,12 @@ RSpec.describe "CFF2 table builder and Otf2Compiler" do
     it "supports Stitcher write_to with format: :otf2" do
       stitcher = Fontisan::Stitcher.new
       stitcher.add_source(:src, font)
-      stitcher.include_notdef(from: :src)
-      stitcher.include_codepoints([0x41], from: :src)
+      stitcher.include_notdef(from: :src, into: :main)
+      stitcher.include_codepoints([0x41], from: :src, into: :main)
 
       Dir.mktmpdir do |dir|
         path = File.join(dir, "stitched.otf")
-        stitcher.write_to(path, format: :otf2)
+        stitcher.write_to(path, format: :otf2, subfont: :main)
 
         reopened = Fontisan::FontLoader.load(path)
         expect(reopened.has_table?("CFF2")).to be(true)

--- a/spec/fontisan/ufo/compile/cpal_spec.rb
+++ b/spec/fontisan/ufo/compile/cpal_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+
+RSpec.describe Fontisan::Ufo::Compile::Cpal do
+  describe ".build" do
+    it "returns nil for nil palettes" do
+      expect(described_class.build(palettes: nil)).to be_nil
+    end
+
+    it "returns nil for empty palettes" do
+      expect(described_class.build(palettes: [])).to be_nil
+    end
+
+    it "produces a valid CPAL v0 header" do
+      palettes = [[
+        described_class::Color.new(blue: 0, green: 0, red: 255, alpha: 255),
+      ]]
+      bytes = described_class.build(palettes: palettes)
+      version, num_entries, num_palettes, num_records, offset = bytes.unpack("nnnnN")
+      expect(version).to eq(0)
+      expect(num_entries).to eq(1)
+      expect(num_palettes).to eq(1)
+      expect(num_records).to eq(1)
+      expect(offset).to eq(12 + 2) # header + 1 palette index
+    end
+
+    it "encodes color records as BGRA" do
+      palettes = [[
+        described_class::Color.new(blue: 10, green: 20, red: 30, alpha: 40),
+      ]]
+      bytes = described_class.build(palettes: palettes)
+      record_offset = 12 + 2 # header + 1 index
+      bgra = bytes[record_offset, 4].unpack("C4")
+      expect(bgra).to eq([10, 20, 30, 40])
+    end
+
+    it "handles multiple palettes with multiple entries each" do
+      red = described_class::Color.new(red: 255, alpha: 255)
+      green = described_class::Color.new(green: 255, alpha: 255)
+      palettes = [[red, green], [green, red]]
+      bytes = described_class.build(palettes: palettes)
+      _, num_entries, num_palettes, num_records, offset = bytes.unpack("nnnnN")
+      expect(num_entries).to eq(2)
+      expect(num_palettes).to eq(2)
+      expect(num_records).to eq(4)
+      expect(offset).to eq(12 + 4) # header + 2 palette indices
+    end
+
+    it "accepts hash colors as an alternative to Color structs" do
+      palettes = [[{ blue: 0, green: 128, red: 255, alpha: 255 }]]
+      bytes = described_class.build(palettes: palettes)
+      record_offset = 14
+      bgra = bytes[record_offset, 4].unpack("C4")
+      expect(bgra).to eq([0, 128, 255, 255])
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/meta_spec.rb
+++ b/spec/fontisan/ufo/compile/meta_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile"
+
+RSpec.describe Fontisan::Ufo::Compile::Meta do
+  describe ".build" do
+    it "returns nil for nil data" do
+      expect(described_class.build(data: nil)).to be_nil
+    end
+
+    it "returns nil for empty data" do
+      expect(described_class.build(data: {})).to be_nil
+    end
+
+    it "produces a valid meta v1 header" do
+      bytes = described_class.build(data: { "dlng" => "en" })
+      version, _flags, data_maps_count, _data_offset = bytes.unpack("NNNN")
+      expect(version).to eq(1)
+      expect(data_maps_count).to eq(1)
+    end
+
+    it "encodes tag, offset, and length in each data map" do
+      bytes = described_class.build(data: { "dlng" => "en-Latn" })
+      # header(16) + 1 data map(12)
+      tag, offset, length = bytes[16, 12].unpack("a4NN")
+      expect(tag).to eq("dlng")
+      expect(offset).to eq(28) # 16 + 12
+      expect(length).to eq(7)  # "en-Latn"
+    end
+
+    it "appends data values after the data maps" do
+      bytes = described_class.build(data: { "dlng" => "en-Latn", "slng" => "en" })
+      # Header(16) + 2 data maps(24) = 40 bytes before data
+      dlng_data = bytes[40, 7]
+      slng_data = bytes[47, 2]
+      expect(dlng_data).to eq("en-Latn")
+      expect(slng_data).to eq("en")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Three deliverables in one PR:

### 1. Stitcher: explicit subfont declaration (no backward compat)

Every `include_*` method requires `into:` — the target subfont name. `write_to` requires `subfont:`. No defaults, no `:default` subfont, no `bindings` alias. The API is clean and explicit:

```ruby
stitcher.include_range(0x41..0x5A, from: :noto_sans, into: :latin)
stitcher.write_to("latin.ttf", format: :ttf, subfont: :latin)
stitcher.write_collection("out.otc", format: :otf2)
```

### 2. CPAL (Color Palette) builder

`Ufo::Compile::Cpal.build(palettes:)` produces CPAL v0 with multiple palettes of BGRA color records. Needed for color fonts (emoji, icons).

### 3. Meta (Metadata) table builder

`Ufo::Compile::Meta.build(data:)` produces meta v1 with tagged data entries (dlng, slng, etc.).

## Test plan

- [x] 48 stitcher specs pass (updated for required `into:`/`subfont:`)
- [x] 5 CPAL specs (header layout, BGRA encoding, multiple palettes, hash colors)
- [x] 6 Meta specs (header format, data map offsets, data value placement)
- [x] All existing specs updated for the clean API
- [x] Rubocop clean
