### PR TITLE
essen-clean: build/inspect/validate collection pipeline (TODO 68-74)

### DIFF
--- a/lib/fontisan.rb
+++ b/lib/fontisan.rb
@@ -72,6 +72,7 @@ module Fontisan
   autoload :VariationDataCorruptedError, "fontisan/error"
   autoload :MultipleCbdtSourcesError, "fontisan/error"
   autoload :GlyphLimitExceededError, "fontisan/error"
+  autoload :PartitionCapExceededError, "fontisan/error"
 
   # Namespace hubs (each hub declares its own child autoloads)
   autoload :Binary, "fontisan/binary"
@@ -91,6 +92,7 @@ module Fontisan
   autoload :Tables, "fontisan/tables"
   autoload :Type1, "fontisan/type1"
   autoload :Ufo, "fontisan/ufo"
+  autoload :Unicode, "fontisan/unicode"
   autoload :Utilities, "fontisan/utilities"
   autoload :Utils, "fontisan/utils"
   autoload :Validation, "fontisan/validation"

--- a/lib/fontisan/cli.rb
+++ b/lib/fontisan/cli.rb
@@ -208,10 +208,12 @@ module Fontisan
     end
 
     desc "convert FONT_FILE", "Convert font to different format"
-    option :to, type: :string, required: true,
-                desc: "Target format: ttf, otf, type1, t1, ttc, otc, dfont, svg, " \
+    option :to, type: :array, required: true,
+                desc: "Target format(s): ttf, otf, type1, t1, ttc, otc, dfont, svg, " \
                       "woff (zlib — works on all browsers incl. legacy), " \
-                      "woff2 (Brotli — ~30% smaller, modern browsers only)",
+                      "woff2 (Brotli — ~30% smaller, modern browsers only). " \
+                      "Pass multiple times (--to woff --to woff2) or comma-separated " \
+                      "(--to woff,woff2) for multi-format output.",
                 aliases: "-t"
     option :output, type: :string,
                     desc: "Output file path (required unless --show-options)",
@@ -358,7 +360,7 @@ module Fontisan
 
       # Handle --show-options
       if options[:show_options]
-        show_recommended_options(source_format, options[:to])
+        show_recommended_options(source_format, options[:to].is_a?(Array) ? options[:to].first : options[:to])
         return
       end
 
@@ -368,7 +370,8 @@ module Fontisan
       end
 
       # Build ConversionOptions
-      conv_options = build_conversion_options(source_format, options[:to],
+      conv_options = build_conversion_options(source_format,
+                                              Array(options[:to]).first,
                                               options)
 
       # Build instance coordinates from axis options
@@ -568,6 +571,27 @@ module Fontisan
         binary_format: options[:binary_format].to_sym,
       )
       exit command.run
+    end
+
+    desc "validate-collection PATH",
+         "Validate a TTC/OTC/dfont (face count, glyph cap, cmap union)"
+    option :expected_faces, type: :numeric,
+                            desc: "Required face count"
+    option :max_glyphs, type: :numeric, default: Fontisan::Commands::ValidateCollectionCommand::DEFAULT_MAX_GLYPHS,
+                        desc: "Per-face glyph cap"
+    option :expected_cmap_union, type: :numeric,
+                                 desc: "Minimum cmap union size across all faces"
+    def validate_collection(path)
+      cmd = Commands::ValidateCollectionCommand.new(
+        input: path,
+        expected_faces: options[:expected_faces],
+        max_glyphs: options[:max_glyphs],
+        expected_cmap_union: options[:expected_cmap_union],
+      )
+      exit cmd.run
+    rescue ArgumentError => e
+      warn "ERROR: #{e.message}"
+      exit 1
     end
 
     desc "version", "Display version information"

--- a/lib/fontisan/collection.rb
+++ b/lib/fontisan/collection.rb
@@ -7,6 +7,7 @@ module Fontisan
     autoload :Builder, "fontisan/collection/builder"
     autoload :DfontBuilder, "fontisan/collection/dfont_builder"
     autoload :OffsetCalculator, "fontisan/collection/offset_calculator"
+    autoload :Reader, "fontisan/collection/reader"
     autoload :SharedLogic, "fontisan/collection/shared_logic"
     autoload :TableAnalyzer, "fontisan/collection/table_analyzer"
     autoload :TableDeduplicator, "fontisan/collection/table_deduplicator"

--- a/lib/fontisan/collection/reader.rb
+++ b/lib/fontisan/collection/reader.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Collection
+    # Read-only counterpart to {Builder}. Opens an existing TTC/OTC/dfont
+    # and exposes per-face metadata (glyph count, codepoint count, sfnt
+    # version) and the cmap union across all faces.
+    #
+    # Delegates header parsing to {FontLoader} — never hand-rolls the
+    # TTC header bytes (that would duplicate BaseCollection.from_file
+    # and only handle TTC/OTC, not dfont).
+    #
+    # @example Per-face glyph counts
+    #   reader = Collection::Reader.open("family.ttc")
+    #   reader.stats.map { |s| [s.index, s.glyph_count] }
+    #
+    # @example Cmap union
+    #   Collection::Reader.open("family.otc").cmap_union.size
+    class Reader
+      autoload :Stats, "fontisan/collection/reader/stats"
+
+      # @!attribute [r] path
+      #   @return [String] the file path this reader was opened with
+      attr_reader :path
+
+      # Collection formats this reader accepts. Single source of truth —
+      # matches {FontLoader::COLLECTION_CLASSES}.
+      FORMATS = %i[ttc otc dfont].freeze
+
+      # @param path [String] path to a TTC/OTC/dfont file
+      # @raise [ArgumentError] if the file is not a recognized collection
+      def initialize(path)
+        @path = path
+        detected = FontLoader.detect_format(path)
+        unless FORMATS.include?(detected)
+          raise ArgumentError,
+                "#{path} is not a TTC/OTC/dfont (detected: #{detected.inspect})"
+        end
+
+        @collection = FontLoader.load_collection(path)
+      end
+
+      # Convenience constructor.
+      # @param path [String]
+      # @return [Reader]
+      def self.open(path)
+        new(path)
+      end
+
+      # @return [Integer] number of faces in the collection
+      def face_count
+        @collection.num_fonts
+      end
+
+      # Yields each face as a loaded TTF/OTF font. Without a block,
+      # returns an Enumerator (so callers can chain +each_with_index+).
+      # The Enumerator's size is set to +face_count+ so size-based
+      # assertions work without consuming it.
+      #
+      # @yieldparam face [TrueTypeFont, OpenTypeFont]
+      # @return [Enumerator, void]
+      def each_face
+        return enum_for(:each_face) { face_count } unless block_given?
+
+        face_count.times { |i| yield FontLoader.load(@path, font_index: i) }
+      end
+
+      # @return [Array<Stats>] one Stats per face, in face-index order
+      def stats
+        each_face.map.with_index do |face, i|
+          Stats.new(
+            index: i,
+            glyph_count: face.table("maxp")&.num_glyphs || 0,
+            codepoint_count: (face.table("cmap")&.unicode_mappings || {}).size,
+            sfnt_version: face.header.sfnt_version,
+          )
+        end
+      end
+
+      # Union of every face's cmap keys.
+      #
+      # @return [Set<Integer>]
+      def cmap_union
+        each_face.with_object(Set.new) do |face, union|
+          union.merge((face.table("cmap")&.unicode_mappings || {}).keys)
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/collection/reader/stats.rb
+++ b/lib/fontisan/collection/reader/stats.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Collection
+    class Reader
+      # Snapshot of one face's headline metrics. Pure value object —
+      # no methods beyond accessors. Separate file from {Reader} so
+      # the Stats struct can be referenced without pulling in the
+      # full Reader (and its FontLoader dependency).
+      #
+      # @!attribute [r] index
+      #   @return [Integer] 0-based face index inside the collection
+      # @!attribute [r] glyph_count
+      #   @return [Integer] face's maxp.numGlyphs
+      # @!attribute [r] codepoint_count
+      #   @return [Integer] count of keys in face's cmap unicode_mappings
+      # @!attribute [r] sfnt_version
+      #   @return [Integer] face sfnt version (0x00010000 for TTF, 0x4F54544F for OTF)
+      Stats = Struct.new(:index, :glyph_count, :codepoint_count, :sfnt_version,
+                         keyword_init: true)
+    end
+  end
+end

--- a/lib/fontisan/commands.rb
+++ b/lib/fontisan/commands.rb
@@ -13,6 +13,7 @@ module Fontisan
     autoload :InfoCommand, "fontisan/commands/info_command"
     autoload :InstanceCommand, "fontisan/commands/instance_command"
     autoload :LsCommand, "fontisan/commands/ls_command"
+    autoload :MultiFormatOutput, "fontisan/commands/multi_format_output"
     autoload :OpticalSizeCommand, "fontisan/commands/optical_size_command"
     autoload :PackCommand, "fontisan/commands/pack_command"
     autoload :ScriptsCommand, "fontisan/commands/scripts_command"
@@ -20,6 +21,7 @@ module Fontisan
     autoload :TablesCommand, "fontisan/commands/tables_command"
     autoload :UnicodeCommand, "fontisan/commands/unicode_command"
     autoload :UnpackCommand, "fontisan/commands/unpack_command"
+    autoload :ValidateCollectionCommand, "fontisan/commands/validate_collection_command"
     autoload :ValidateCommand, "fontisan/commands/validate_command"
     autoload :VariableCommand, "fontisan/commands/variable_command"
   end

--- a/lib/fontisan/commands/convert_command.rb
+++ b/lib/fontisan/commands/convert_command.rb
@@ -42,11 +42,20 @@ module Fontisan
     #   )
     #   command.run
     class ConvertCommand < BaseCommand
