### PR TITLE
sfnt/svg/stitcher: from_tables encoding, per-glyph SVG attributes, add_source remap (fixes #79, #80, #81)

### DIFF
--- a/lib/fontisan/converters/svg_generator.rb
+++ b/lib/fontisan/converters/svg_generator.rb
@@ -145,7 +145,7 @@ palette_index: 0)
       #
       # @param font [TrueTypeFont, OpenTypeFont] Source font
       # @param options [Hash] Extraction options
-      # @return [Hash] Glyph data map (glyph_id => {outline, unicode, name, advance})
+      # @return [Hash] Glyph data map (glyph_id => {outline, codepoints, name, advance})
       def extract_glyph_data(font, options = {})
         extractor = OutlineExtractor.new(font)
         cmap = font.table("cmap")
@@ -157,33 +157,20 @@ palette_index: 0)
         num_glyphs = maxp&.num_glyphs || 0
         max_glyphs = options[:max_glyphs] || num_glyphs
 
-        # Get unicode mappings
-        unicode_map = build_unicode_map(cmap)
+        gid_to_codepoints = build_glyph_to_codepoints(cmap)
+        glyph_names = post&.glyph_names || []
 
-        # Extract specified or all glyphs
         glyph_ids = options[:glyph_ids] || (0...num_glyphs).to_a
         glyph_ids = glyph_ids.take(max_glyphs) if max_glyphs
 
         glyph_ids.each do |glyph_id|
           next if glyph_id >= num_glyphs
 
-          # Extract outline
-          outline = extractor.extract(glyph_id)
-
-          # Get advance width
-          advance = extract_advance_width(hmtx, glyph_id)
-
-          # Get unicode character
-          unicode = unicode_map[glyph_id]
-
-          # Get glyph name
-          glyph_name = extract_glyph_name(post, glyph_id)
-
           glyph_data[glyph_id] = {
-            outline: outline,
-            unicode: unicode,
-            name: glyph_name,
-            advance: advance,
+            outline: extractor.extract(glyph_id),
+            codepoints: gid_to_codepoints[glyph_id] || [],
+            name: glyph_name_for(glyph_names, glyph_id),
+            advance: extract_advance_width(hmtx, glyph_id),
           }
         rescue StandardError => e
           warn "Failed to extract glyph #{glyph_id}: #{e.message}"
@@ -193,61 +180,38 @@ palette_index: 0)
         glyph_data
       end
 
-      # Build unicode to glyph ID map from cmap table
+      # Build reverse cmap: glyph_id => [codepoint, ...].
       #
-      # @param cmap [Tables::Cmap, nil] Cmap table
-      # @return [Hash<Integer, String>] Map of glyph_id to unicode character
-      def build_unicode_map(cmap)
+      # A glyph can be referenced by multiple codepoints (e.g. space
+      # and non-breaking space might share a glyph). Uses
+      # +cmap.unicode_mappings+ directly — that is the canonical
+      # {codepoint => gid} hash.
+      #
+      # @param cmap [Tables::Cmap, nil]
+      # @return [Hash<Integer, Array<Integer>>]
+      def build_glyph_to_codepoints(cmap)
         return {} unless cmap
 
-        unicode_map = {}
-
-        # Get best cmap subtable (prefer Unicode BMP or full)
-        subtable = find_best_cmap_subtable(cmap)
-        return {} unless subtable
-
-        # Build reverse map: glyph_id => unicode
-        subtable.each do |code_point, glyph_id|
-          # Store first unicode for each glyph
-          next if unicode_map[glyph_id]
-
-          unicode_map[glyph_id] = [code_point].pack("U")
-        rescue StandardError
-          # Skip invalid code points
-          next
+        cmap.unicode_mappings.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(cp, gid), h|
+          h[gid] << cp
         end
-
-        unicode_map
       rescue StandardError => e
-        warn "Failed to build unicode map: #{e.message}"
+        warn "Failed to build glyph to codepoints map: #{e.message}"
         {}
       end
 
-      # Find best cmap subtable for unicode mapping
+      # Look up glyph name from the post table's per-gid name array.
       #
-      # @param cmap [Tables::Cmap] Cmap table
-      # @return [Hash, nil] Subtable or nil
-      def find_best_cmap_subtable(cmap)
-        # Try Unicode BMP (platform 3, encoding 1) - Windows Unicode BMP
-        subtable = cmap.subtable(3, 1)
-        return subtable if subtable
-
-        # Try Unicode full (platform 3, encoding 10) - Windows Unicode full
-        subtable = cmap.subtable(3, 10)
-        return subtable if subtable
-
-        # Try Unicode (platform 0, encoding 3) - Unicode 2.0+ BMP
-        subtable = cmap.subtable(0, 3)
-        return subtable if subtable
-
-        # Try Unicode (platform 0, encoding 4) - Unicode 2.0+ full
-        subtable = cmap.subtable(0, 4)
-        return subtable if subtable
-
-        # Fallback to any available subtable
-        cmap.subtables.first
-      rescue StandardError
-        nil
+      # Falls back to +"gidN"+ when the post table has no name for the
+      # given gid (post version 3.0 fonts omit per-glyph names, and
+      # version 2.0 may have gaps). Always returns a non-nil string so
+      # the SVG <glyph> element carries a useful glyph-name attribute.
+      #
+      # @param glyph_names [Array<String>] post.glyph_names
+      # @param glyph_id [Integer]
+      # @return [String]
+      def glyph_name_for(glyph_names, glyph_id)
+        glyph_names[glyph_id] || "gid#{glyph_id}"
       end
 
       # Extract advance width for glyph
