### PR TITLE
release: expose acknowledge_breaking_in_patch opt-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,17 @@ on:
           Next release version. Possible values: x.y.z, major, minor, patch or pre|rc|etc
         required: true
         default: "skip"
+      acknowledge_breaking_in_patch:
+        description: |
+          Acknowledge that this patch release contains breaking changes and
+          override the breaking-change heuristic guard. Use only when the
+          breaking change is intentional and accepted (e.g. 0.x API churn).
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
   push:
     tags:
       - v*
@@ -26,6 +37,7 @@ jobs:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
+      acknowledge_breaking_in_patch: ${{ github.event.inputs.acknowledge_breaking_in_patch == 'true' }}
     secrets:
       rubygems-api-key: ${{ secrets.FONTIST_CI_RUBYGEMS_API_KEY }}
       # NOTE: GITHUB_TOKEN is intentionally NOT passed as pat_token. The


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` input `acknowledge_breaking_in_patch` (default `"false"`) to `.github/workflows/release.yml`.
- Flows through to `metanorma/ci`'s `rubygems-release.yml`, overriding the breaking-change heuristic guard when set to `"true"`.
- The guard remains active by default for routine patch releases.

## Why

The next patch release contains an intentional API removal (`Fontisan::Stitcher#add_notdef_from_bindings` — replaced by `include_notdef(from:, into:)` during the explicit-subfont Stitcher rewrite). On a 0.x project, this kind of API churn ships in patch releases; the override knob lets us proceed without disabling the guard permanently.

## Test plan

- [x] YAML syntax valid (workflow file parses)
- [x] Default behavior unchanged (`false` keeps guard active)
- [x] Opt-in path passes through to metanorma/ci workflow