+      # Public readers for the parsed target formats and per-format output
+      # paths. Exposed (rather than relying on @ivar access from specs) so
+      # multi-format behaviour can be tested through the public surface.
+      attr_reader :target_formats, :output_paths
+
       # Initialize convert command
       #
       # @param font_path [String] Path to input font file
       # @param options [Hash] Conversion options
-      # @option options [String] :to Target format (ttf, otf, woff, woff2)
+      # @option options [String, Array<String>] :to Target format(s):
+      #   ttf, otf, woff, woff2, type1, ttc, otc, dfont, svg. Pass a
+      #   comma-separated string ("woff,woff2") or an array (["woff",
+      #   "woff2"]) for multi-format output. Single-font → single-font
+      #   only; multi-format + collection input is rejected.
       # @option options [String] :output Output file path (required)
       # @option options [Integer] :font_index Index for TTC/OTC (default: 0)
       # @option options [String] :coordinates Coordinate string (e.g., "wght=700,wdth=100")
@@ -69,8 +78,13 @@ module Fontisan
 
         @output_path = @options[:output]
 
-        # Parse target format
-        @target_format = parse_target_format(@options[:to])
+        # Parse target format(s). Always an Array<Symbol>, deduped, order
+        # preserved. Single-format callsites get a one-element array.
+        @target_formats = parse_target_formats(@options[:to])
+
+        # Resolve per-format output paths up front so filename ambiguity
+        # surfaces before any pipeline work is done.
+        @output_paths = resolve_output_paths
 
         # Extract ConversionOptions if provided
         @conv_options = extract_conversion_options(@options)
@@ -92,17 +106,26 @@ module Fontisan
 
       # Execute the conversion
       #
-      # @return [Hash] Result information
+      # @return [Hash, Array<Hash>] Result information. Single-format
+      #   returns one result hash (back-compat). Multi-format returns
+      #   an array of result hashes, one per target format.
       # @raise [ArgumentError] If output path is not specified
       # @raise [Error] If conversion fails
       def run
         validate_options!
 
-        # Check if input is a collection
         if collection_file?
+          if multi_format?
+            raise ArgumentError,
+                  "Multi-format conversion is not supported for collection " \
+                  "input. Specify a single target format."
+          end
+
           convert_collection
+        elsif multi_format?
+          convert_multi_format
         else
-          convert_single_font
+          convert_single_font(@target_formats.first, @output_paths.first)
         end
       rescue ArgumentError
         # Let ArgumentError propagate for validation errors
@@ -112,6 +135,11 @@ module Fontisan
       end
 
       private
+
+      # @return [Boolean] true when more than one target format was given
+      def multi_format?
+        @target_formats.size > 1
+      end
 
       # Check if input file is a collection
       #
@@ -123,15 +151,36 @@ module Fontisan
         false
       end
 
-      # Convert a single font (original implementation)
+      # Convert to each target format and aggregate results.
       #
+      # @return [Array<Hash>]
+      def convert_multi_format
+        unless @options[:quiet]
+          puts "Converting #{File.basename(font_path)} to " \
+               "#{@target_formats.join(', ')}..."
+        end
+
+        @target_formats.zip(@output_paths).map do |fmt, out_path|
+          result = convert_single_font(fmt, out_path)
+          unless @options[:quiet]
+            puts "  #{fmt}: wrote #{File.basename(out_path)} " \
+                 "(#{format_size(File.size(out_path))})"
+          end
+          result
+        end
+      end
+
+      # Convert a single font to a single target format at +out_path+.
+      #
+      # @param target_format [Symbol]
+      # @param out_path [String]
       # @return [Hash] Result information
-      def convert_single_font
-        puts "Converting #{File.basename(font_path)} to #{@target_format}..." unless @options[:quiet]
+      def convert_single_font(target_format, out_path)
+        puts "Converting #{File.basename(font_path)} to #{target_format}..." unless @options[:quiet]
 
         # Build pipeline options
         pipeline_options = {
-          target_format: @target_format,
+          target_format: target_format,
           validate: @validate,
           verbose: @options[:verbose],
         }
@@ -160,7 +209,7 @@ module Fontisan
         # Use TransformationPipeline for universal conversion
         pipeline = Pipeline::TransformationPipeline.new(
           font_path,
-          @output_path,
+          out_path,
           pipeline_options,
         )
 
@@ -168,12 +217,12 @@ module Fontisan
 
         # Display results
         unless @options[:quiet]
-          output_size = File.size(@output_path)
+          output_size = File.size(out_path)
           input_size = File.size(font_path)
 
           puts "Conversion complete!"
           puts "  Input:  #{font_path} (#{format_size(input_size)})"
-          puts "  Output: #{@output_path} (#{format_size(output_size)})"
+          puts "  Output: #{out_path} (#{format_size(output_size)})"
           puts "  Format: #{result[:details][:source_format]} → #{result[:details][:target_format]}"
 
           if result[:details][:variation_preserved]
@@ -186,11 +235,11 @@ module Fontisan
         {
           success: true,
           input_path: font_path,
-          output_path: @output_path,
+          output_path: out_path,
           source_format: result[:details][:source_format],
           target_format: result[:details][:target_format],
           input_size: File.size(font_path),
-          output_size: File.size(@output_path),
+          output_size: File.size(out_path),
           variation_strategy: result[:details][:variation_strategy],
         }
       end
@@ -200,11 +249,11 @@ module Fontisan
       # @return [Hash] Result information
       def convert_collection
         # Determine target collection type from target format
-        target_type = collection_type_from_format(@target_format)
+        target_type = collection_type_from_format(@target_formats.first)
 
         unless target_type
           raise ArgumentError,
-                "Target format #{@target_format} is not a collection format. " \
+                "Target format #{@target_formats.first} is not a collection format. " \
                 "Use ttc, otc, or dfont for collection conversion."
         end
 
@@ -302,10 +351,39 @@ module Fontisan
                 "Output path is required. Use --output option."
         end
 
-        unless @target_format
+        if @target_formats.empty?
           raise ArgumentError,
                 "Target format is required. Use --to option."
         end
+      end
+
+      # Normalize the +--to+ value into a deduplicated Array<Symbol>.
+      #
+      # Accepts:
+      #   - "woff"               → [:woff]
+      #   - "woff,woff2"         → [:woff, :woff2]
+      #   - ["woff", "woff2"]    → [:woff, :woff2]
+      #   - ["woff,woff2", "ttf"] → [:woff, :woff2, :ttf]
+      #   - nil / ""             → []
+      #
+      # @return [Array<Symbol>]
+      def parse_target_formats(raw)
+        array = Array(raw).flat_map { |s| s.to_s.split(",") }
+          .map { |s| s.strip.downcase }
+          .reject(&:empty?)
+          .map { |s| parse_target_format(s) }
+        array.uniq
+      end
+
+      # Resolve the per-format output paths via {MultiFormatOutput}.
+      # Returns nil when no target formats have been parsed yet (the
+      # validate_options! path will surface the missing-format error).
+      #
+      # @return [Array<String>, nil]
+      def resolve_output_paths
+        return nil if @target_formats.empty? || @output_path.nil?
+
+        MultiFormatOutput.new(@output_path, @target_formats).paths
       end
 
       # Parse target format from string/symbol

--- a/lib/fontisan/commands/multi_format_output.rb
+++ b/lib/fontisan/commands/multi_format_output.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Commands
+    # Resolves the on-disk output path for each target format in a
+    # multi-format conversion (TODO 72).
+    #
+    # Rules:
+    #   - One format + path has extension → use the path as-is.
+    #   - One format + path has no extension → append ".<format>".
+    #   - Many formats + path has extension → +ArgumentError+ (ambiguous).
+    #   - Many formats + path has no extension → append ".<format>" per target.
+    #
+    # Pure value object: no I/O, no mutation. Extracted from
+    # {ConvertCommand} so multi-format path resolution can be tested
+    # independently of the transformation pipeline.
+    class MultiFormatOutput
+      # @param base_path [String] user-supplied --output value
+      # @param target_formats [Array<Symbol>] non-empty, deduplicated
+      def initialize(base_path, target_formats)
+        @base_path = base_path
+        @target_formats = target_formats
+      end
+
+      # @return [Array<String>] one resolved path per target format,
+      #   in the same order as +target_formats+
+      # @raise [ArgumentError] if the base path is ambiguous
+      def paths
+        single? ? [single_format_path] : multi_format_paths
+      end
+
+      private
+
+      def single?
+        @target_formats.size == 1
+      end
+
+      def single_format_path
+        has_extension? ? @base_path : "#{@base_path}.#{@target_formats.first}"
+      end
+
+      def multi_format_paths
+        if has_extension?
+          raise ArgumentError,
+                "Output path #{@base_path.inspect} has an extension but " \
+                "#{@target_formats.size} target formats were given " \
+                "(#{@target_formats.join(', ')}). Drop the extension or " \
+                "specify a single format."
+        end
+
+        @target_formats.map { |fmt| "#{@base_path}.#{fmt}" }
+      end
+
+      def has_extension?
+        !File.extname(@base_path).strip.downcase.empty?
+      end
+    end
+  end
+end

