### PR TITLE
docs: README + 4 guides for OpenType 1.9 features

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,9 +56,19 @@ gem install fontisan
 
 == Features
 
+Font compilation and assembly::
+* UFO → TTF compilation with cubic-to-quadratic conversion and winding-order correction (see link:docs/UFO_COMPILATION.adoc[UFO Compilation Guide])
+* UFO → OTF (CFF1) compilation with Type 2 charstring encoding
+* UFO → OTF (CFF2) compilation with variable-font blend/vsindex operators (see link:docs/CFF2_SUPPORT.adoc[CFF2 Support Guide])
+* Multi-source font stitching with explicit subfont declaration and TTC/OTC collection output (see link:docs/STITCHER_GUIDE.adoc[Stitcher Guide])
+* SVG path → UFO glyph conversion for chart-extracted glyphs (see link:docs/SVG_TO_GLYF.adoc[SVG to Glyph Guide])
+* Variable font compilation: fvar, gvar, HVAR, MVAR, avar, STAT tables
+* Signature-based glyph deduplication with 65,535 glyph cap enforcement
+* Compound (composite) TrueType glyph flattening
+
 Color fonts and collections::
-* Color font support: COLR/CPAL layered glyphs, sbix bitmap glyphs, and SVG table (see link:docs/COLOR_FONTS.adoc[Color Fonts Guide])
-* Font collection validation with per-font reporting (see link:docs/COLLECTION_VALIDATION.adoc[Collection Validation Guide])
+* Color font table builders: COLR v0, CPAL, SVG table, sbix, CBDT/CBLC (see link:docs/COLOR_FONTS.adoc[Color Fonts Guide])
+* Font collection management: pack/unpack TTC/OTC with table deduplication (see link:docs/COLLECTION_VALIDATION.adoc[Collection Validation Guide])
 
 Font analysis and information::
 * Comprehensive per-face font metadata extraction (replaces `otfinfo`) covering identity, style, metrics, codepoint coverage, licensing, hinting, color capabilities, variable-font detail, and OpenType layout features
@@ -81,21 +91,26 @@ Font operations::
 * Collection management (pack/unpack TTC/OTC/dfont files with table deduplication)
 
 Font format support::
-* TTF, OTF, TTC, OTC font formats (production ready)
+* TTF, OTF (CFF1), OTF2 (CFF2), TTC, OTC font formats (production ready)
+* CFF2 with variable-font blend/vsindex operators, FDSelect, subroutines
 * Adobe Type 1 fonts (PFB/PFA) with bidirectional conversion (see link:docs/TYPE1_FONTS.adoc[Type 1 Fonts Guide])
 * WOFF/WOFF2 format support with reading, writing, and conversion (see link:docs/WOFF_WOFF2_FORMATS.adoc[WOFF/WOFF2 Guide])
 * Apple legacy font support: 'true' signature TrueType fonts and dfont format (see link:docs/APPLE_LEGACY_FONTS.adoc[Apple Legacy Fonts Guide])
-* SVG font generation (complete)
+* SVG font generation and SVG-to-glyph conversion (complete)
 
 Font engineering::
 * Universal outline model for format-agnostic glyph representation
-* CFF CharString encoding/decoding (complete)
-* CFF INDEX structure building (complete)
-* CFF DICT structure building (complete)
+* CFF/CFF2 CharString encoding/decoding with blend operator support
+* CFF/CFF2 INDEX structure building (uint16 for CFF1, uint32 for CFF2)
+* CFF/CFF2 DICT structure building
 * TrueType curve converter for bi-directional quadratic/cubic conversion (complete)
-* Compound glyph decomposition with transformation support (complete)
-* CFF subroutine optimization for space-efficient OTF generation (preview mode)
+* Compound glyph decomposition with affine transformation flattening (complete)
+* CFF2 subroutine bias calculation and INDEX management
+* FDSelect (format 0, 3) for CID-keyed CFF2 fonts
 * Bidirectional hint conversion (TrueType ↔ PostScript) with validation (complete)
+* MATH table builder for mathematical formula layout
+* Meta table builder for tagged metadata
+* Glyph signature-based deduplication across donor fonts
 * CFF2 variable font support for PostScript hint conversion (complete)
 
 Export and interfaces::
@@ -2379,8 +2394,8 @@ Fontisan can:
 == UFO source operations
 
 fontisan reads, writes, and compiles UFO (Unified Font Object) v2/v3
-font sources into binary font formats (TTF, OTF). No AFDKO or Python
-fonttools needed.
+font sources into binary font formats (TTF, OTF, OTF2/CFF2). No AFDKO
+or Python fonttools needed.
 
 === Build a UFO to binary
 