@@ -264,22 +228,6 @@ palette_index: 0)
         advance
       rescue StandardError
         0
-      end
-
-      # Extract glyph name from post table
-      #
-      # @param post [Tables::Post, nil] Post table
-      # @param glyph_id [Integer] Glyph ID
-      # @return [String, nil] Glyph name or nil
-      def extract_glyph_name(post, glyph_id)
-        return nil unless post
-
-        name = post.glyph_name_for(glyph_id)
-        return nil if name.nil? || name.empty?
-
-        name
-      rescue StandardError
-        nil
       end
     end
   end

--- a/lib/fontisan/sfnt_font.rb
+++ b/lib/fontisan/sfnt_font.rb
@@ -59,8 +59,16 @@ module Fontisan
       header.num_tables
     }
 
-    # Table data is stored separately since it's at variable offsets
-    attr_accessor :table_data
+    # Table data is stored separately since it's at variable offsets.
+    # The setter normalizes all keys to UTF-8 so Hash lookups don't
+    # silently miss due to encoding mismatch — BinData-derived tag
+    # strings are ASCII-8BIT, literals callers pass are usually UTF-8,
+    # and String#eql? is encoding-sensitive.
+    attr_reader :table_data
+
+    def table_data=(hash)
+      @table_data = hash.transform_keys { |tag| normalize_tag(tag) }
+    end
 
     # Parsed table instances cache
     attr_accessor :parsed_tables
@@ -470,6 +478,8 @@ module Fontisan
     # @return [Tables::*, nil] Parsed table object or nil if not found
     # @raise [ArgumentError] if table is not available in current loading mode
     def table(tag)
+      tag = normalize_tag(tag)
+
       # Check mode restrictions
       unless table_available?(tag)
         if has_table?(tag)

--- a/lib/fontisan/stitcher.rb
+++ b/lib/fontisan/stitcher.rb
@@ -52,8 +52,8 @@ module Fontisan
       @deduplicate = deduplicate
     end
 
-    def add_source(label, font)
-      @sources[label.to_sym] = Source.new(font)
+    def add_source(label, font, remap: nil)
+      @sources[label.to_sym] = Source.new(font, remap: remap)
     end
 
     def include_range(range, from:, into:)

--- a/lib/fontisan/stitcher/source.rb
+++ b/lib/fontisan/stitcher/source.rb
@@ -15,14 +15,49 @@ module Fontisan
     # #bitmap_mode. When a source is :cbdt, the Stitcher propagates
     # the raw CBDT/CBLC tables into the output instead of extracting
     # outlines. The glyph data lives in the bitmap tables, not in glyf.
+    #
+    # = Codepoint remap
+    #
+    # Some donor fonts ship glyphs at non-canonical codepoints — a
+    # keyboard-mapped font whose "A" is at U+0041, or a PUA-allocated
+    # pre-Unicode font. Pass a +remap:+ hash at construction to expose
+    # those glyphs at their canonical codepoints without mutating the
+    # donor font's cmap:
+    #
+    #   Source.new(font, remap: { 0x41 => 0x11DB0 })
+    #
+    # With a remap set, the source answers +gid_for_codepoint+ for the
+    # *target* codepoints (0x11DB0 in the example) by translating them
+    # to the donor's *source* codepoints (0x41). Source codepoints not
+    # listed in the remap are hidden — only the remapped coverage is
+    # exposed. This matches the typical "use this donor for exactly
+    # these output characters" intent, and avoids leaking the donor's
+    # ASCII/PUA noise into the output.
     class Source
       MAX_COMPOUND_DEPTH = 32
 
-      attr_reader :font
+      attr_reader :font, :remap
 
-      def initialize(font)
+      # @param font [TrueTypeFont, OpenTypeFont, Ufo::Font] donor font
+      # @param remap [Hash{Integer=>Integer}, nil] optional
+      #   {source_codepoint => target_codepoint}. When present (even
+      #   empty), source codepoints not listed are hidden from
+      #   lookups. Pass +nil+ (the default) for the passthrough
+      #   behavior — every donor codepoint is exposed as-is.
+      def initialize(font, remap: nil)
         @font = font
         @bin_data_cache = nil