--- a/lib/fontisan/commands/validate_collection_command.rb
+++ b/lib/fontisan/commands/validate_collection_command.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Commands
+    # Validates the structural integrity of a TTC/OTC/dfont collection
+    # (TODO 74). Complements {ValidateCommand}, which runs profile-based
+    # checks against a single face. This command runs collection-level
+    # checks: face count, per-face glyph cap, optional cmap-union size.
+    #
+    # Returns an integer exit code (0 = all checks passed, 1 = any check
+    # failed) suitable for use as the CLI's exit status.
+    #
+    # The command is intentionally narrow: it does not subclass
+    # {BaseCommand} (which eagerly loads a single font at construction
+    # time) because the input here is a collection, not a single face.
+    # It owns its own loading via {Collection::Reader}.
+    class ValidateCollectionCommand
+      # Per-check result. The +message+ is +nil+ on pass.
+      #
+      # @!attribute [r] name
+      #   @return [Symbol] check identifier (:face_count, :glyph_cap, :cmap_union)
+      # @!attribute [r] passed
+      #   @return [Boolean]
+      # @!attribute [r] message
+      #   @return [String, nil] human-readable failure detail
+      Check = Struct.new(:name, :passed, :message, keyword_init: true) do
+        # Predicate form so callers can write +check.passed?+ instead of
+        # +check.passed+. Struct does not provide the +?+ suffix
+        # automatically.
+        def passed?
+          passed
+        end
+      end
+
+      DEFAULT_MAX_GLYPHS = 65_535
+
+      # @param input [String] path to a TTC/OTC/dfont
+      # @param expected_faces [Integer, nil] required face count, or nil to skip
+      # @param max_glyphs [Integer] per-face glyph cap (default 65,535)
+      # @param expected_cmap_union [Integer, nil] minimum cmap-union size, or nil to skip
+      def initialize(input:, expected_faces: nil, max_glyphs: DEFAULT_MAX_GLYPHS,
+                     expected_cmap_union: nil)
+        @input = input
+        @expected_faces = expected_faces
+        @max_glyphs = max_glyphs
+        @expected_cmap_union = expected_cmap_union
+      end
+
+      # @return [Integer] 0 if all checks passed, 1 otherwise
+      def run
+        reader = Collection::Reader.open(@input)
+        @checks = [
+          check_face_count(reader),
+          check_glyph_cap(reader),
+          check_cmap_union(reader),
+        ].compact
+
+        render_report(reader)
+        @checks.all?(&:passed?) ? 0 : 1
+      end
+
+      # @return [Array<Check>] the most recent run's checks
+      attr_reader :checks
+
+      private
+
+      def check_face_count(reader)
+        return nil unless @expected_faces
+
+        actual = reader.face_count
+        passed = actual == @expected_faces
+        Check.new(
+          name: :face_count,
+          passed: passed,
+          message: passed ? nil : "expected #{@expected_faces} faces, got #{actual}",
+        )
+      end
+
+      def check_glyph_cap(reader)
+        over = reader.stats.select { |s| s.glyph_count > @max_glyphs }
+        Check.new(
+          name: :glyph_cap,
+          passed: over.empty?,
+          message: over.empty? ? nil : "faces over cap: #{over.map { |s| "##{s.index}=#{s.glyph_count}" }.join(', ')}",
+        )
+      end
+
+      def check_cmap_union(reader)
+        return nil unless @expected_cmap_union
+
+        actual = reader.cmap_union.size
+        passed = actual >= @expected_cmap_union
+        Check.new(
+          name: :cmap_union,
+          passed: passed,
+          message: passed ? nil : "cmap union #{actual} < expected #{@expected_cmap_union}",
+        )
+      end
+
+      # Default rendering. Callers wanting structured output can
+      # instantiate the command, call +#run+, then read +#checks+
+      # directly instead of relying on stdout.
+      def render_report(reader)
+        reader.stats.each do |s|
+          marker = s.glyph_count <= @max_glyphs ? "✓" : "✗"
+          puts format("face %<index>d: %<glyphs>7d glyphs %<marker>s",
+                      index: s.index, glyphs: s.glyph_count, marker: marker)
+        end
+        puts "all #{reader.face_count} faces within #{@max_glyphs}-glyph cap ✓"
+
+        @checks.each do |check|
+          if check.passed?
+            puts "#{check.name}: ✓"
+          else
+            puts "#{check.name}: ✗ (#{check.message})"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/error.rb
+++ b/lib/fontisan/error.rb
@@ -237,6 +237,31 @@ module Fontisan
     end
   end
 
+  # Partition strategy could not satisfy the requested cap.
+  #
+  # Raised by {Stitcher::PartitionStrategy} when a single Unicode block
+  # contains more codepoints than the configured cap, so the partitioner
+  # cannot sub-split it further. This is a partitioning-time detection
+  # distinct from {GlyphLimitExceededError}, which fires at compile time
+  # after the Stitcher has produced more glyphs than the output format
+  # supports. Both surface the same underlying constraint (65,535-glyph
+  # cap) but at different stages.
+  class PartitionCapExceededError < Error
+    attr_reader :block_label, :actual, :cap
+
+    # @param block_label [String] e.g. "CJK_Ext_B", or "plane_N" if the
+    #   overflow is not attributable to a known block
+    # @param actual [Integer] number of codepoints in the block
+    # @param cap [Integer] the cap that was exceeded
+    def initialize(block_label:, actual:, cap:)
+      @block_label = block_label
+      @actual = actual
+      @cap = cap
+      super("single Unicode block #{block_label} (#{actual} cps) exceeds " \
+            "cap #{cap}; cannot sub-split further")
+    end
+  end
+
   # Variation data corrupted (for use in data_extractor)
   #
   # Raised when extracted variation data appears corrupted.

--- a/lib/fontisan/stitcher.rb
+++ b/lib/fontisan/stitcher.rb
@@ -25,11 +25,20 @@ module Fontisan
   #   stitcher.include_range(0x4E00..0x9FFF, from: :noto_cjk, into: :cjk)
   #   stitcher.write_collection("out.otc", format: :otf2)
   class Stitcher
-    autoload :Source,          "fontisan/stitcher/source"
-    autoload :Selector,        "fontisan/stitcher/selector"
-    autoload :GlyphSignature,  "fontisan/stitcher/glyph_signature"
-    autoload :Deduplicator,    "fontisan/stitcher/deduplicator"
-    autoload :GlyphLimit,      "fontisan/stitcher/glyph_limit"
+    autoload :Source,           "fontisan/stitcher/source"
+    autoload :Selector,         "fontisan/stitcher/selector"
+    autoload :GlyphSignature,   "fontisan/stitcher/glyph_signature"
+    autoload :Deduplicator,     "fontisan/stitcher/deduplicator"
+    autoload :GlyphLimit,       "fontisan/stitcher/glyph_limit"
+    autoload :CollectionResult, "fontisan/stitcher/collection_result"
+    autoload :SubfontStats,     "fontisan/stitcher/collection_result"
+    autoload :PartitionStrategy, "fontisan/stitcher/partition_strategy"
+
+    # Internal: pairs a compiled loaded font with its stats so
+    # +write_collection+ can build the collection and the result from a
+    # single compilation pass.
+    CompiledSubfont = Struct.new(:name, :font, :stats, keyword_init: true)
+    private_constant :CompiledSubfont
 
     DEFAULT_DEDUPLICATE = true
 
@@ -52,6 +61,13 @@ module Fontisan
 
     def include_codepoints(codepoints, from:, into:)
       Selector::Codepoints.new(codepoints).apply(source(from), @subfonts[into])
+    end
+
+    def include_codepoints_map(cp_map, into:)
+      cp_map.to_h
+        .group_by { |_cp, label| label }
+        .transform_values { |pairs| pairs.map(&:first).sort }
+        .each { |label, cps| include_codepoints(cps, from: label, into: into) }
     end
 
     def include_gid(donor_gid, from:, into:)
@@ -89,13 +105,19 @@ module Fontisan
       raise ArgumentError, "no subfonts declared" if @subfonts.empty?
 
       compiled = @subfonts.keys.map do |name|
-        compile_subfont_to_loaded_font(name, format: format)
+        compile_subfont_with_stats(name, format: format)
       end
+      fonts = compiled.map(&:font)
 
       collection_format = collection_format_for(format)
-      Collection::Builder.new(compiled, format: collection_format,
-                                        optimize: true).build_to_file(path)
-      path
+      Collection::Builder.new(fonts, format: collection_format,
+                                     optimize: true).build_to_file(path)
+
+      CollectionResult.new(
+        path: path,
+        bytes: File.size(path),
+        subfonts: compiled.map(&:stats),
+      )
     end
 
     private
@@ -140,6 +162,10 @@ module Fontisan
     end
 
     def compile_subfont_to_loaded_font(subfont_name, format:)
+      compile_subfont_with_stats(subfont_name, format: format).font
+    end
+
+    def compile_subfont_with_stats(subfont_name, format:)
       target = build_target_for(subfont_name)
       GlyphLimit.check!(target.glyphs.size, format: format)
 
@@ -148,7 +174,15 @@ module Fontisan
         sub_path = File.join(dir, "sub#{subfont_name}#{ext}")
         compiler = compiler_for(format)
         compiler.new(target).compile(output_path: sub_path)
-        return Fontisan::FontLoader.load(sub_path)
+        propagate_cbdt_tables(sub_path) if cbdt_source
+
+        loaded = Fontisan::FontLoader.load(sub_path)
+        stats = SubfontStats.new(
+          name: subfont_name,
+          glyph_count: loaded.table("maxp")&.num_glyphs || 0,
+          codepoint_count: (loaded.table("cmap")&.unicode_mappings || {}).size,
+        )
+        CompiledSubfont.new(name: subfont_name, font: loaded, stats: stats)
       end
     end
 

--- a/lib/fontisan/stitcher/collection_result.rb
+++ b/lib/fontisan/stitcher/collection_result.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    # Per-subfont stats computed from the loaded, on-disk subfont (not the
+    # in-memory UFO target — the compiler may add glyphs, e.g. .notdef).
+    SubfontStats = Struct.new(:name, :glyph_count, :codepoint_count,
+                              keyword_init: true)
+
+    # Return value of {Stitcher#write_collection}. Carries the output path,
+    # total bytes, and one {SubfontStats} per declared subfont.
+    CollectionResult = Struct.new(:path, :bytes, :subfonts, keyword_init: true) do
+      def face_count
+        subfonts.size
+      end
+    end
+  end
+end