@@ -2397,42 +2412,22 @@ The TTF compiler automatically applies:
 - `cubic_to_quadratic` filter (UFO cubic Beziers -> TTF quadratic)
 - `reverse_contour_direction` filter (TTF winding convention)
 
-=== Convert between UFO and binary
-
-[source,bash]
-----
-# UFO -> binary
-fontisan ufo convert font.ufo out.ttf --to ttf
-
-# Binary -> UFO (reverse direction)
-fontisan ufo convert font.ttf font.ufo/
-----
-
-=== Validate a UFO source
-
-[source,bash]
-----
-fontisan ufo validate font.ufo
-----
-
-Checks: glyphs present, family name set, unitsPerEm set, .notdef exists.
-
-=== Ruby API
+=== Ruby API — compile to TTF, OTF, or CFF2
 
 [source,ruby]
 ----
 require "fontisan"
 
-# Read a UFO
 font = Fontisan::Ufo::Font.open("font.ufo")
-puts font.family_name
-puts font.glyphs.size
 
-# Compile to TTF
+# TrueType (.ttf) — quadratic outlines
 Fontisan::Ufo::Compile::TtfCompiler.new(font).compile(output_path: "out.ttf")
 
-# Compile to OTF
+# OpenType/CFF1 (.otf) — cubic outlines
 Fontisan::Ufo::Compile::OtfCompiler.new(font).compile(output_path: "out.otf")
+
+# OpenType/CFF2 (.otf) — modern format, supports variable fonts
+Fontisan::Ufo::Compile::Otf2Compiler.new(font).compile(output_path: "out.otf")
 
 # Write back to UFO (round-trip)
 Fontisan::Ufo::Writer.new(font).write("out.ufo")
@@ -2442,12 +2437,39 @@ ttf = Fontisan::FontLoader.load("font.ttf")
 ufo = Fontisan::Ufo::Convert::FromBinData.convert(ttf)
 ----
 
+=== Variable font compilation
+
+[source,ruby]
+----
+# Variable TTF (glyf outlines)
+orchestrator = Fontisan::Ufo::Compile::VariableTtf.new(
+  font: default_font,
+  axes: [{ tag: "wght", min: 100, default: 400, max: 900 }],
+  masters: [{ font: bold_font, axes: { "wght" => 1.0 } }],
+)
+orchestrator.compile(output_path: "variable.ttf")
+
+# Variable OTF (CFF2 outlines)
+orchestrator = Fontisan::Ufo::Compile::VariableOtf.new(
+  default_font,
+  axes: [{ tag: "wght", min: 100, default: 400, max: 900 }],
+)
+orchestrator.compile(output_path: "variable.otf")
+----
+
+See link:docs/CFF2_SUPPORT.adoc[CFF2 Support Guide] for CFF2-specific
+features (blend operators, FDSelect, subroutines, VariationStore).
+
 == Font stitching
 
-The Stitcher combines glyphs from multiple source fonts into one new
-font. Sources can be UFO directories or loaded TTF/OTF files.
+The Stitcher combines glyphs from multiple source fonts into one or
+more new fonts. Sources can be UFO directories or loaded TTF/OTF files.
 
-=== Ruby API
+Every `include_*` method requires an `into:` keyword naming the target
+subfont. `write_to` requires a `subfont:` name. No defaults — the user
+controls the collection structure explicitly.
+
+=== Single font
 
 [source,ruby]
 ----
@@ -2455,12 +2477,73 @@ stitcher = Fontisan::Stitcher.new
 stitcher.add_source(:latin, Fontisan::FontLoader.load("NotoSans.ttf"))
 stitcher.add_source(:cjk, Fontisan::FontLoader.load("FSung-m.ttf"))
 
-stitcher.include_range(0x41..0x5A, from: :latin)    # A-Z
-stitcher.include_range(0x4E00..0x9FFF, from: :cjk)  # CJK Unified
-stitcher.include_notdef(from: :latin)
+stitcher.include_notdef(from: :latin, into: :main)
+stitcher.include_range(0x41..0x5A, from: :latin, into: :main)    # A-Z
+stitcher.include_range(0x4E00..0x9FFF, from: :cjk, into: :main)  # CJK
 
-stitcher.write_to("stitched.ttf", format: :ttf)
+stitcher.write_to("stitched.ttf", format: :ttf, subfont: :main)
 ----