+
+        # Distinguish "no remap kwarg" (nil → passthrough) from
+        # "explicit empty remap" ({} → drop everything). The latter
+        # still flips the source into remapped mode, just with no
+        # entries — every donor codepoint gets filtered out.
+        return unless remap
+
+        @remap = remap.to_h.transform_keys(&:to_i).transform_values(&:to_i)
+        @inverse_remap = @remap.each_with_object({}) do |(src, target), h|
+          h[target] = src
+        end
       end
 
       # @return [Symbol] :ufo, :ttf, :otf
@@ -57,12 +92,21 @@ module Fontisan
       end
 
       # Find the gid for a Unicode codepoint in this source.
+      #
+      # When +remap+ was set at construction, +codepoint+ is treated as
+      # a *target* codepoint — the source codepoint that maps to it via
+      # +remap+ is what actually gets looked up. Returns +nil+ for
+      # codepoints the remap does not cover.
+      #
       # @param codepoint [Integer]
       # @return [Integer, nil]
       def gid_for_codepoint(codepoint)
+        src_cp = source_codepoint_for(codepoint)
+        return nil unless src_cp
+
         case @font
-        when Fontisan::Ufo::Font then ufo_gid_for(codepoint)
-        else bin_data_gid_for(codepoint)
+        when Fontisan::Ufo::Font then ufo_gid_for(src_cp)
+        else bin_data_gid_for(src_cp)
         end
       end
 
@@ -317,13 +361,50 @@ module Fontisan
       end
 
       # Add Unicode codepoints from the cmap that map to this gid.
+      #
+      # When +remap+ was set at construction, the source's raw codepoints
+      # are translated through the remap (source→target), and source
+      # codepoints not in the remap are dropped. Otherwise the raw cmap
+      # codepoints are attached as-is.
       def add_cmap_unicodes(gid, glyph)
-        cmap = @font.table("cmap")
-        return unless cmap
+        effective_codepoints_for_gid(gid).each { |cp| glyph.add_unicode(cp) }
+      end
 
-        (cmap.unicode_mappings || {}).each do |cp, g|
-          glyph.add_unicode(cp) if g == gid
+      # Translate a caller-facing codepoint to the donor's own codepoint.
+      # Without remap, the two are identical. With remap, the caller's
+      # codepoint is the *target*; look up the source codepoint that
+      # maps to it. Returns +nil+ if no remap entry covers the target.
+      def source_codepoint_for(codepoint)
+        return codepoint unless @remap
+
+        @inverse_remap[codepoint]
+      end
+
+      # Codepoints that should be attached to a glyph at the given gid,
+      # after applying the remap (if any).
+      def effective_codepoints_for_gid(gid)
+        raw_cmap = self.raw_cmap
+        raw_cmap.each_with_object([]) do |(src_cp, g), cps|
+          next unless g == gid
+
+          if @remap
+            target = @remap[src_cp]
+            cps << target if target
+          else
+            cps << src_cp
+          end
         end
+      end
+
+      # The raw cmap hash from the donor's table. Always {src_cp => gid};
+      # never remapped. UFO sources return {} (no cmap table).
+      def raw_cmap
+        cmap = @font.table("cmap")
+        return {} unless cmap
+
+        cmap.unicode_mappings || {}
+      rescue StandardError
+        {}
       end
     end
   end

--- a/lib/fontisan/svg/font_generator.rb
+++ b/lib/fontisan/svg/font_generator.rb
@@ -28,7 +28,7 @@ module Fontisan
       # @return [TrueTypeFont, OpenTypeFont] Font instance
       attr_reader :font
 
-      # @return [Hash] Glyph data map (glyph_id => {outline, unicode, name, advance})
+      # @return [Hash] Glyph data map (glyph_id => {outline, codepoints, name, advance})
       attr_reader :glyph_data
 
       # @return [Hash] Generation options