--- a/lib/fontisan/stitcher/partition_strategy.rb
+++ b/lib/fontisan/stitcher/partition_strategy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    # Namespace for codepoint partitioners that split a codepoint set
+    # across named subfonts while respecting the format's glyph cap.
+    #
+    # A partitioner is a strategy object with a single entry point
+    # (`.partition`) that takes a +{codepoint => donor}+ map and returns
+    # a {Blueprint}. The blueprint is then applied to a Stitcher via
+    # {Blueprint#apply_to}.
+    #
+    # Adding a new partitioner = adding a new file + a new entry here.
+    # No edits to existing partitioners required (open/closed).
+    module PartitionStrategy
+      autoload :Base, "fontisan/stitcher/partition_strategy/base"
+      autoload :Blueprint, "fontisan/stitcher/partition_strategy/blueprint"
+      autoload :Partition, "fontisan/stitcher/partition_strategy/partition"
+      autoload :ByPlane, "fontisan/stitcher/partition_strategy/by_plane"
+    end
+  end
+end

--- a/lib/fontisan/stitcher/partition_strategy/base.rb
+++ b/lib/fontisan/stitcher/partition_strategy/base.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    module PartitionStrategy
+      # Abstract base. Concrete partitioners (ByPlane, ByBlock, …)
+      # implement {#call} and return a {Blueprint}.
+      class Base
+        # Default cap: 65,535 − .notdef − safety margin. Matches the
+        # Stitcher's own +GlyphLimit+ cap for TTF.
+        DEFAULT_CAP = 65_484
+
+        # @param cp_map [Hash{Integer=>Object}] codepoint → donor label
+        # @param cap [Integer] max codepoints per partition
+        # @return [Blueprint]
+        def call(cp_map, cap: DEFAULT_CAP)
+          raise NotImplementedError,
+                "#{self.class} must implement #call"
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/stitcher/partition_strategy/blueprint.rb
+++ b/lib/fontisan/stitcher/partition_strategy/blueprint.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    module PartitionStrategy
+      # The result of partitioning a codepoint set: an ordered list of
+      # {Partition}s. Applying a blueprint to a Stitcher declares one
+      # subfont per partition.
+      Blueprint = Struct.new(:partitions, keyword_init: true) do
+        # @param stitcher [Fontisan::Stitcher]
+        # @return [Array<Symbol>] names of subfonts declared
+        def apply_to(stitcher)
+          partitions.each { |p| p.apply_to(stitcher) }
+          partitions.map(&:name)
+        end
+
+        # @return [Array<Symbol>]
+        def names
+          partitions.map(&:name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/stitcher/partition_strategy/by_plane.rb
+++ b/lib/fontisan/stitcher/partition_strategy/by_plane.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    module PartitionStrategy
+      # Partition codepoints by Unicode plane (BMP, SMP, SIP, …).
+      #
+      # For each plane with codepoints:
+      #   - if the count fits under +cap+, emit one partition named
+      #     +:plane_<n>+ (e.g. +:plane_0+, +:plane_2+);
+      #   - otherwise sub-split using the large CJK extension block
+      #     boundaries, naming partitions +:plane_<n>_a+, +:plane_<n>_b+,
+      #     and so on.
+      #
+      # If a single CJK extension block alone exceeds +cap+, raises
+      # {Fontisan::GlyphLimitExceededError} — the partitioner cannot
+      # satisfy the cap and the caller must use a smaller cap, split
+      # manually, or switch to a format with a higher glyph limit.
+      class ByPlane < Base
+        # @param cp_map [Hash{Integer=>Object}] codepoint → donor label
+        # @param cap [Integer] max codepoints per partition
+        # @return [Blueprint]
+        def call(cp_map, cap: DEFAULT_CAP)
+          grouped = group_by_plane(cp_map)
+          partitions = grouped.flat_map do |plane_num, entries|
+            build_partitions_for_plane(plane_num, entries, cap)
+          end
+          Blueprint.new(partitions: partitions)
+        end
+
+        private
+
+        def group_by_plane(cp_map)
+          cp_map.group_by { |cp, _label| Fontisan::Unicode::Plane.of(cp) }
+        end
+
+        def build_partitions_for_plane(plane_num, entries, cap)
+          if entries.size <= cap
+            return [single_partition(plane_num, entries)]
+          end
+
+          sub_split_by_block(plane_num, entries, cap)
+        end
+
+        def single_partition(plane_num, entries)
+          Partition.new(
+            name: :"plane_#{plane_num}",
+            cps: entries.map(&:first),
+            donor_map: entries.to_h,
+          )
+        end
+
+        # When a plane overflows +cap+, carve it along the large CJK
+        # extension block boundaries. The +:other+ bucket (everything
+        # outside the known mega-blocks) is split into chunks of +cap+,
+        # while each known large block becomes one partition atomically —
+        # if a single block alone exceeds +cap+, we cannot sub-split it
+        # (its codepoints are contiguous and we don't have finer-grained
+        # boundaries to use), so raise.
+        def sub_split_by_block(plane_num, entries, cap)
+          buckets = bucket_by_large_block(entries)
+          partitions = []
+          suffix = "a"
+
+          buckets.each do |label, bucket_entries|
+            if large_block?(label) && bucket_entries.size > cap
+              raise PartitionCapExceededError.new(
+                block_label: label,
+                actual: bucket_entries.size,
+                cap: cap,
+              )
+            end
+
+            chunks(bucket_entries, cap).each do |chunk|
+              partitions << Partition.new(
+                name: :"plane_#{plane_num}_#{suffix}",
+                cps: chunk.map(&:first),
+                donor_map: chunk.to_h,
+              )
+              suffix = suffix.succ
+            end
+          end
+          partitions
+        end
+
+        def large_block?(label)
+          Fontisan::Unicode::Plane::LARGE_CJK_BLOCKS.key?(label)
+        end
+
+        # Split +entries+ into sub-arrays of at most +cap+ each.
+        def chunks(entries, cap)
+          entries.each_slice(cap).to_a
+        end
+
+        # Bucket entries by which large CJK block (or :other) they fall
+        # into. Entries outside any known large block go into :other,
+        # which is then packed into its own partition(s).
+        def bucket_by_large_block(entries)
+          buckets = { other: [] }
+          Fontisan::Unicode::Plane::LARGE_CJK_BLOCKS.each_key do |label|
+            buckets[label] = []
+          end
+
+          entries.each do |cp, label|
+            block = find_large_block(cp)
+            if block
+              buckets[block] << [cp, label]
+            else
+              buckets[:other] << [cp, label]
+            end
+          end
+
+          # Drop empty buckets; preserve order (other first if non-empty,
+          # then CJK blocks in declaration order).
+          ordered = []
+          ordered << [:other, buckets[:other]] unless buckets[:other].empty?
+          Fontisan::Unicode::Plane::LARGE_CJK_BLOCKS.each_key do |label|
+            ordered << [label, buckets[label]] unless buckets[label].empty?
+          end
+          ordered
+        end
+
+        def find_large_block(codepoint)
+          Fontisan::Unicode::Plane::LARGE_CJK_BLOCKS.find do |_label, range|
+            range.include?(codepoint)
+          end&.first
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/stitcher/partition_strategy/partition.rb
+++ b/lib/fontisan/stitcher/partition_strategy/partition.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    module PartitionStrategy
+      # One slice of a partitioned codepoint set. Each partition names
+      # a target subfont and the codepoints + donor mapping that should
+      # land in it.
+      #
+      # {#apply_to} pushes the partition's bindings into a Stitcher via
+      # +include_codepoints_map+ (TODO 68). If that API is unavailable
+      # (older Stitcher), it falls back to one +include_codepoints+
+      # call per donor — but the preferred path is the map API.
+      Partition = Struct.new(:name, :cps, :donor_map, keyword_init: true) do
+        # @param stitcher [Fontisan::Stitcher]
+        # @return [void]
+        def apply_to(stitcher)
+          slice = cps.to_h { |cp| [cp, donor_map[cp]] }
+          stitcher.include_codepoints_map(slice, into: name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/name.rb
+++ b/lib/fontisan/ufo/compile/name.rb
@@ -31,7 +31,7 @@ module Fontisan
           family = font.info.family_name || "Untitled"
           subfamily = font.info.style_name || "Regular"
           ps_name = font.info.postscript_font_name || "#{family}-#{subfamily}"
-          full_name = "#{family} #{subfamily}".strip
+          full_name = font.info.postscript_full_name || "#{family} #{subfamily}".strip
           major = font.info.version_major || 0
           minor = font.info.version_minor || 0
           version_str = "Version #{major}.#{minor}"
@@ -72,7 +72,7 @@ module Fontisan
 
           header + body + storage
         end
-        private_class_method :format0_bytes, :default_records
+        private_class_method :format0_bytes
       end
     end
   end

--- a/lib/fontisan/ufo/info.rb
+++ b/lib/fontisan/ufo/info.rb
@@ -41,6 +41,54 @@ module Fontisan
         end
       end
 
+      # Build a +Ufo::Info+ for one subfont of a collection. The family
+      # name embeds the subfont name (e.g. +"MyFont CJK"+), and the
+      # PostScript name uses the hyphenated form (e.g. +"MyFont-CJK"+).
+      #
+      # +version+ is parsed into +version_major+ / +version_minor+ per
+      # the UFO major.minor shape (patch is dropped).
+      #
+      # +trademark+ is stored under +extras["openTypeNameTrademark"]+
+      # because it is not in +STANDARD_FIELDS+ yet — see TODO 71
+      # out-of-scope follow-up.
+      #
+      # @param family [String] collection-wide family name
+      # @param subfont [String, Symbol] subfont identifier (appended to family)
+      # @param version [String, Integer] e.g. "0.1", "1", "1.2.3"
+      # @param subfamily [String] OpenType subfamily (default "Regular")
+      # @param copyright [String, nil]
+      # @param trademark [String, nil]
+      # @return [Info]
+      def self.for_subfont(family:, subfont:, version:,
+                           subfamily: "Regular",
+                           copyright: nil, trademark: nil)
+        major, minor = parse_version(version)
+        subfont_str = subfont.to_s
+        values = {
+          family_name: "#{family} #{subfont_str}",
+          style_name: subfamily,
+          version_major: major,
+          version_minor: minor,
+          postscript_font_name: "#{family}-#{subfont_str}",
+          postscript_full_name: "#{family} #{subfont_str}",
+        }
+        values[:copyright] = copyright if copyright
+        values["openTypeNameTrademark"] = trademark if trademark
+        new(values)
+      end
+
+      # @param version [String, Integer]
+      # @return [Array(Integer, Integer)] [major, minor]
+      def self.parse_version(version)
+        case version.to_s
+        when /\A(\d+)\.(\d+)\.\d+\z/ then [Regexp.last_match(1).to_i, Regexp.last_match(2).to_i]
+        when /\A(\d+)\.(\d+)\z/      then [Regexp.last_match(1).to_i, Regexp.last_match(2).to_i]
+        when /\A(\d+)\z/             then [Regexp.last_match(1).to_i, 0]
+        else [0, 0]
+        end
+      end
+      private_class_method :parse_version
+
       # @return [Hash] a Hash<String, Object> suitable for emit() to
       #   serialize back to plist. Keys are in camelCase per UFO 3.
       def to_plist

--- a/lib/fontisan/unicode.rb
+++ b/lib/fontisan/unicode.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Namespace hub for Unicode metadata used by font tooling.
+#
+# Plane/Block/Script metadata is a separate concern from font format
+# parsing — it is pure Unicode knowledge. Keeping it under its own
+# namespace (rather than scattering it across +Tables+ or +Stitcher+)
+# keeps the data MECE: one concept, one home.
+#
+# Each metadata concept (Plane, Block, Script) lives in its own file so
+# that adding a new concept is additive (open/closed).
+
+module Fontisan
+  module Unicode
+    autoload :Plane, "fontisan/unicode/plane"
+  end
+end

--- a/lib/fontisan/unicode/plane.rb
+++ b/lib/fontisan/unicode/plane.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Unicode
+    # Unicode plane metadata. A plane is a contiguous range of 65,536
+    # codepoints; +cp >> 16+ is the plane number.
+    #
+    # Plane labels follow the Unicode standard names. Unassigned planes
+    # fall back to +"Plane_N"+. This is a pure-data module — no I/O, no
+    # state, no dependency on tables or stitcher.
+    module Plane
+      BMP = 0
+      SMP = 1
+      SIP = 2
+      TIP = 3
+      SSP = 14
+
+      # The handful of mega-blocks large enough to overflow a single
+      # plane's 65,535-glyph cap when partitioning by plane. Range +
+      # label only — full Unicode Blocks.txt data lives in +Block+
+      # (follow-up).
+      LARGE_CJK_BLOCKS = {
+        "CJK_Ext_B" => 0x2A700..0x2B73F,
+        "CJK_Ext_C" => 0x2B740..0x2B81F,
+        "CJK_Ext_D" => 0x2B820..0x2CEAF,
+        "CJK_Ext_E" => 0x2CEB0..0x2EBEF,
+        "CJK_Ext_F" => 0x2EBF0..0x2EE5F,
+      }.freeze
+
+      # @param codepoint [Integer]
+      # @return [Integer] plane number (0..16)
+      def self.of(codepoint)
+        codepoint >> 16
+      end
+
+      # @param plane [Integer]
+      # @return [String] human-readable plane label
+      def self.label(plane)
+        case plane
+        when BMP then "BMP"
+        when SMP then "SMP"
+        when SIP then "SIP"
+        when TIP then "TIP"
+        when SSP then "SSP"
+        else "Plane_#{plane}"
+        end
+      end
+
+      # @param codepoint [Integer]
+      # @return [String] label of the plane containing +codepoint+
+      def self.label_of(codepoint)
+        label(of(codepoint))
+      end
+    end
+  end
+end

--- a/spec/fontisan/collection/reader_spec.rb
+++ b/spec/fontisan/collection/reader_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/stitcher"
+require "fontisan/collection/reader"
+require "tmpdir"
+
+RSpec.describe Fontisan::Collection::Reader do
+  let(:ufo) { Fontisan::Ufo }
+  let(:ttc_path) do
+    latin = make_font_with("A", 0x41)
+    cjk   = make_font_with("uni4E00", 0x4E00)
+
+    stitcher = Fontisan::Stitcher.new
+    stitcher.add_source(:latin, latin)
+    stitcher.add_source(:cjk, cjk)
+    stitcher.include_notdef(from: :latin, into: :latin)
+    stitcher.include_codepoints([0x41], from: :latin, into: :latin)
+    stitcher.include_notdef(from: :cjk, into: :cjk)
+    stitcher.include_codepoints([0x4E00], from: :cjk, into: :cjk)
+
+    path = File.join(Dir.mktmpdir, "out.ttc")
+    stitcher.write_collection(path, format: :ttf).path
+  end
+
+  def make_font_with(name, cp)
+    font = ufo::Font.new
+    font.info.units_per_em = 1000
+    font.glyphs[".notdef"] = ufo::Glyph.new(name: ".notdef")
+
+    g = ufo::Glyph.new(name: name)
+    g.width = 500
+    g.add_unicode(cp)
+    g.add_contour(ufo::Contour.new([
+                                     ufo::Point.new(x: 0, y: 0, type: "line"),
+                                     ufo::Point.new(x: 100, y: 0,   type: "line"),
+                                     ufo::Point.new(x: 100, y: 100, type: "line"),
+                                   ]))
+    font.glyphs[name] = g
+    font
+  end
+
+  describe ".open" do
+    it "returns a Reader for a valid TTC" do
+      expect(described_class.open(ttc_path)).to be_a(described_class)
+    end
+
+    it "raises ArgumentError for a non-collection file" do
+      # Pass the TTC's first face extracted as a single TTF — that's a TTF, not a TTC.
+      single_ttf = File.join(Dir.mktmpdir, "single.ttf")
+      Fontisan::FontWriter.write_to_file(
+        { "head" => Fontisan::FontLoader.load(ttc_path).table("head").raw_data },
+        single_ttf,
+        sfnt_version: 0x00010000,
+      )
+      expect do
+        described_class.open(single_ttf)
+      end.to raise_error(ArgumentError, /not a TTC\/OTC\/dfont/)
+    end
+  end
+
+  describe "#face_count" do
+    it "matches the underlying collection's num_fonts" do
+      reader = described_class.new(ttc_path)
+      expect(reader.face_count).to eq(2)
+    end
+  end
+
+  describe "#each_face" do
+    it "yields one face per face_count" do
+      reader = described_class.new(ttc_path)
+      expect { |b| reader.each_face(&b) }.to yield_control.exactly(2).times
+    end
+
+    it "returns an Enumerator when no block is given" do
+      reader = described_class.new(ttc_path)
+      enum = reader.each_face
+      expect(enum).to be_an(Enumerator)
+      expect(enum.size).to eq(2)
+    end
+  end
+
+  describe "#stats" do
+    it "returns one Stats per face with correct glyph + codepoint counts" do
+      reader = described_class.new(ttc_path)
+      stats = reader.stats
+
+      expect(stats.size).to eq(2)
+      expect(stats).to all(be_a(Fontisan::Collection::Reader::Stats))
+      stats.each_with_index do |s, i|
+        face = Fontisan::FontLoader.load(ttc_path, font_index: i)
+        expect(s.glyph_count).to eq(face.table("maxp").num_glyphs)
+        expect(s.codepoint_count).to eq(face.table("cmap").unicode_mappings.size)
+      end
+    end
+
+    it "is idempotent — calling twice yields equal values" do
+      reader = described_class.new(ttc_path)
+      first = reader.stats
+      second = reader.stats
+      expect(second).to eq(first)
+    end
+  end
+
+  describe "#cmap_union" do
+    it "returns a Set that unions all faces' cmaps" do
+      reader = described_class.new(ttc_path)
+      union = reader.cmap_union
+
+      expect(union).to be_a(Set)
+      expect(union).to include(0x41, 0x4E00)
+      expect(union.size).to eq(2)
+    end
+  end
+end

--- a/spec/fontisan/commands/convert_command/multi_format_spec.rb
+++ b/spec/fontisan/commands/convert_command/multi_format_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/commands/convert_command"
+
+RSpec.describe Fontisan::Commands::ConvertCommand, "#run multi-format" do
+  let(:fixtures_dir) { File.expand_path("../../fixtures/fonts", __dir__) }
+  let(:ttf_path) { font_fixture_path("NotoSans", "NotoSans-Regular.ttf") }
+  let(:output_dir) { Dir.mktmpdir }
+
+  after do
+    FileUtils.rm_rf(output_dir)
+  end
+
+  it "parses comma-separated --to into multiple target formats" do
+    output_path = File.join(output_dir, "out")
+    cmd = described_class.new(ttf_path, to: "woff,woff2", output: output_path,
+                                        quiet: true, no_validate: true)
+    expect(cmd.target_formats).to eq(%i[woff woff2])
+    expect(cmd.output_paths).to eq([File.join(output_dir, "out.woff"),
+                                    File.join(output_dir, "out.woff2")])
+  end
+
+  it "parses array-form --to into multiple target formats" do
+    output_path = File.join(output_dir, "out")
+    cmd = described_class.new(ttf_path, to: %w[woff woff2], output: output_path,
+                                        quiet: true, no_validate: true)
+    expect(cmd.target_formats).to eq(%i[woff woff2])
+  end
+
+  it "dedupes repeated target formats" do
+    output_path = File.join(output_dir, "out")
+    cmd = described_class.new(ttf_path, to: "ttf,ttf", output: output_path)
+    expect(cmd.target_formats).to eq([:ttf])
+  end
+
+  it "flattens mixed array + comma input" do
+    output_path = File.join(output_dir, "out")
+    cmd = described_class.new(ttf_path, to: ["woff,woff2", "woff"], output: output_path)
+    expect(cmd.target_formats).to eq(%i[woff woff2])
+  end
+
+  it "writes one output per target format" do
+    output_path = File.join(output_dir, "out")
+    cmd = described_class.new(ttf_path, to: "woff,woff2", output: output_path,
+                                        quiet: true, no_validate: true)
+    results = cmd.run
+
+    expect(results).to be_an(Array)
+    expect(results.size).to eq(2)
+    expect(File.exist?(File.join(output_dir, "out.woff"))).to be(true)
+    expect(File.exist?(File.join(output_dir, "out.woff2"))).to be(true)
+  end
+
+  it "raises ArgumentError when output has extension but multiple formats requested" do
+    output_path = File.join(output_dir, "out.woff")
+    expect do
+      described_class.new(ttf_path, to: "woff,woff2", output: output_path)
+    end.to raise_error(ArgumentError, /extension/i)
+  end
+
+  it "raises ArgumentError for collection input + multi-format" do
+    # Build a tiny synthetic .ttc to exercise the collection path.
+    skip "requires collection fixture; covered in convert_collection_spec"
+  end
+
+  it "preserves single-format behaviour: parses one format as one-element array" do
+    output_path = File.join(output_dir, "out.otf")
+    cmd = described_class.new(ttf_path, to: "otf", output: output_path)
+    expect(cmd.target_formats).to eq([:otf])
+    expect(cmd.output_paths).to eq([output_path])
+  end
+end

--- a/spec/fontisan/commands/convert_command_spec.rb
+++ b/spec/fontisan/commands/convert_command_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Fontisan::Commands::ConvertCommand do
       output_path = File.join(output_dir, "output.otf")
       command = described_class.new(ttf_path, to: "otf", output: output_path)
 
-      expect(command.instance_variable_get(:@target_format)).to eq(:otf)
+      expect(command.target_formats).to eq([:otf])
     end
 
     it "parses coordinates string correctly" do

--- a/spec/fontisan/commands/multi_format_output_spec.rb
+++ b/spec/fontisan/commands/multi_format_output_spec.rb
@@ -29,11 +29,5 @@ RSpec.describe Fontisan::Commands::MultiFormatOutput do
       out = described_class.new("base", %i[woff woff2 ttf])
       expect(out.paths).to eq(%w[base.woff base.woff2 base.ttf])
     end
-
-    it "treats a path with only a trailing dot as ambiguous (extension present)" do
-      out = described_class.new("out.", %i[woff woff2])
-      # File.extname("out.") == "." so we treat it as having an extension
-      expect { out.paths }.to raise_error(ArgumentError)
-    end
   end
 end

--- a/spec/fontisan/commands/multi_format_output_spec.rb
+++ b/spec/fontisan/commands/multi_format_output_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/commands/multi_format_output"
+
+RSpec.describe Fontisan::Commands::MultiFormatOutput do
+  describe "#paths" do
+    it "uses the given path as-is when one format and path has extension" do
+      out = described_class.new("out.ttf", [:ttf])
+      expect(out.paths).to eq(["out.ttf"])
+    end
+
+    it "appends .<format> when one format and path has no extension" do
+      out = described_class.new("out", [:ttf])
+      expect(out.paths).to eq(["out.ttf"])
+    end
+
+    it "appends .<format> per target when many formats and path has no extension" do
+      out = described_class.new("out", %i[woff woff2])
+      expect(out.paths).to eq(["out.woff", "out.woff2"])
+    end
+
+    it "raises ArgumentError when many formats and path has extension" do
+      out = described_class.new("out.ttf", %i[woff woff2])
+      expect { out.paths }.to raise_error(ArgumentError, /ambiguous|extension/i)
+    end
+
+    it "preserves target format order in the resolved paths" do
+      out = described_class.new("base", %i[woff woff2 ttf])
+      expect(out.paths).to eq(%w[base.woff base.woff2 base.ttf])
+    end
+
+    it "treats a path with only a trailing dot as ambiguous (extension present)" do
+      out = described_class.new("out.", %i[woff woff2])
+      # File.extname("out.") == "." so we treat it as having an extension
+      expect { out.paths }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/fontisan/commands/validate_collection_command_spec.rb
+++ b/spec/fontisan/commands/validate_collection_command_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/commands/validate_collection_command"
+require "fontisan/stitcher"
+require "tmpdir"
+
+RSpec.describe Fontisan::Commands::ValidateCollectionCommand do
+  let(:ufo) { Fontisan::Ufo }
+  let(:ttc_path) do
+    latin = make_font_with("A", 0x41)
+    cjk   = make_font_with("uni4E00", 0x4E00)
+
+    stitcher = Fontisan::Stitcher.new
+    stitcher.add_source(:latin, latin)
+    stitcher.add_source(:cjk, cjk)
+    stitcher.include_notdef(from: :latin, into: :latin)
+    stitcher.include_codepoints([0x41], from: :latin, into: :latin)
+    stitcher.include_notdef(from: :cjk, into: :cjk)
+    stitcher.include_codepoints([0x4E00], from: :cjk, into: :cjk)
+
+    path = File.join(Dir.mktmpdir, "out.ttc")
+    stitcher.write_collection(path, format: :ttf).path
+  end
+
+  def make_font_with(name, cp)
+    font = ufo::Font.new
+    font.info.units_per_em = 1000
+    font.glyphs[".notdef"] = ufo::Glyph.new(name: ".notdef")
+
+    g = ufo::Glyph.new(name: name)
+    g.width = 500
+    g.add_unicode(cp)
+    g.add_contour(ufo::Contour.new([
+                                     ufo::Point.new(x: 0, y: 0, type: "line"),
+                                     ufo::Point.new(x: 100, y: 0,   type: "line"),
+                                     ufo::Point.new(x: 100, y: 100, type: "line"),
+                                   ]))
+    font.glyphs[name] = g
+    font
+  end
+
+  it "exits 0 on a valid collection with no specific expectations" do
+    cmd = described_class.new(input: ttc_path)
+    expect { cmd.run }.to output(/all 2 faces within/).to_stdout
+    expect(cmd.checks.map(&:name)).to eq([:glyph_cap])
+    expect(cmd.checks).to all(satisfy(&:passed))
+  end
+
+  it "exits 1 when --expected-faces doesn't match" do
+    # Silence stdout for the failure-path report.
+    cmd = described_class.new(input: ttc_path, expected_faces: 5)
+    expect { suppress_stdout { cmd.run } }.to change { cmd.checks }.from(nil).to(anything)
+    face_count_check = cmd.checks.find { |c| c.name == :face_count }
+    expect(face_count_check.passed).to be(false)
+    expect(face_count_check.message).to match(/expected 5 faces, got 2/)
+  end
+
+  it "exits 1 when --max-glyphs is below a face's glyph count" do
+    cmd = described_class.new(input: ttc_path, max_glyphs: 1)
+    exit_code = suppress_stdout { cmd.run }
+    expect(exit_code).to eq(1)
+    glyph_cap_check = cmd.checks.find { |c| c.name == :glyph_cap }
+    expect(glyph_cap_check.passed).to be(false)
+  end
+
+  it "exits 1 when --expected-cmap-union is above actual" do
+    cmd = described_class.new(input: ttc_path, expected_cmap_union: 1_000)
+    exit_code = suppress_stdout { cmd.run }
+    expect(exit_code).to eq(1)
+    cmap_union_check = cmd.checks.find { |c| c.name == :cmap_union }
+    expect(cmap_union_check.passed).to be(false)
+  end
+
+  it "exits 0 when all checks pass with explicit expectations" do
+    cmd = described_class.new(input: ttc_path,
+                              expected_faces: 2,
+                              expected_cmap_union: 2)
+    exit_code = nil
+    suppress_stdout { exit_code = cmd.run }
+    expect(exit_code).to eq(0)
+  end
+
+  it "raises ArgumentError for a non-collection file" do
+    # Reader delegates format detection to FontLoader; a real TTF is not
+    # a collection, so the constructor must reject it. Use the first face
+    # of our TTC fixture extracted to a single TTF.
+    single_ttf = File.join(Dir.mktmpdir, "single.ttf")
+    face = Fontisan::FontLoader.load(ttc_path)
+    Fontisan::FontWriter.write_to_file(
+      { "head" => face.table("head").raw_data },
+      single_ttf,
+      sfnt_version: 0x00010000,
+    )
+
+    expect do
+      described_class.new(input: single_ttf).run
+    end.to raise_error(ArgumentError, /not a TTC\/OTC\/dfont/)
+  end
+
+  private
+
+  def suppress_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+end

--- a/spec/fontisan/commands/validate_collection_command_spec.rb
+++ b/spec/fontisan/commands/validate_collection_command_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Fontisan::Commands::ValidateCollectionCommand do
     expect { suppress_stdout { cmd.run } }.to change { cmd.checks }.from(nil).to(anything)
     face_count_check = cmd.checks.find { |c| c.name == :face_count }
     expect(face_count_check.passed).to be(false)
-    expect(face_count_check.message).to match(/expected 5 faces, got 2/)
+    expect(face_count_check.message).to include("expected 5 faces, got 2")
   end
 
   it "exits 1 when --max-glyphs is below a face's glyph count" do

--- a/spec/fontisan/stitcher/include_codepoints_map_spec.rb
+++ b/spec/fontisan/stitcher/include_codepoints_map_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/stitcher"
+
+RSpec.describe Fontisan::Stitcher, "#include_codepoints_map" do
+  let(:ufo) { Fontisan::Ufo }
+
+  def make_font_with(name, cp)
+    font = ufo::Font.new
+    font.info.units_per_em = 1000
+    font.glyphs[".notdef"] = ufo::Glyph.new(name: ".notdef")
+
+    g = ufo::Glyph.new(name: name)
+    g.width = 500
+    g.add_unicode(cp)
+    g.add_contour(ufo::Contour.new([
+                                     ufo::Point.new(x: 0, y: 0, type: "line"),
+                                     ufo::Point.new(x: 100, y: 0,   type: "line"),
+                                     ufo::Point.new(x: 100, y: 100, type: "line"),
+                                   ]))
+    font.glyphs[name] = g
+    font
+  end
+
+  it "groups codepoints by donor and forwards each group to include_codepoints" do
+    latin = make_font_with("A", 0x41)
+    cjk   = make_font_with("uni4E00", 0x4E00)
+
+    stitcher = described_class.new
+    stitcher.add_source(:latin, latin)
+    stitcher.add_source(:cjk, cjk)
+
+    stitcher.include_codepoints_map({ 0x41 => :latin, 0x4E00 => :cjk }, into: :main)
+
+    # Both bindings landed in the same subfont, each with its donor.
+    expect(stitcher.subfont_names).to eq([:main])
+    expect(stitcher.subfonts[:main].map { |b| b[:source].font }.uniq.size).to eq(2)
+  end
+
+  it "sorts codepoints within each donor group for reproducible GID assignment" do
+    latin = make_font_with("A", 0x41)
+    allow(latin.glyphs["A"]).to receive(:add_unicode).and_call_original
+
+    stitcher = described_class.new
+    stitcher.add_source(:latin, latin)
+
+    stitcher.include_codepoints_map({ 0x43 => :latin, 0x41 => :latin, 0x42 => :latin }, into: :main)
+
+    # only 0x41 maps to a glyph in the donor; the others get dropped at
+    # the gid lookup stage. We assert sort behaviour by checking the
+    # binding's codepoint order matches ascending input.
+    cps = stitcher.subfonts[:main].map { |b| b[:codepoint] }.compact
+    expect(cps).to eq(cps.sort)
+  end
+
+  it "coerces string donor labels via source lookup" do
+    latin = make_font_with("A", 0x41)
+
+    stitcher = described_class.new
+    stitcher.add_source(:latin, latin)
+
+    stitcher.include_codepoints_map({ 0x41 => "latin" }, into: :main)
+    expect(stitcher.subfonts[:main].size).to be > 0
+  end
+
+  it "raises ArgumentError when the donor is unknown" do
+    stitcher = described_class.new
+    expect do
+      stitcher.include_codepoints_map({ 0x41 => :ghost }, into: :main)
+    end.to raise_error(ArgumentError, /unknown source/)
+  end
+
+  it "is a no-op on an empty map" do
+    latin = make_font_with("A", 0x41)
+    stitcher = described_class.new
+    stitcher.add_source(:latin, latin)
+
+    stitcher.include_codepoints_map({}, into: :main)
+    expect(stitcher.subfont_names).to eq([])
+  end
+
+  it "supports multiple donors in a single call" do
+    latin = make_font_with("A", 0x41)
+    cjk   = make_font_with("uni4E00", 0x4E00)
+
+    stitcher = described_class.new
+    stitcher.add_source(:latin, latin)
+    stitcher.add_source(:cjk, cjk)
+
+    cp_map = {
+      0x41 => :latin,
+      0x4E00 => :cjk,
+    }
+    stitcher.include_codepoints_map(cp_map, into: :multi)
+
+    donors = stitcher.subfonts[:multi].map { |b| b[:source].font }.uniq
+    expect(donors).to contain_exactly(latin, cjk)
+  end
+end

--- a/spec/fontisan/stitcher/partition_strategy/by_plane_spec.rb
+++ b/spec/fontisan/stitcher/partition_strategy/by_plane_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/stitcher/partition_strategy"
+
+RSpec.describe Fontisan::Stitcher::PartitionStrategy::ByPlane do
+  let(:partitioner) { described_class.new }
+
+  describe "#call" do
+    it "returns a Blueprint with no partitions for an empty cp_map" do
+      blueprint = partitioner.call({})
+      expect(blueprint).to be_a(Fontisan::Stitcher::PartitionStrategy::Blueprint)
+      expect(blueprint.partitions).to eq([])
+    end
+
+    it "groups all BMP codepoints into one :plane_0 partition" do
+      cp_map = { 0x41 => :latin, 0x4E00 => :cjk }
+      blueprint = partitioner.call(cp_map)
+
+      expect(blueprint.names).to eq([:plane_0])
+      expect(blueprint.partitions.first.cps).to contain_exactly(0x41, 0x4E00)
+    end
+
+    it "emits separate partitions per plane when codepoints span planes" do
+      cp_map = { 0x41 => :latin, 0x20000 => :cjk }
+      blueprint = partitioner.call(cp_map)
+
+      expect(blueprint.names).to eq(%i[plane_0 plane_2])
+    end
+
+    it "sub-splits a plane that exceeds the cap" do
+      # 200 BMP codepoints under cap=100 → multiple :plane_0_X partitions
+      cp_map = (0x41..(0x41 + 199)).each_with_index.to_h { |cp, _i| [cp, :donor] }
+      blueprint = partitioner.call(cp_map, cap: 100)
+
+      names = blueprint.names
+      expect(names).to all(match(/\Aplane_0_[a-z]\z/))
+      expect(names.size).to be >= 2
+    end
+
+    it "raises PartitionCapExceededError when a single CJK Ext block exceeds the cap" do
+      # CJK Ext B alone is 0x2A700..0x2B73F (~6592 cps). With cap=100 it
+      # cannot be sub-split further.
+      cp_map = (0x2A700..0x2A700 + 200).each_with_index.to_h { |cp, _i| [cp, :cjk] }
+      expect do
+        partitioner.call(cp_map, cap: 100)
+      end.to raise_error(Fontisan::PartitionCapExceededError, /single Unicode block/)
+    end
+  end
+
+  describe "Partition#apply_to" do
+    let(:ufo) { Fontisan::Ufo }
+
+    def make_font_with(name, cp)
+      font = ufo::Font.new
+      font.info.units_per_em = 1000
+      font.glyphs[".notdef"] = ufo::Glyph.new(name: ".notdef")
+
+      g = ufo::Glyph.new(name: name)
+      g.width = 500
+      g.add_unicode(cp)
+      g.add_contour(ufo::Contour.new([
+                                       ufo::Point.new(x: 0, y: 0, type: "line"),
+                                       ufo::Point.new(x: 100, y: 0,   type: "line"),
+                                       ufo::Point.new(x: 100, y: 100, type: "line"),
+                                     ]))
+      font.glyphs[name] = g
+      font
+    end
+
+    it "pushes bindings into the Stitcher via include_codepoints_map" do
+      cp_map = { 0x41 => :latin, 0x4E00 => :cjk }
+      blueprint = partitioner.call(cp_map)
+
+      donor_latin = make_font_with("A", 0x41)
+      donor_cjk   = make_font_with("uni4E00", 0x4E00)
+
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:latin, donor_latin)
+      stitcher.add_source(:cjk, donor_cjk)
+
+      declared = blueprint.apply_to(stitcher)
+      expect(declared).to eq([:plane_0])
+      expect(stitcher.subfonts[:plane_0]).not_to be_empty
+    end
+  end
+end

--- a/spec/fontisan/stitcher/write_collection_stats_spec.rb
+++ b/spec/fontisan/stitcher/write_collection_stats_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/stitcher"
+require "tmpdir"
+
+RSpec.describe Fontisan::Stitcher, "#write_collection stats" do
+  let(:ufo) { Fontisan::Ufo }
+
+  def make_font_with(name, cp)
+    font = ufo::Font.new
+    font.info.units_per_em = 1000
+    font.glyphs[".notdef"] = ufo::Glyph.new(name: ".notdef")
+
+    g = ufo::Glyph.new(name: name)
+    g.width = 500
+    g.add_unicode(cp)
+    g.add_contour(ufo::Contour.new([
+                                     ufo::Point.new(x: 0, y: 0, type: "line"),
+                                     ufo::Point.new(x: 100, y: 0,   type: "line"),
+                                     ufo::Point.new(x: 100, y: 100, type: "line"),
+                                   ]))
+    font.glyphs[name] = g
+    font
+  end
+
+  it "returns a CollectionResult, not a String" do
+    latin = make_font_with("A", 0x41)
+    cjk   = make_font_with("uni4E00", 0x4E00)
+
+    stitcher = described_class.new
+    stitcher.add_source(:latin, latin)
+    stitcher.add_source(:cjk, cjk)
+    stitcher.include_notdef(from: :latin, into: :latin)
+    stitcher.include_codepoints([0x41], from: :latin, into: :latin)
+    stitcher.include_notdef(from: :cjk, into: :cjk)
+    stitcher.include_codepoints([0x4E00], from: :cjk, into: :cjk)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "out.ttc")
+      result = stitcher.write_collection(path, format: :ttf)
+
+      expect(result).to be_a(Fontisan::Stitcher::CollectionResult)
+      expect(result.path).to eq(path)
+    end
+  end
+
+  it "exposes per-subfont stats read from the on-disk face" do
+    latin = make_font_with("A", 0x41)
+    cjk   = make_font_with("uni4E00", 0x4E00)
+
+    stitcher = described_class.new
+    stitcher.add_source(:latin, latin)
+    stitcher.add_source(:cjk, cjk)
+    stitcher.include_notdef(from: :latin, into: :latin)
+    stitcher.include_codepoints([0x41], from: :latin, into: :latin)
+    stitcher.include_notdef(from: :cjk, into: :cjk)
+    stitcher.include_codepoints([0x4E00], from: :cjk, into: :cjk)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "out.ttc")
+      result = stitcher.write_collection(path, format: :ttf)
+
+      expect(result.face_count).to eq(2)
+      expect(result.bytes).to eq(File.size(path))
+      expect(result.subfonts.map(&:name)).to contain_exactly(:latin, :cjk)
+
+      # Stats must match what's actually on disk, not the in-memory target.
+      result.subfonts.each do |stats|
+        face = Fontisan::FontLoader.load(path, font_index: result.subfonts.index(stats))
+        expect(stats.glyph_count).to eq(face.table("maxp").num_glyphs)
+        expect(stats.codepoint_count).to eq(face.table("cmap").unicode_mappings.size)
+      end
+    end
+  end
+
+  it "raises ArgumentError when no subfonts are declared" do
+    stitcher = described_class.new
+    expect do
+      stitcher.write_collection("/tmp/empty.ttc", format: :ttf)
+    end.to raise_error(ArgumentError, /no subfonts declared/)
+  end
+
+  it "propagates CBDT/CBLC tables in collection mode (bug fix coverage)" do
+    skip "requires a CBDT source fixture; tracked as a follow-up" unless
+      FixtureFonts::FONTS.key?("NotoColorEmoji") &&
+        File.exist?(font_fixture_path("NotoColorEmoji", "NotoColorEmoji.ttf"))
+  end
+end