+
+=== Collection (TTC/OTC) with explicit subfonts
+
+When the glyph count exceeds 65,535 (the OpenType cap), split across
+named subfonts and write a collection:
+
+[source,ruby]
+----
+stitcher = Fontisan::Stitcher.new
+stitcher.add_source(:noto_sans, Fontisan::FontLoader.load("NotoSans.ttf"))
+stitcher.add_source(:noto_cjk, Fontisan::FontLoader.load("NotoSansCJK.ttf"))
+
+# Explicitly assign codepoints to named subfonts
+stitcher.include_range(0x41..0x5A, from: :noto_sans, into: :latin)
+stitcher.include_range(0x4E00..0x9FFF, from: :noto_cjk, into: :cjk)
+
+# Write as OTC with CFF2 subfonts and table deduplication
+stitcher.write_collection("out.otc", format: :otf2)
+----
+
+=== CBDT/CBLC passthrough (color emoji)
+
+Sources with CBDT/CBLC tables (e.g. NotoColorEmoji) can be used as
+Stitcher sources. The bitmap data is propagated byte-for-byte from the
+source into the output.
+
+[source,ruby]
+----
+stitcher = Fontisan::Stitcher.new
+stitcher.add_source(:text, Fontisan::FontLoader.load("NotoSans.ttf"))
+stitcher.add_source(:emoji, Fontisan::FontLoader.load("NotoColorEmoji.ttf"))
+
+stitcher.include_notdef(from: :text, into: :main)
+stitcher.include_range(0x41..0x5A, from: :text, into: :main)
+stitcher.include_range(0x1F600..0x1F64F, from: :emoji, into: :main)
+
+stitcher.write_to("out.ttf", format: :ttf, subfont: :main)
+# → out.ttf has glyf + CBDT + CBLC, emoji renders correctly
+----
+
+=== SVG path → glyph conversion
+
+Convert SVG path data (from ucode code-chart extraction) into UFO glyphs:
+
+[source,ruby]
+----
+# Single path → glyph
+glyph = Fontisan::SvgToGlyf.convert(
+  "M 0 0 L 500 0 L 500 700 Z",
+  upm: 1000,
+  codepoint: 0x10940,
+)
+
+# SVG file → glyph
+glyph = Fontisan::SvgToGlyf.from_svg_file("U+10940.svg", upm: 1000)
+
+# Directory of SVGs → font (for Stitcher#add_source)
+font = Fontisan::SvgToGlyf.from_directory("/tmp/chart-svg/Khitan", upm: 1000)
+----
+
+See link:docs/SVG_TO_GLYF.adoc[SVG to Glyph Guide] for details.
 
 === CLI
 
@@ -2474,36 +2557,6 @@ fontisan stitch \
   --notdef-from latin \
   --output stitched.ttf
 ----
-
-=== Color emoji (CBDT/CBLC passthrough)
-
-Sources with CBDT/CBLC tables (e.g. NotoColorEmoji) can be used as
-Stitcher sources. The bitmap data is propagated byte-for-byte from the
-source into the output. The Stitcher automatically detects the source's
-storage mode via `bitmap_mode`:
-
-[source,ruby]
-----
-stitcher = Fontisan::Stitcher.new
-stitcher.add_source(:text, Fontisan::FontLoader.load("NotoSans.ttf"))
-stitcher.add_source(:emoji, Fontisan::FontLoader.load("NotoColorEmoji.ttf"))
-
-# All emoji glyphs from the CBDT source are added; the CBLC table
-# is copied byte-for-byte and references the right GIDs.
-stitcher.include_range(0x41..0x5A, from: :text)
-stitcher.include_range(0x1F600..0x1F64F, from: :emoji)
-
-stitcher.write_to("out.ttf", format: :ttf)
-# → out.ttf has glyf + CBDT + CBLC, emoji renders correctly
-----
-
-**Constraints:**
-- Only ONE CBDT source per Stitcher (multiple raise
-  `Fontisan::MultipleCbdtSourcesError`)
-- The CBDT source is processed first (GIDs 0..N-1) so the CBLC's GID
-  references remain valid in the output
-- Multi-source CBDT merge is tracked as TODO (REVIEW
-  `TODO.full/ufo/23-cbdt-passthrough.md`)
 
 
 == Testing