@@ -179,7 +179,7 @@ module Fontisan
 
           glyph_generator.generate_glyph_xml(
             data[:outline],
-            unicode: data[:unicode],
+            codepoints: data[:codepoints],
             glyph_name: data[:name],
             advance_width: data[:advance],
             indent: "      ",

--- a/lib/fontisan/svg/glyph_generator.rb
+++ b/lib/fontisan/svg/glyph_generator.rb
@@ -20,7 +20,7 @@ module Fontisan
     #
     # @example Generate SVG glyph element
     #   generator = GlyphGenerator.new(calculator)
-    #   xml = generator.generate_glyph_xml(outline, unicode: "A", advance_width: 600)
+    #   xml = generator.generate_glyph_xml(outline, codepoints: [0x41], advance_width: 600)
     class GlyphGenerator
       # @return [ViewBoxCalculator] Coordinate calculator
       attr_reader :calculator
@@ -38,23 +38,30 @@ module Fontisan
       # Generate SVG glyph element
       #
       # @param outline [Models::GlyphOutline] Glyph outline
-      # @param unicode [String, nil] Unicode character
-      # @param glyph_name [String, nil] Glyph name
+      # @param codepoints [Array<Integer>] Unicode codepoints that cmap
+      #   maps to this glyph. Empty for unmapped glyphs (.notdef, raw
+      #   ligatures, etc.). Each codepoint is rendered per SVG Fonts
+      #   spec: printable ASCII as the character (XML-escaped), others
+      #   as &#xHEX; entities. Multiple codepoints are concatenated —
+      #   rare but valid (e.g. a glyph mapped from both space and
+      #   non-breaking space).
+      # @param glyph_name [String, nil] Glyph name from the post table
       # @param advance_width [Integer] Horizontal advance width
       # @param indent [String] Indentation string
       # @return [String] XML glyph element
-      def generate_glyph_xml(outline, unicode: nil, glyph_name: nil,
+      def generate_glyph_xml(outline, codepoints: [], glyph_name: nil,
 advance_width: 0, indent: "      ")
-        # Build attribute parts
         attr_parts = []
 
-        attr_parts << "unicode=\"#{escape_xml(unicode)}\"" if unicode
-        attr_parts << "glyph-name=\"#{escape_xml(glyph_name)}\"" if glyph_name
-        attr_parts << "horiz-adv-x=\"#{advance_width}\"" if advance_width&.positive?
+        unless codepoints.empty?
+          attr_parts << %(unicode="#{format_codepoints(codepoints)}")
+        end
+        attr_parts << %(glyph-name="#{escape_xml(glyph_name)}") if glyph_name
+        attr_parts << %(horiz-adv-x="#{advance_width}") if advance_width&.positive?
 
         # Generate SVG path with Y-axis transformation
         path_data = generate_svg_path(outline)
-        attr_parts << "d=\"#{path_data}\"" if path_data && !path_data.empty?
+        attr_parts << %(d="#{path_data}") if path_data && !path_data.empty?
 
         "#{indent}<glyph #{attr_parts.join(' ')}/>"
       end
@@ -87,6 +94,34 @@ advance_width: 0, indent: "      ")
       end
 
       private
+
+      # Format an array of codepoints as the SVG `unicode=` attribute
+      # value. Returns the FINAL string — already escaped / entity-fied.
+      # The caller must not re-escape it (would double-escape the
+      # entities this method emits).
+      #
+      # Per SVG Fonts spec, each codepoint renders as either:
+      #   - printable ASCII (0x20..0x7E): the character itself, with
+      #     XML-special chars (&, <, >, ", ') escaped
+      #   - any other codepoint: a numeric entity &#xHEX;
+      #
+      # Multiple codepoints are concatenated in codepoint order. The
+      # SVG spec accepts this for ligature-style mappings.
+      def format_codepoints(codepoints)
+        codepoints.map { |cp| format_codepoint(cp) }.join
+      end
+
+      def format_codepoint(cp)
+        if printable_ascii?(cp)
+          escape_xml(cp.chr(Encoding::UTF_8))
+        else
+          "&#x#{cp.to_s(16).upcase};"
+        end
+      end
+
+      def printable_ascii?(cp)
+        (0x20..0x7E).cover?(cp)
+      end
 
       # Build SVG path for a contour with Y-axis transformation
       #

--- a/spec/fontisan/converters/svg_generator_spec.rb
+++ b/spec/fontisan/converters/svg_generator_spec.rb
@@ -104,5 +104,96 @@ RSpec.describe Fontisan::Converters::SvgGenerator do
       expect(svg).to be_a(String)
       expect(svg).to include("<svg")
     end
+
+    context "with per-glyph unicode and glyph-name attributes (issue #80)" do
+      let(:svg) { generator.convert(font)[:svg_xml] }
+
+      it "emits glyph-name on every <glyph> element" do
+        # Every glyph — including .notdef — should carry a glyph-name.
+        # post v2.0 fonts supply canonical names; the gidN fallback
+        # covers any gaps.
+        glyph_lines = svg.scan(/<glyph [^>]*\/>/)
+        expect(glyph_lines).not_to be_empty
+        expect(glyph_lines).to all(match(/glyph-name="[^"]+"/))
+      end
+
+      it "emits unicode on <glyph> elements that have cmap mappings" do
+        # At least the ASCII range should appear as unicode="...". We
+        # pick a few printable ASCII characters that MonaSans-ExtraLightItalic
+        # is guaranteed to map (letters, digits, common punctuation).
+        expect(svg).to match(/unicode="[A-Za-z0-9]"/)
+      end
+
+      it "renders non-ASCII codepoints as numeric entities" do
+        # Any glyph whose cmap mapping includes a codepoint > 0x7E must
+        # surface that codepoint as a &#xHEX; entity in the unicode
+        # attribute. We don't pin a specific codepoint — fonts differ
+        # in cmap ordering — but every CJK/Latin-Extended font has at
+        # least one.
+        entities = svg.scan(/unicode="[^"]*(&#x[0-9A-Fa-f]+;)[^"]*"/)
+          .map(&:first).uniq
+        expect(entities).not_to be_empty
+
+        # Every matched entity must be a codepoint above printable ASCII
+        # (the whole point of entity-encoding).
+        entities.each do |entity|
+          hex = entity.match(/^&#x([0-9A-Fa-f]+);$/).captures.first
+          expect(hex.to_i(16)).to be > 0x7E
+        end
+      end
+
+      it "escapes XML-special ASCII codepoints rather than emitting them raw" do
+        # If the font maps any of <, >, &, ", ' to a glyph, that codepoint
+        # must appear in `unicode=` as the named entity (&lt; &gt; &amp;
+        # &quot; &apos;), never as the raw character inside an attribute.
+        # These are all in printable ASCII so they go through the
+        # char-then-escape path, not the hex-entity path.
+        cmap = font.table("cmap")
+        named_entities = {
+          0x3C => "&lt;",
+          0x3E => "&gt;",
+          0x26 => "&amp;",
+          0x22 => "&quot;",
+          0x27 => "&apos;",
+        }
+        present = named_entities.select { |cp, _| cmap.unicode_mappings.key?(cp) }
+        skip "font has no XML-special codepoints in cmap" if present.empty?
+
+        present.each_value { |entity| expect(svg).to include(%(unicode="#{entity}")) }
+
+        # No attribute value should contain a raw < or unescaped &.
+        svg.scan(/unicode="([^"]*)"/).each do |(value)|
+          stripped = value
+            .gsub("&lt;", "").gsub("&gt;", "").gsub("&quot;", "")
+            .gsub("&apos;", "").gsub("&amp;", "").gsub(/&#x[0-9A-Fa-f]+;/, "")
+          expect(stripped).not_to include("<")
+          expect(stripped).not_to include("&")
+        end
+      end
+
+      it "omits unicode= on .notdef (no cmap mapping)" do
+        notdef_line = svg.scan(/<glyph [^>]*\/>/).find { |l| l.include?('glyph-name=".notdef"') }
+        expect(notdef_line).not_to be_nil
+        expect(notdef_line).not_to include("unicode=")
+      end
+
+      it "supports glyphs mapped from multiple codepoints" do
+        # Find a glyph mapped from >1 codepoint (common: space and
+        # non-breaking space share a glyph). The unicode attribute
+        # should carry both, concatenated.
+        cmap = font.table("cmap")
+        gid_to_cps = cmap.unicode_mappings.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(cp, gid), h|
+          h[gid] << cp
+        end
+        multi_cps_gid = gid_to_cps.find { |_gid, cps| cps.size > 1 }&.first
+        skip "font has no multi-codepoint glyph" unless multi_cps_gid
+
+        # Build the expected unicode string and verify it appears.
+        expected = gid_to_cps[multi_cps_gid].map do |cp|
+          (0x20..0x7E).cover?(cp) ? cp.chr(Encoding::UTF_8) : "&#x#{cp.to_s(16).upcase};"
+        end.join
+        expect(svg).to include(%(unicode="#{expected}"))
+      end
+    end
   end
 end

--- a/spec/fontisan/from_tables_spec.rb
+++ b/spec/fontisan/from_tables_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan"
+require "tmpdir"
+
+# Reproduces issue #79: TrueTypeFont.from_tables / OpenTypeFont.from_tables
+# left parsed_tables empty because BinData-derived tag strings are
+# ASCII-8BIT and the lookup literal is UTF-8 — String#eql? is encoding-
+# sensitive so Hash lookup returned nil. Fixed by normalizing keys in
+# SfntFont#table_data= and normalizing the tag at entry to #table.
+RSpec.describe "Fontisan from_tables round-trip (issue #79)" do
+  shared_examples "from_tables parses tables on lookup" do
+    let(:source_path) { source_fixture_path }
+    let(:source) { Fontisan::FontLoader.load(source_path) }
+
+    let(:tables) do
+      source.table_names.each_with_object({}) do |tag, h|
+        raw = begin
+          source.table(tag)&.raw_data
+        rescue StandardError
+          nil
+        end
+        h[tag] = raw if raw && !raw.empty?
+      end
+    end
+
+    let(:rebuilt) { font_class.from_tables(tables) }
+
+    it "exposes has_table?(tag) for every key in the input hash" do
+      tables.each_key do |tag|
+        expect(rebuilt.has_table?(tag)).to be(true)
+      end
+    end
+
+    it "returns a parsed instance from table(tag), not nil" do
+      expect(rebuilt.table("head")).to be_a(Fontisan::Tables::Head)
+      expect(rebuilt.table("maxp")).to be_a(Fontisan::Tables::Maxp)
+    end
+
+    it "round-trips: table bytes extracted from the rebuilt font match the input" do
+      # Normalize input keys to UTF-8 so Hash#eq (which is encoding-
+      # sensitive via eql?) matches the normalized rebuilt.table_data.
+      input_normalized = tables.transform_keys { |k| k.dup.force_encoding("UTF-8") }
+      expect(rebuilt.table_data).to eq(input_normalized)
+    end
+
+    describe "tag encoding robustness" do
+      it "looks up tables when the caller passes a UTF-8 literal" do
+        expect(rebuilt.table("head".dup.force_encoding("UTF-8")))
+          .to be_a(Fontisan::Tables::Head)
+      end
+
+      it "looks up tables when the caller passes an ASCII-8BIT binary string" do
+        expect(rebuilt.table("head".b)).to be_a(Fontisan::Tables::Head)
+      end
+
+      it "looks up tables when the caller passes a frozen string" do
+        expect(rebuilt.table("head")).to be_a(Fontisan::Tables::Head)
+      end
+
+      it "caches parsed instances under the normalized key (no double-parse)" do
+        # Same tag, different encodings — must hit the cache, not re-parse.
+        rebuilt.table("head")
+        before = rebuilt.parsed_tables.size
+        rebuilt.table("head".b)
+        rebuilt.table("head")
+        expect(rebuilt.parsed_tables.size).to eq(before)
+      end
+    end
+
+    it "writes WOFF2 via OutputWriter from the rebuilt tables" do
+      Dir.mktmpdir do |dir|
+        out_path = File.join(dir, "out.woff2")
+        Fontisan::Pipeline::OutputWriter.new(out_path, :woff2).write(tables)
+        expect(File.exist?(out_path)).to be(true)
+        expect(File.size(out_path)).to be > 0
+      end
+    end
+  end
+
+  describe Fontisan::TrueTypeFont do
+    it_behaves_like "from_tables parses tables on lookup" do
+      let(:font_class) { described_class }
+      let(:source_fixture_path) { "spec/fixtures/fonttools/TestTTF.ttf" }
+    end
+  end
+
+  describe Fontisan::OpenTypeFont do
+    it_behaves_like "from_tables parses tables on lookup" do
+      let(:font_class) { described_class }
+      let(:source_fixture_path) { "spec/fixtures/fonttools/TestOTF.otf" }
+    end
+  end
+
+  # Direct unit test for the encoding-normalization fix on the setter,
+  # independent of from_tables end-to-end behavior.
+  describe Fontisan::SfntFont, "#table_data= normalizes key encoding" do
+    let(:font) do
+      # Build a bare-ish SfntFont by loading any fixture; we only care
+      # about the table_data hash on the resulting instance.
+      Fontisan::FontLoader.load("spec/fixtures/fonttools/TestTTF.ttf")
+    end
+
+    it "converts ASCII-8BIT keys to UTF-8" do
+      font.table_data = { "head".b => "bytes" }
+      expect(font.table_data.keys.first.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "leaves UTF-8 keys as UTF-8" do
+      font.table_data = { "head" => "bytes" }
+      expect(font.table_data.keys.first.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "preserves key equality post-normalization" do
+      font.table_data = { "head".b => "bytes" }
+      expect(font.table_data.key?("head")).to be(true)
+      expect(font.table_data["head"]).to eq("bytes")
+    end
+  end
+end

--- a/spec/fontisan/stitcher/source_remap_spec.rb
+++ b/spec/fontisan/stitcher/source_remap_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/stitcher"
+
+# Issue #81: Stitcher#add_source(label, font, remap:) gives donors
+# whose glyphs live at non-canonical codepoints a first-class API for
+# exposing those glyphs at their canonical targets, without callers
+# reaching into the donor's cached cmap.
+RSpec.describe Fontisan::Stitcher::Source, "#remap" do
+  let(:donor) { Fontisan::FontLoader.load("spec/fixtures/fonttools/TestTTF.ttf") }
+
+  # TestTTF has 5 cmap entries: U+0000, U+000D, U+0020 (space),
+  # U+002E (period), U+2026 (ellipsis). Of these, gids 1-3 (whitespace
+  # / control) have no outlines — extract_truetype_glyph returns nil
+  # for them. Gid 4 (period) is the simplest glyph with real outlines,
+  # so use it for tests that need to inspect the extracted glyph.
+  let(:source_cp) { 0x2E } # period
+  let(:source_gid) { donor.table("cmap").unicode_mappings[source_cp] }
+
+  describe "without remap (default)" do
+    let(:source) { described_class.new(donor) }
+
+    it "looks up the donor's raw codepoints directly" do
+      expect(source.gid_for_codepoint(source_cp)).to eq(source_gid)
+    end
+
+    it "exposes every codepoint the donor's cmap has" do
+      expect(source.remap).to be_nil
+    end
+
+    it "attaches the donor's raw codepoints to extracted glyphs" do
+      glyph = source.glyph_for_gid(source_gid)
+      expect(glyph.unicodes).to include(source_cp)
+    end
+  end
+
+  describe "with a remap" do
+    # Pretend the donor's space + period glyphs are actually letters
+    # of a hypothetical script that lives at U+11DB0.. (essenfont's
+    # Tolong Siki range). The remap exposes those glyphs at the new
+    # targets while keeping the donor's cmap untouched.
+    let(:remap) do
+      { source_cp => 0x11DB0 }
+    end
+    let(:source) { described_class.new(donor, remap: remap) }
+
+    it "exposes the remap hash on the #remap reader" do
+      expect(source.remap).to eq(remap)
+    end
+
+    it "looks up target codepoints via the remap (translates to source)" do
+      expect(source.gid_for_codepoint(0x11DB0)).to eq(source_gid)
+    end
+
+    it "returns nil for codepoints the remap does not cover" do
+      # Source cps not in the remap are hidden — looking up the raw
+      # source cp directly must return nil.
+      expect(source.gid_for_codepoint(source_cp)).to be_nil
+      # And codepoints the remap doesn't target are nil too.
+      expect(source.gid_for_codepoint(0x11DB5)).to be_nil
+    end
+
+    it "does not mutate the donor's cmap" do
+      original_mappings = donor.table("cmap").unicode_mappings
+      original_size = original_mappings.size
+
+      # Force a lookup that runs the remap path.
+      source.gid_for_codepoint(0x11DB0)
+
+      expect(donor.table("cmap").unicode_mappings.size).to eq(original_size)
+      expect(donor.table("cmap").unicode_mappings[source_cp]).to eq(source_gid)
+    end
+
+    it "attaches target codepoints (not source codepoints) to extracted glyphs" do
+      glyph = source.glyph_for_gid(source_gid)
+      expect(glyph.unicodes).to include(0x11DB0)
+      expect(glyph.unicodes).not_to include(source_cp)
+    end
+
+    it "accepts string keys and coerces to Integer" do
+      # Some manifests (YAML loaders) hand back string keys. Coerce
+      # rather than blow up — matches the issue body's proposal.
+      source_with_strings = described_class.new(donor, remap: { source_cp.to_s => 0x11DB0.to_s })
+      expect { source_with_strings.gid_for_codepoint(0x11DB0) }.not_to raise_error
+    end
+
+    it "supports multiple sources with different remaps on one Stitcher" do
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:remapped, donor, remap: { source_cp => 0x11DB0 })
+      stitcher.add_source(:passthrough, donor)
+
+      remapped_gid = stitcher.instance_variable_get(:@sources)[:remapped].gid_for_codepoint(0x11DB0)
+      passthrough_gid = stitcher.instance_variable_get(:@sources)[:passthrough].gid_for_codepoint(source_cp)
+
+      expect(remapped_gid).to eq(source_gid)
+      expect(passthrough_gid).to eq(source_gid)
+    end
+  end
+
+  describe "with an empty remap" do
+    let(:source) { described_class.new(donor, remap: {}) }
+
+    it "exposes no codepoints (every source cp is dropped by design)" do
+      expect(source.gid_for_codepoint(source_cp)).to be_nil
+    end
+
+    it "does not attach any codepoints to extracted glyphs" do
+      glyph = source.glyph_for_gid(source_gid)
+      attached = glyph.unicodes & donor.table("cmap").unicode_mappings.keys
+      expect(attached).to be_empty
+    end
+  end
+
+  describe Fontisan::Stitcher, "#add_source with remap:" do
+    it "forwards the remap to the Source it constructs" do
+      stitcher = described_class.new
+      stitcher.add_source(:tolong_siki, donor, remap: { source_cp => 0x11DB0 })
+
+      source = stitcher.instance_variable_get(:@sources)[:tolong_siki]
+      expect(source).to be_a(Fontisan::Stitcher::Source)
+      expect(source.remap).to eq(source_cp => 0x11DB0)
+    end
+
+    it "defaults remap to nil when omitted (backwards-compatible)" do
+      stitcher = described_class.new
+      stitcher.add_source(:plain, donor)
+
+      source = stitcher.instance_variable_get(:@sources)[:plain]
+      expect(source.remap).to be_nil
+    end
+  end
+end

--- a/spec/fontisan/svg/font_generator_spec.rb
+++ b/spec/fontisan/svg/font_generator_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Fontisan::Svg::FontGenerator do
     {
       0 => {
         outline: nil,
-        unicode: nil,
+        codepoints: [],
         name: ".notdef",
         advance: 500,
       },
       65 => {
         outline: create_test_outline(65),
-        unicode: "A",
+        codepoints: [0x41],
         name: "A",
         advance: 600,
       },

--- a/spec/fontisan/svg/glyph_generator_spec.rb
+++ b/spec/fontisan/svg/glyph_generator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Fontisan::Svg::GlyphGenerator do
     it "generates glyph XML element" do
       xml = generator.generate_glyph_xml(
         outline,
-        unicode: "A",
+        codepoints: [0x41],
         advance_width: 600,
       )
 
@@ -59,7 +59,7 @@ RSpec.describe Fontisan::Svg::GlyphGenerator do
     it "includes glyph name when provided" do
       xml = generator.generate_glyph_xml(
         outline,
-        unicode: "A",
+        codepoints: [0x41],
         glyph_name: "A",
         advance_width: 600,
       )
@@ -86,14 +86,39 @@ RSpec.describe Fontisan::Svg::GlyphGenerator do
       expect(xml).not_to include("d=")
     end
 
-    it "escapes XML characters in unicode" do
+    it "escapes XML-special ASCII codepoints" do
       xml = generator.generate_glyph_xml(
         outline,
-        unicode: "<",
+        codepoints: [0x3C], # "<"
         advance_width: 600,
       )
 
       expect(xml).to include('unicode="&lt;"')
+    end
+
+    it "emits numeric entities for non-ASCII codepoints" do
+      xml = generator.generate_glyph_xml(
+        outline,
+        codepoints: [0x2026], # "…"
+        advance_width: 600,
+      )
+
+      expect(xml).to include('unicode="&#x2026;"')
+    end
+
+    it "concatenates multiple codepoints into one unicode attribute" do
+      xml = generator.generate_glyph_xml(
+        outline,
+        codepoints: [0x41, 0x42], # "AB"
+        advance_width: 600,
+      )
+
+      expect(xml).to include('unicode="AB"')
+    end
+
+    it "omits the unicode attribute when codepoints is empty" do
+      xml = generator.generate_glyph_xml(outline, advance_width: 600)
+      expect(xml).not_to include("unicode=")
     end
 
     it "uses custom indentation" do


### PR DESCRIPTION
## Summary

Three issues folded into one PR per the "fold new work into the existing open PR" rule. Each commit is independent and can be reviewed on its own.

### 1. `sfnt: normalize tag encoding in table_data= and table()` — fixes #79

`SfntFont#table_data=` now normalizes every key to UTF-8 via the existing `normalize_tag` helper (replaces raw `attr_accessor`). `SfntFont#table` normalizes the incoming tag at entry. Callers can pass tags in any encoding (binary, UTF-8, frozen) and cache lookups hit consistently.

**Root cause:** BinData-derived tag strings are ASCII-8BIT, literals callers pass are UTF-8, and `String#eql?` is encoding-sensitive — so Hash lookup silently returned nil. IO-loaded fonts accidentally worked because `load_all_tables` calls `normalize_tag` on the way in; `from_tables` bypassed that path and stored the input hash verbatim, so `font.table("head")` returned nil even though `has_table?("head")` returned true.

### 2. `svg: emit per-glyph unicode= and glyph-name= attributes` — fixes #80

`SvgGenerator#extract_glyph_data` now reads `cmap.unicode_mappings` directly (replacing the broken `cmap.subtable(...)` path) and builds a glyph_id → [codepoint, ...] reverse map. Glyph names come from `post.glyph_names[gid]` with a `gidN` fallback for post v3 fonts.

`GlyphGenerator#generate_glyph_xml` takes `codepoints:` (Array<Integer>) instead of `unicode:` (String). Each codepoint renders per SVG Fonts spec: printable ASCII as the character (XML-escaped), everything else as a numeric `&#xHEX;` entity. Multiple codepoints concatenate.

**Root cause:** `SvgGenerator` was calling `cmap.subtable(...)`, `cmap.subtables.first`, and `post.glyph_name_for(...)` — none of those methods exist on the current `Tables::Cmap` and `Tables::Post`. Every lookup raised `NoMethodError`, got rescued to nil, and the unicode map came back empty.

### 3. `stitcher: add remap: kwarg to add_source for non-canonical donors` — fixes #81

`Stitcher#add_source(label, font, remap:)` accepts an optional `{src_cp => target_cp}` hash and forwards it to `Source.new`. The remap is a translation layer at the front of the source's API: target codepoints get inverse-mapped to source codepoints before lookup, and target codepoints get attached to extracted glyphs instead of the donor's raw codepoints. The donor's cmap is never mutated.

- `remap: nil` (default) — passthrough; backwards-compatible.
- `remap: { src => target, ... }` — source codepoints not listed are hidden; only remapped coverage is exposed.
- `remap: {}` (explicit empty) — every source codepoint is dropped.

**Before**, callers had to mutate the donor's cached cmap via `Hash#replace`, which coupled them to fontisan's caching strategy and silently broke if any of three invariants changed.

## Test plan

- [x] `bundle exec rspec spec/fontisan/from_tables_spec.rb` — 19 examples, 0 failures (issue #79)
- [x] `bundle exec rspec spec/fontisan/svg/ spec/fontisan/converters/svg_generator_spec.rb` — 80 examples, 0 failures, 1 pending (issue #80)
- [x] `bundle exec rspec spec/fontisan/stitcher/source_remap_spec.rb` — 14 examples, 0 failures (issue #81)
- [x] `bundle exec rspec` — 5717 examples, 0 failures, 2 pre-existing pending
- [x] `bundle exec rubocop` — clean across 698 files

Closes #79, closes #80, closes #81.