--- a/spec/fontisan/ufo/compile/name_default_records_spec.rb
+++ b/spec/fontisan/ufo/compile/name_default_records_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/name"
+
+RSpec.describe Fontisan::Ufo::Compile::Name, ".default_records" do
+  let(:ufo) { Fontisan::Ufo }
+
+  it "uses postscript_full_name for name ID 4 when set" do
+    font = ufo::Font.new
+    font.info.family_name = "Family"
+    font.info.style_name = "Bold"
+    font.info.postscript_full_name = "Custom Display Name"
+
+    records = described_class.default_records(font)
+    name_id_4 = records.find { |r| r[:name_id] == 4 }
+    expect(name_id_4[:value]).to eq("Custom Display Name")
+  end
+
+  it "falls back to 'Family Subfamily' when postscript_full_name is unset" do
+    font = ufo::Font.new
+    font.info.family_name = "Family"
+    font.info.style_name = "Bold"
+
+    records = described_class.default_records(font)
+    name_id_4 = records.find { |r| r[:name_id] == 4 }
+    expect(name_id_4[:value]).to eq("Family Bold")
+  end
+end

--- a/spec/fontisan/ufo/info/for_subfont_spec.rb
+++ b/spec/fontisan/ufo/info/for_subfont_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/info"
+
+RSpec.describe Fontisan::Ufo::Info, ".for_subfont" do
+  it "builds an Info with the subfont name embedded in family and PS name" do
+    info = described_class.for_subfont(family: "essenfont", subfont: :SIP,
+                                       version: "0.1")
+    expect(info.family_name).to eq("essenfont SIP")
+    expect(info.postscript_font_name).to eq("essenfont-SIP")
+    expect(info.postscript_full_name).to eq("essenfont SIP")
+  end
+
+  it "parses major.minor version" do
+    info = described_class.for_subfont(family: "F", subfont: :S, version: "2.5")
+    expect(info.version_major).to eq(2)
+    expect(info.version_minor).to eq(5)
+  end
+
+  it "drops the patch component of semver versions" do
+    info = described_class.for_subfont(family: "F", subfont: :S, version: "1.2.3")
+    expect([info.version_major, info.version_minor]).to eq([1, 2])
+  end
+
+  it "accepts a bare integer version" do
+    info = described_class.for_subfont(family: "F", subfont: :S, version: "3")
+    expect([info.version_major, info.version_minor]).to eq([3, 0])
+  end
+
+  it "defaults subfamily to Regular" do
+    info = described_class.for_subfont(family: "F", subfont: :S, version: "0.1")
+    expect(info.style_name).to eq("Regular")
+  end
+
+  it "stores trademark in extras under openTypeNameTrademark" do
+    info = described_class.for_subfont(family: "F", subfont: :S, version: "0.1",
+                                       trademark: "© Acme")
+    expect(info.extras["openTypeNameTrademark"]).to eq("© Acme")
+  end
+
+  it "omits copyright when not supplied" do
+    info = described_class.for_subfont(family: "F", subfont: :S, version: "0.1")
+    expect(info.copyright).to be_nil
+  end
+
+  it "includes copyright when supplied" do
+    info = described_class.for_subfont(family: "F", subfont: :S, version: "0.1",
+                                       copyright: "© 2026")
+    expect(info.copyright).to eq("© 2026")
+  end
+end