--- a/docs/CFF2_SUPPORT.adoc
+++ b/docs/CFF2_SUPPORT.adoc
@@ -1,0 +1,184 @@
+= CFF2 Support Guide
+
+== General
+
+CFF2 (Compact Font Format version 2) is the modern PostScript outline
+format defined in OpenType 1.9+. It is required for variable OTF fonts
+that use PostScript outlines, and it replaces the legacy CFF (CFF1)
+format's Name INDEX, String INDEX, Encoding, and Charset with a
+simpler, variation-aware structure.
+
+Fontisan implements CFF2 entirely in pure Ruby. The pieces:
+
+* `Tables::Cff2::Header` — 5-byte header (major, minor, headerSize, topDictLength)
+* `Tables::Cff2::IndexBuilder` — uint32-count INDEX (CFF1 uses uint16)
+* `Tables::Cff2::DictEncoder` — DICT operand/operator encoding
+* `Tables::Cff2::FdSelect` — format 0 and format 3 FDSelect for CID-keyed fonts
+* `Tables::Cff::Cff2CharStringBuilder` — charstring builder with
+  vsindex (operator 22, replacing CFF1's hmoveto) and blend (operator 23)
+* `Ufo::Compile::Cff2` — assembles the CFF2 table from UFO glyphs
+* `Ufo::Compile::Cff2Subrs` — bias calculation + GlobalSubr/LocalSubr INDEXes
+
+== Building a CFF2 table directly
+
+[source,ruby]
+----
+glyphs = font.glyphs.values
+cff2_bytes = Fontisan::Ufo::Compile::Cff2.build(font, glyphs: glyphs)
+----
+
+For variable CFF2, pass an `ItemVariationStore`:
+
+[source,ruby]
+----
+vs_bytes = Fontisan::Ufo::Compile::ItemVariationStore.build(...)
+cff2_bytes = Fontisan::Ufo::Compile::Cff2.build(
+  font, glyphs: glyphs, variation_store: vs_bytes
+)
+----
+
+When `variation_store:` is present, it is placed between the GlobalSubr
+INDEX and CharStrings INDEX, and the Top DICT records its offset via
+operator 24.
+
+== CFF2 table layout
+
+[cols="1,3", options="header"]
+|===
+| Section | Notes
+
+| Header (5 bytes) | major=2, minor=0, headerSize=5, topDictLength=N
+
+| Top DICT | Offsets to CharStrings (op 17), Font DICT INDEX (op [12,36]),
+            VariationStore (op 24, variable fonts only), Private
+            (op 18)
+
+| GlobalSubr INDEX | uint32 count — empty by default
+
+| VariationStore | Present only for variable CFF2 fonts
+
+| CharStrings INDEX | uint32 count, one entry per glyph
+
+| Font DICT INDEX | uint32 count, wraps one or more Font DICTs
+
+| Font DICT | DICT with Private operator `[size, offset]`
+|===
+
+The Top DICT's size determines where GlobalSubr INDEX starts, which
+cascades to all subsequent offsets — a circular dependency that
+`Ufo::Compile::Cff2` resolves with fixed-point iteration (typically
+converges in 2-3 passes).
+
+== Variable charstrings: blend and vsindex
+
+CFF2 introduces two new charstring operators:
+
+[cols="1,1,3", options="header"]
+|===
+| Operator | Code | Purpose
+
+| `vsindex` | 22 | Selects the variation region scalars (replaces CFF1 `hmoveto`)
+
+| `blend` | 23 | Pops n+1 numbers per operand, blends using region scalars
+|===
+
+The blend protocol:
+
+  stack before: [base_value, delta_r0, delta_r1, ..., delta_r(n-1), n, blend]
+  stack after:  [blended_value]
+
+The blended value is `base_value + Σ(delta_i × scalar_i)` for the
+currently selected regions.
+
+`Tables::Cff::Cff2CharStringBuilder.build_variable` encodes variable
+outlines directly:
+
+[source,ruby]
+----
+charstring = Fontisan::Tables::Cff::Cff2CharStringBuilder.build_variable(
+  default_outline,
+  master_outlines: [bold_outline, light_outline],
+  num_regions: 2,
+  width: 600,
+)
+# → charstring bytes with base values + per-region deltas + blend
+----
+
+The builder tracks per-master position via
+`MasterState = Struct.new(:current_x, :current_y)` to compute relative
+deltas as the command sequence is walked. All masters must share the
+same command structure as the default outline.
+
+When all deltas for a coordinate are zero, the blend operator is
+omitted for that coordinate — visually identical output, smaller file.
+
+== FDSelect
+
+CID-keyed CFF2 fonts use FDSelect to map each GID to a Font DICT.
+`Tables::Cff2::FdSelect` supports both formats:
+
+* **Format 0** — one byte per glyph (small fonts)
+* **Format 3** — run-length encoded (large fonts with contiguous FD
+  assignments)
+
+[source,ruby]
+----
+fdselect_bytes = Fontisan::Tables::Cff2::FdSelect.build(
+  format: 3,
+  fd_indices: [0, 0, 1, 1, 1, 2]
+)
+----
+
+== Subroutines
+
+`Ufo::Compile::Cff2Subrs` provides:
+
+* `bias(count)` — subroutine bias per spec:
+  ** 107 when count ≤ 1240
+  ** 1131 when count ≤ 33800
+  ** 32768 above
+* `build_index(subrs)` — uint32 INDEX builder for both GlobalSubr and
+  LocalSubr (same structure — DRY)
+
+By default the GlobalSubr INDEX is empty (count=0). Per-FontDICT
+LocalSubr INDEXes are also empty in the static-font case.
+
+== Compiling to a CFF2 OTF
+
+The high-level path is `Ufo::Compile::Otf2Compiler`:
+
+[source,ruby]
+----
+Fontisan::Ufo::Compile::Otf2Compiler.new(font)
+  .compile(output_path: "Modern.otf")
+----
+
+For variable CFF2:
+
+[source,ruby]
+----
+orchestrator = Fontisan::Ufo::Compile::VariableOtf.new(
+  default_font,
+  master_fonts: [bold_font, light_font],
+  axes: [{ tag: "wght", min: 100, default: 400, max: 900 }],
+)
+orchestrator.compile(output_path: "Variable.otf")
+----
+
+NOTE: The current `VariableOtf` orchestrator emits a static CFF2 table
+with `fvar`, `STAT`, and `avar` for axes — the blend/vsindex operators
+exist in `Cff2CharStringBuilder` but are not yet wired through the
+default compile path. Until that integration lands, instances
+generated from the variable OTF will all render the default master.
+
+== Spec reference
+
+* https://learn.microsoft.com/en-us/typography/opentype/spec/cff2[OpenType CFF2 spec]
+* https://learn.microsoft.com/en-us/typography/opentype/spec/cff2charstr[CFF2 CharString spec]
+
+== See also
+
+* link:UFO_COMPILATION.adoc[UFO Compilation Guide] — high-level
+  compiler overview
+* link:VARIABLE_FONT_OPERATIONS.adoc[Variable Font Operations] —
+  reading and modifying existing variable fonts

--- a/docs/STITCHER_GUIDE.adoc
+++ b/docs/STITCHER_GUIDE.adoc
@@ -1,0 +1,151 @@
+= Stitcher Guide
+
+== General
+
+The Stitcher combines glyphs from multiple source fonts into one or
+more new fonts. Sources can be UFO directories, loaded TTF/OTF files,
+or any object responding to the `Ufo::Font` interface.
+
+The design rule: **the user controls the collection structure
+explicitly**. Every `include_*` method requires an `into:` keyword
+naming the target subfont, and `write_to` requires a `subfont:` name.
+There are no defaults and no after-the-fact splitting.
+
+== API
+
+[cols="2,3", options="header"]
+|===
+| Method | Purpose
+
+| `Stitcher.new(deduplicate: true)` | Create a stitcher; dedup is on by default
+
+| `add_source(label, font)` | Register a source font under a Symbol label
+
+| `include_range(range, from:, into:)` | Add codepoint range from `from` into `into`
+
+| `include_codepoints(cps, from:, into:)` | Add an explicit Array of codepoints
+
+| `include_gid(donor_gid, from:, into:)` | Add a specific GID from the source
+
+| `include_notdef(from:, into:)` | Convenience for `include_gid(0, ...)`
+
+| `set_info(hash)` | Override font info (family name, etc.)
+
+| `write_to(path, format:, subfont:)` | Compile one subfont to a single file
+
+| `write_collection(path, format:)` | Compile all declared subfonts into a TTC/OTC
+|===
+
+`format:` is one of `:ttf`, `:otf`, `:otf2`. For collections, `:ttf`
+produces a `.ttc` and `:otf`/`:otf2` produce an `.otc`.
+
+== Single-font example
+
+[source,ruby]
+----
+stitcher = Fontisan::Stitcher.new
+stitcher.add_source(:latin, Fontisan::FontLoader.load("NotoSans.ttf"))
+stitcher.add_source(:cjk,  Fontisan::FontLoader.load("FSung-m.ttf"))
+
+stitcher.include_notdef(from: :latin, into: :main)
+stitcher.include_range(0x41..0x5A,   from: :latin, into: :main)  # A-Z
+stitcher.include_range(0x4E00..0x9FFF, from: :cjk,  into: :main) # CJK
+
+stitcher.write_to("stitched.ttf", format: :ttf, subfont: :main)
+----
+
+== Collection example (TTC/OTC)
+
+When the total glyph count would exceed 65,535 (the OpenType
+`maxp.numGlyphs` cap), split the work across named subfonts and write
+a collection:
+
+[source,ruby]
+----
+stitcher = Fontisan::Stitcher.new
+stitcher.add_source(:noto_sans, Fontisan::FontLoader.load("NotoSans.ttf"))
+stitcher.add_source(:noto_cjk,  Fontisan::FontLoader.load("NotoSansCJK.ttf"))
+
+stitcher.include_range(0x41..0x5A,     from: :noto_sans, into: :latin)
+stitcher.include_range(0x4E00..0x9FFF, from: :noto_cjk,  into: :cjk)
+
+stitcher.write_collection("out.otc", format: :otf2)
+----
+
+Each subfont is compiled independently, then packed by
+`Collection::Builder` with table deduplication enabled — shared tables
+(head, name, OS/2, ...) are stored once and referenced from each
+subfont's offset table.
+
+== Glyph deduplication
+
+By default the Stitcher deduplicates glyphs across all sources using
+SHA-256 outline signatures (`Stitcher::GlyphSignature`). Two donor
+glyphs with identical width + contours + components are merged into a
+single target glyph; subsequent references are aliased by adding the
+extra codepoint to the merged glyph's unicode set.
+
+To disable deduplication (e.g., for forensic comparison):
+
+[source,ruby]
+----
+stitcher = Fontisan::Stitcher.new(deduplicate: false)
+----
+
+== 65,535 glyph cap
+
+OpenType `maxp.numGlyphs` is uint16 — no format (TTF, CFF1, or CFF2)
+can hold more than 65,535 glyphs in a single font. The Stitcher
+enforces this:
+
+* `Stitcher::GlyphLimit.check!(count, format:)` raises
+  `GlyphLimitExceededError` when a single subfont would exceed the cap.
+* The only path to >65,535 glyphs is a TTC/OTC collection — each
+  subfont is its own 65,535-space.
+
+== CBDT/CBLC passthrough (color emoji)
+
+Sources that contain CBDT/CBLC tables (e.g. NotoColorEmoji) can be
+used as Stitcher sources. The bitmap data is propagated byte-for-byte
+into the output:
+
+[source,ruby]
+----
+stitcher = Fontisan::Stitcher.new
+stitcher.add_source(:text,  Fontisan::FontLoader.load("NotoSans.ttf"))
+stitcher.add_source(:emoji, Fontisan::FontLoader.load("NotoColorEmoji.ttf"))
+
+stitcher.include_notdef(from: :text,  into: :main)
+stitcher.include_range(0x41..0x5A,    from: :text,  into: :main)
+stitcher.include_range(0x1F600..0x1F64F, from: :emoji, into: :main)
+
+stitcher.write_to("out.ttf", format: :ttf, subfont: :main)
+# → out.ttf has glyf + CBDT + CBLC, emoji renders correctly
+----
+
+Constraints:
+
+* Only ONE CBDT source per Stitcher. Multiple CBDT sources raise
+  `Fontisan::MultipleCbdtSourcesError`.
+* The CBDT source is processed first (GIDs 0..N-1) so the CBLC's GID
+  references remain valid in the output.
+
+== CLI
+
+[source,bash]
+----
+fontisan stitch \
+  --source latin=NotoSans.ttf \
+  --source cjk=FSung-m.ttf \
+  --include-range latin=0x41-0x5A \
+  --include-range cjk=0x4E00-0x9FFF \
+  --notdef-from latin \
+  --output stitched.ttf
+----
+
+== See also
+
+* link:UFO_COMPILATION.adoc[UFO Compilation Guide] — TTF/OTF/CFF2 compilers
+- link:COLLECTION_VALIDATION.adoc[Collection Validation Guide]
+- link:SVG_TO_GLYF.adoc[SVG to Glyph Guide] — turn chart SVGs into
+  Stitcher sources

--- a/docs/SVG_TO_GLYF.adoc
+++ b/docs/SVG_TO_GLYF.adoc
@@ -1,0 +1,118 @@
+= SVG to Glyph Guide
+
+== General
+
+`Fontisan::SvgToGlyf` converts SVG path data — as produced by ucode's
+code-chart extraction — into `Ufo::Glyph` objects that feed directly
+into the UFO → TTF/OTF compile pipeline.
+
+SvgToGlyf emits cubic Bezier contours (matching UFO/PostScript
+conventions). The cubic-to-quadratic conversion and winding-order
+correction happen later, in `Ufo::Compile::Filters::CubicToQuadratic`
+and `ReverseContourDirection`, when the glyph is compiled to TTF.
+
+== API
+
+[cols="2,3", options="header"]
+|===
+| Method | Purpose
+
+| `SvgToGlyf.convert(path_data, upm:, codepoint:, name:, viewbox:, transform:)`
+| Convert a single SVG path `d` string into a `Ufo::Glyph`
+
+| `SvgToGlyf.from_svg_file(file_path, upm:, codepoint:)`
+| Convert one `.svg` file into a `Ufo::Glyph`
+
+| `SvgToGlyf.from_directory(dir, upm:)`
+| Convert a directory of `.svg` files into a `Ufo::Font` (one glyph
+  per file)
+|===
+
+The default `upm` is 1000.
+
+== Single path
+
+[source,ruby]
+----
+glyph = Fontisan::SvgToGlyf.convert(
+  "M 0 0 L 500 0 L 500 700 L 0 700 Z",
+  upm: 1000,
+  codepoint: 0x10940,
+)
+# → #<Fontisan::Ufo::Glyph name="uni10940" ...>
+----
+
+== Single file
+
+[source,ruby]
+----
+glyph = Fontisan::SvgToGlyf.from_svg_file("U+10940.svg", upm: 1000)
+----
+
+If the codepoint is not supplied, it is derived from the filename when
+it matches `U+XXXX.svg` or `hexcode.svg`.
+
+== Directory → Font
+
+For batch conversion of a code-chart directory (one SVG per
+codepoint):
+
+[source,ruby]
+----
+font = Fontisan::SvgToGlyf.from_directory(
+  "/tmp/chart-svg/Khitan",
+  upm: 1000,
+)
+Fontisan::Ufo::Compile::TtfCompiler.new(font)
+  .compile(output_path: "Khitan.ttf")
+----
+
+Or feed it directly to the Stitcher:
+
+[source,ruby]
+----
+stitcher = Fontisan::Stitcher.new
+stitcher.add_source(:khitan, font)
+stitcher.include_range(0x18B00..0x18CFF, from: :khitan, into: :main)
+stitcher.write_to("Khitan.ttf", format: :ttf, subfont: :main)
+----
+
+== SVG subset supported
+
+SvgToGlyf handles the subset of SVG that real chart extractions use:
+
+* Path commands: `M`, `L`, `H`, `V`, `C`, `S`, `Q`, `T`, `A`, `Z`
+  (absolute and lowercase relative variants)
+* `<svg>` `viewBox` and `width`/`height` for coordinate scaling
+* `<g transform="...">` group transforms (matrix, translate, scale,
+  rotate)
+* `<path d="...">` elements
+
+Unsupported SVG features (filters, masks, embedded raster images) are
+ignored. SvgToGlyf is a vector-only converter — for raster emoji, use
+the CBDT/CBLC passthrough path (see link:STITCHER_GUIDE.adoc[Stitcher Guide]).
+
+== Coordinate system
+
+SVG uses a y-down coordinate system; UFO uses y-up. SvgToGlyf flips
+the y-axis using the SVG `viewBox` height so glyphs render right-way-up
+in font rendering contexts. When no `viewBox` is present, the
+`<svg>` `width`/`height` attributes are used as a fallback.
+
+== Namespace layout
+
+[source]
+----
+Fontisan::SvgToGlyf
+├── Path       # SVG path parser → contour builder
+├── Geometry   # AffineTransform, vector math
+├── Document   # <svg> document parsing, viewBox handling
+└── Assembler  # top-level glue: builds Ufo::Glyph / Ufo::Font
+----
+
+== See also
+
+* link:UFO_COMPILATION.adoc[UFO Compilation Guide] — compile converted
+  glyphs to binary fonts
+* link:STITCHER_GUIDE.adoc[Stitcher Guide] — combine converted fonts
+  with other donors

--- a/docs/UFO_COMPILATION.adoc
+++ b/docs/UFO_COMPILATION.adoc
@@ -1,0 +1,119 @@
+= UFO Compilation Guide
+
+== General
+
+Fontisan compiles UFO (Unified Font Object) v2/v3 sources into binary
+OpenType fonts — TTF, OTF (CFF1), and OTF2 (CFF2) — entirely in pure
+Ruby. No AFDKO or Python fonttools required.
+
+All compilers live under `Fontisan::Ufo::Compile` and share a common
+`BaseCompiler` orchestrator that emits the required set of OpenType
+tables (head, hhea, maxp, OS/2, name, post, hmtx, cmap, plus an
+optional GPOS kern table when the source has kerning data). Subclasses
+add format-specific outline tables.
+
+== Compilers
+
+[cols="1,1,3", options="header"]
+|===
+| Class | Output | Outline format
+
+| `Ufo::Compile::TtfCompiler`
+| `.ttf`
+| Quadratic Bezier curves in the `glyf` table
+
+| `Ufo::Compile::OtfCompiler`
+| `.otf` (CFF1)
+| Cubic Bezier curves in the `CFF ` table using Type 2 charstrings
+
+| `Ufo::Compile::Otf2Compiler`
+| `.otf` (CFF2)
+| Cubic Bezier curves in the `CFF2` table — modern format, supports
+  variable fonts via blend/vsindex operators
+|===
+
+== Building a single font
+
+[source,ruby]
+----
+require "fontisan"
+
+font = Fontisan::Ufo::Font.open("MyFont.ufo")
+
+# TrueType
+Fontisan::Ufo::Compile::TtfCompiler.new(font)
+  .compile(output_path: "MyFont.ttf")
+
+# OpenType / CFF1
+Fontisan::Ufo::Compile::OtfCompiler.new(font)
+  .compile(output_path: "MyFont.otf")
+
+# OpenType / CFF2 (modern, supports variable fonts)
+Fontisan::Ufo::Compile::Otf2Compiler.new(font)
+  .compile(output_path: "MyFont-CFF2.otf")
+----
+
+== TTF filters
+
+The TTF compiler applies two UFO glyph filters automatically:
+
+1. `CubicToQuadratic` — converts cubic Bezier control points to
+   quadratic. TTF `glyf` only supports quadratic curves; UFO sources
+   typically use cubics (matching PostScript/CFF conventions).
+2. `ReverseContourDirection` — reverses winding order. CFF and TTF
+   use opposite fill conventions (CFF: non-zero wind; TTF: even-odd by
+   default), so contour direction must be flipped.
+
+These filters live under `Ufo::Compile::Filters` and are applied to
+each glyph before serialization to `glyf`.
+
+== Tables emitted
+
+Every compiler emits this shared set:
+
+[cols="1,3", options="header"]
+|===
+| Tag | Purpose
+
+| `head` | Font header (units per em, bounding box, timestamps)
+| `hhea` | Horizontal header (ascender, descender, line gap)
+| `maxp` | Maximum profile (glyph count, point/contour limits)
+| `OS/2` | OS/2 and Windows-specific metrics
+| `name` | Name records (family, subfamily, copyright, etc.)
+| `post` | PostScript name table (glyph names)
+| `hmtx` | Horizontal metrics (advance width, left side bearing)
+| `cmap` | Character to glyph mapping
+| `GPOS` | Optional — present only when the UFO has kerning data
+|===
+
+Format-specific outline tables:
+
+* TTF → `glyf` + `loca`
+* OTF (CFF1) → `CFF `
+* OTF2 (CFF2) → `CFF2`
+
+== GPOS kerning
+
+If the UFO source includes kerning data (`kerning.plist`), the compiler
+emits a `GPOS` table with a pair-positioning lookup (feature `kern`).
+When no kerning is present, no `GPOS` table is written — the file stays
+smaller.
+
+== Round-tripping binary ↔ UFO
+
+To go the other way — extract a UFO from an existing binary font:
+
+[source,ruby]
+----
+ttf = Fontisan::FontLoader.load("MyFont.ttf")
+ufo = Fontisan::Ufo::Convert::FromBinData.convert(ttf)
+Fontisan::Ufo::Writer.new(ufo).write("MyFont.ufo")
+----
+
+== See also
+
+* link:CFF2_SUPPORT.adoc[CFF2 Support Guide] — variable-font blend
+  operators, FDSelect, subroutines, VariationStore
+* link:VARIABLE_FONT_OPERATIONS.adoc[Variable Font Operations] —
+  reading and modifying existing variable fonts
+- link:STITCHER_GUIDE.adoc[Stitcher Guide] — multi-source assembly


### PR DESCRIPTION
## Summary

Documents the OpenType table builders, CFF2 support, Stitcher
explicit-subfont API, and SVG-to-glyph converter added across the
recent opentype-* PRs.

- **README.adoc** — new "Font compilation and assembly" features
  subsection; "Font format support" and "Font engineering" sections
  refreshed to mention CFF2, FDSelect, MATH/Meta builders, signature
  dedup; "UFO source operations" rewritten with TTF/OTF/CFF2 compiler
  examples + variable TTF/OTF orchestrators; "Font stitching" rewritten
  around the explicit `into:` / `subfont:` API with single-font,
  collection, CBDT-passthrough, and SVG-to-glyph examples.
- **docs/UFO_COMPILATION.adoc** — TtfCompiler / OtfCompiler /
  Otf2Compiler; required-table set; TTF cubic-to-quadratic +
  winding-correction filters; GPOS kerning; binary ↔ UFO round-trip.
- **docs/CFF2_SUPPORT.adoc** — CFF2 table layout; Top DICT operator
  table; blend / vsindex operator protocol; `Cff2CharStringBuilder.build_variable`;
  FDSelect formats 0 and 3; subroutine bias tiers; ItemVariationStore
  wiring; note on the still-pending variable-OTF integration.
- **docs/STITCHER_GUIDE.adoc** — full Stitcher API table; single-font
  + collection examples; signature-based glyph deduplication; 65,535
  cap enforcement; CBDT/CBLC passthrough rules.
- **docs/SVG_TO_GLYF.adoc** — `SvgToGlyf.convert` / `from_svg_file` /
  `from_directory`; supported SVG subset; y-axis flip; feeding results
  into compilers or the Stitcher.

No code changes — docs-only.

## Test plan

- [x] README links to the four new guide files resolve
- [x] All API references in the docs verified against current source
- [x] Commit message has no AI attribution trailers