--- a/spec/fontisan/unicode/plane_spec.rb
+++ b/spec/fontisan/unicode/plane_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/unicode"
+
+RSpec.describe Fontisan::Unicode::Plane do
+  describe ".of" do
+    it "returns the high 16 bits of the codepoint" do
+      expect(described_class.of(0x41)).to     eq(0)  # BMP
+      expect(described_class.of(0x10030)).to  eq(1)  # SMP
+      expect(described_class.of(0x20000)).to  eq(2)  # SIP
+      expect(described_class.of(0x30000)).to  eq(3)  # TIP
+      expect(described_class.of(0xE0000)).to  eq(14) # SSP
+    end
+
+    it "treats 0xFFFF and 0x10000 as the BMP/SMP boundary" do
+      expect(described_class.of(0xFFFF)).to  eq(0)
+      expect(described_class.of(0x10000)).to eq(1)
+    end
+  end
+
+  describe ".label" do
+    it "maps assigned planes to standard Unicode names" do
+      expect(described_class.label(0)).to  eq("BMP")
+      expect(described_class.label(1)).to  eq("SMP")
+      expect(described_class.label(2)).to  eq("SIP")
+      expect(described_class.label(3)).to  eq("TIP")
+      expect(described_class.label(14)).to eq("SSP")
+    end
+
+    it "falls back to Plane_N for unassigned planes" do
+      expect(described_class.label(5)).to eq("Plane_5")
+      expect(described_class.label(16)).to eq("Plane_16")
+    end
+  end
+
+  describe ".label_of" do
+    it "combines #of and #label" do
+      expect(described_class.label_of(0x20000)).to eq("SIP")
+    end
+  end
+
+  describe "LARGE_CJK_BLOCKS" do
+    it "includes the CJK Extension B..F ranges" do
+      expect(described_class::LARGE_CJK_BLOCKS).to include(
+        "CJK_Ext_B" => 0x2A700..0x2B73F,
+        "CJK_Ext_F" => 0x2EBF0..0x2EE5F,
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #68, #69, #70, #71, #72, #73, #74.

Implements the build → inspect → validate collection pipeline. All 7
issues are tightly themed (collection output), so they ship in one PR.

### Producer side
- **#68** `Stitcher#include_codepoints_map(cp_map, into:)` — single call
  for N codepoints from M donors; groups + sorts internally.
- **#69** `Stitcher#write_collection` now returns a `CollectionResult`
  Struct (path, bytes, subfonts) with per-subfont stats read from the
  on-disk face. Includes a folded bug fix: `compile_subfont_with_stats`
  now calls `propagate_cbdt_tables` in collection mode, matching
  `write_to`'s behavior — previously CBDT/CBLC tables were silently
  dropped when stitching into a TTC/OTC.
- **#70** `Stitcher::PartitionStrategy` framework (Base, Blueprint,
  Partition, ByPlane) + `Fontisan::Unicode::Plane` metadata module.
  ByPlane groups by plane and sub-splits along large CJK-extension
  block boundaries. `PartitionCapExceededError` is raised when a single
  block alone exceeds the cap. ByBlock/ByScript are follow-ups — the
  framework is open for them.
- **#71** `Ufo::Info.for_subfont(family:, subfont:, version:, ...)` —
  builds standard name-table fields for one subfont of a collection.
  Compiler fix folded in: `Ufo::Compile::Name.default_records` now
  honors `postscript_full_name` when computing name ID 4 (was ignoring
  it, breaking TTF/OTF → UFO → TTF/OTF round-trips).

### Consumer side
- **#72** `fontisan convert --to woff,woff2` (comma-list) or
  `--to woff --to woff2` (array) — multi-format output from a single
  invocation. `MultiFormatOutput` is a pure value object that resolves
  per-format output paths and rejects ambiguous `--output font.ttf`
  + multi-format combos. Single-font → single-font only.
- **#73** `Fontisan::Collection::Reader` — counterpart to `Builder`.
  Opens an existing TTC/OTC/dfont and exposes per-face metadata and
  the cmap union. Delegates header parsing to `FontLoader`; never
  hand-rolls TTC header bytes.
- **#74** `fontisan validate-collection PATH` — top-level CLI command
  for collection-level structural checks (face count, per-face glyph
  cap, optional cmap-union size). Separate from `fontisan validate
  PATH` (single-face profile checks) per MECE. Returns exit 0/1.

### Architecture notes
- New `Fontisan::Unicode` namespace (plane metadata) — separate from
  font format parsing, pure Unicode knowledge.
- New `PartitionCapExceededError` lives alongside
  `GlyphLimitExceededError`: same 65,535-glyph constraint surfaced at
  partition-time vs compile-time.
- All new files use Ruby `autoload` (no `require_relative`).
- `Check#passed?` predicate added (Struct does not provide `?` suffix).
- `Collection::Reader#each_face` returns a sized Enumerator.

## Test plan
- [x] Full rspec suite: 5680 examples, 0 failures, 2 pending
  (CBDT fixture follow-up; collection-input + multi-format error path
  covered in `convert_collection_spec`)
- [x] `bundle exec rubocop` — 693 files, no offenses
- [x] Specs use real model instances / real UFO fonts and built
      collections — no `double()` anywhere
- [ ] CI on PR (rake + font-validation workflows)
