### PR TITLE
svg: emit per-glyph unicode= and glyph-name= attributes (fixes #80)

### DIFF
--- a/lib/fontisan/converters/svg_generator.rb
+++ b/lib/fontisan/converters/svg_generator.rb
@@ -145,7 +145,7 @@ palette_index: 0)
       #
       # @param font [TrueTypeFont, OpenTypeFont] Source font
       # @param options [Hash] Extraction options
-      # @return [Hash] Glyph data map (glyph_id => {outline, unicode, name, advance})
+      # @return [Hash] Glyph data map (glyph_id => {outline, codepoints, name, advance})
       def extract_glyph_data(font, options = {})
         extractor = OutlineExtractor.new(font)
         cmap = font.table("cmap")
@@ -157,33 +157,20 @@ palette_index: 0)
         num_glyphs = maxp&.num_glyphs || 0
         max_glyphs = options[:max_glyphs] || num_glyphs
 
-        # Get unicode mappings
-        unicode_map = build_unicode_map(cmap)
+        gid_to_codepoints = build_glyph_to_codepoints(cmap)
+        glyph_names = post&.glyph_names || []
 
-        # Extract specified or all glyphs
         glyph_ids = options[:glyph_ids] || (0...num_glyphs).to_a
         glyph_ids = glyph_ids.take(max_glyphs) if max_glyphs
 
         glyph_ids.each do |glyph_id|
           next if glyph_id >= num_glyphs
 
-          # Extract outline
-          outline = extractor.extract(glyph_id)
-
-          # Get advance width
-          advance = extract_advance_width(hmtx, glyph_id)
-
-          # Get unicode character
-          unicode = unicode_map[glyph_id]
-
-          # Get glyph name
-          glyph_name = extract_glyph_name(post, glyph_id)
-
           glyph_data[glyph_id] = {
-            outline: outline,
-            unicode: unicode,
-            name: glyph_name,
-            advance: advance,
+            outline: extractor.extract(glyph_id),
+            codepoints: gid_to_codepoints[glyph_id] || [],
+            name: glyph_name_for(glyph_names, glyph_id),
+            advance: extract_advance_width(hmtx, glyph_id),
           }
         rescue StandardError => e
           warn "Failed to extract glyph #{glyph_id}: #{e.message}"
@@ -193,61 +180,38 @@ palette_index: 0)
         glyph_data
       end
 
-      # Build unicode to glyph ID map from cmap table
+      # Build reverse cmap: glyph_id => [codepoint, ...].
       #
-      # @param cmap [Tables::Cmap, nil] Cmap table
-      # @return [Hash<Integer, String>] Map of glyph_id to unicode character
-      def build_unicode_map(cmap)
+      # A glyph can be referenced by multiple codepoints (e.g. space
+      # and non-breaking space might share a glyph). Uses
+      # +cmap.unicode_mappings+ directly — that is the canonical
+      # {codepoint => gid} hash.
+      #
+      # @param cmap [Tables::Cmap, nil]
+      # @return [Hash<Integer, Array<Integer>>]
+      def build_glyph_to_codepoints(cmap)
         return {} unless cmap
 
-        unicode_map = {}
-
-        # Get best cmap subtable (prefer Unicode BMP or full)
-        subtable = find_best_cmap_subtable(cmap)
-        return {} unless subtable
-
-        # Build reverse map: glyph_id => unicode
-        subtable.each do |code_point, glyph_id|
-          # Store first unicode for each glyph
-          next if unicode_map[glyph_id]
-
-          unicode_map[glyph_id] = [code_point].pack("U")
-        rescue StandardError
-          # Skip invalid code points
-          next
+        cmap.unicode_mappings.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(cp, gid), h|
+          h[gid] << cp
         end
-
-        unicode_map
       rescue StandardError => e
-        warn "Failed to build unicode map: #{e.message}"
+        warn "Failed to build glyph to codepoints map: #{e.message}"
         {}
       end
 
-      # Find best cmap subtable for unicode mapping
+      # Look up glyph name from the post table's per-gid name array.
       #
-      # @param cmap [Tables::Cmap] Cmap table
-      # @return [Hash, nil] Subtable or nil
-      def find_best_cmap_subtable(cmap)
-        # Try Unicode BMP (platform 3, encoding 1) - Windows Unicode BMP
-        subtable = cmap.subtable(3, 1)
-        return subtable if subtable
-
-        # Try Unicode full (platform 3, encoding 10) - Windows Unicode full
-        subtable = cmap.subtable(3, 10)
-        return subtable if subtable
-
-        # Try Unicode (platform 0, encoding 3) - Unicode 2.0+ BMP
-        subtable = cmap.subtable(0, 3)
-        return subtable if subtable
-
-        # Try Unicode (platform 0, encoding 4) - Unicode 2.0+ full
-        subtable = cmap.subtable(0, 4)
-        return subtable if subtable
-
-        # Fallback to any available subtable
-        cmap.subtables.first
-      rescue StandardError
-        nil
+      # Falls back to +"gidN"+ when the post table has no name for the
+      # given gid (post version 3.0 fonts omit per-glyph names, and
+      # version 2.0 may have gaps). Always returns a non-nil string so
+      # the SVG <glyph> element carries a useful glyph-name attribute.
+      #
+      # @param glyph_names [Array<String>] post.glyph_names
+      # @param glyph_id [Integer]
+      # @return [String]
+      def glyph_name_for(glyph_names, glyph_id)
+        glyph_names[glyph_id] || "gid#{glyph_id}"
       end
 
       # Extract advance width for glyph
@@ -264,22 +228,6 @@ palette_index: 0)
         advance
       rescue StandardError
         0
-      end
-
-      # Extract glyph name from post table
-      #
-      # @param post [Tables::Post, nil] Post table
-      # @param glyph_id [Integer] Glyph ID
-      # @return [String, nil] Glyph name or nil
-      def extract_glyph_name(post, glyph_id)
-        return nil unless post
-
-        name = post.glyph_name_for(glyph_id)
-        return nil if name.nil? || name.empty?
-
-        name
-      rescue StandardError
-        nil
       end
     end
   end

--- a/lib/fontisan/svg/font_generator.rb
+++ b/lib/fontisan/svg/font_generator.rb
@@ -28,7 +28,7 @@ module Fontisan
       # @return [TrueTypeFont, OpenTypeFont] Font instance
       attr_reader :font
 
-      # @return [Hash] Glyph data map (glyph_id => {outline, unicode, name, advance})
+      # @return [Hash] Glyph data map (glyph_id => {outline, codepoints, name, advance})
       attr_reader :glyph_data
 
       # @return [Hash] Generation options
@@ -179,7 +179,7 @@ module Fontisan
 
           glyph_generator.generate_glyph_xml(
             data[:outline],
-            unicode: data[:unicode],
+            codepoints: data[:codepoints],
             glyph_name: data[:name],
             advance_width: data[:advance],
             indent: "      ",

--- a/lib/fontisan/svg/glyph_generator.rb
+++ b/lib/fontisan/svg/glyph_generator.rb
@@ -20,7 +20,7 @@ module Fontisan
     #
     # @example Generate SVG glyph element
     #   generator = GlyphGenerator.new(calculator)
-    #   xml = generator.generate_glyph_xml(outline, unicode: "A", advance_width: 600)
+    #   xml = generator.generate_glyph_xml(outline, codepoints: [0x41], advance_width: 600)
     class GlyphGenerator
       # @return [ViewBoxCalculator] Coordinate calculator
       attr_reader :calculator
@@ -38,23 +38,30 @@ module Fontisan
       # Generate SVG glyph element
       #
       # @param outline [Models::GlyphOutline] Glyph outline
-      # @param unicode [String, nil] Unicode character
-      # @param glyph_name [String, nil] Glyph name
+      # @param codepoints [Array<Integer>] Unicode codepoints that cmap
+      #   maps to this glyph. Empty for unmapped glyphs (.notdef, raw
+      #   ligatures, etc.). Each codepoint is rendered per SVG Fonts
+      #   spec: printable ASCII as the character (XML-escaped), others
+      #   as &#xHEX; entities. Multiple codepoints are concatenated —
+      #   rare but valid (e.g. a glyph mapped from both space and
+      #   non-breaking space).
+      # @param glyph_name [String, nil] Glyph name from the post table
       # @param advance_width [Integer] Horizontal advance width
       # @param indent [String] Indentation string
       # @return [String] XML glyph element
-      def generate_glyph_xml(outline, unicode: nil, glyph_name: nil,
+      def generate_glyph_xml(outline, codepoints: [], glyph_name: nil,
 advance_width: 0, indent: "      ")
-        # Build attribute parts
         attr_parts = []
 
-        attr_parts << "unicode=\"#{escape_xml(unicode)}\"" if unicode
-        attr_parts << "glyph-name=\"#{escape_xml(glyph_name)}\"" if glyph_name
-        attr_parts << "horiz-adv-x=\"#{advance_width}\"" if advance_width&.positive?
+        unless codepoints.empty?
+          attr_parts << %(unicode="#{format_codepoints(codepoints)}")
+        end
+        attr_parts << %(glyph-name="#{escape_xml(glyph_name)}") if glyph_name
+        attr_parts << %(horiz-adv-x="#{advance_width}") if advance_width&.positive?
 
         # Generate SVG path with Y-axis transformation
         path_data = generate_svg_path(outline)
-        attr_parts << "d=\"#{path_data}\"" if path_data && !path_data.empty?
+        attr_parts << %(d="#{path_data}") if path_data && !path_data.empty?
 
         "#{indent}<glyph #{attr_parts.join(' ')}/>"
       end
@@ -87,6 +94,34 @@ advance_width: 0, indent: "      ")
       end
 
       private
+
+      # Format an array of codepoints as the SVG `unicode=` attribute
+      # value. Returns the FINAL string — already escaped / entity-fied.
+      # The caller must not re-escape it (would double-escape the
+      # entities this method emits).
+      #
+      # Per SVG Fonts spec, each codepoint renders as either:
+      #   - printable ASCII (0x20..0x7E): the character itself, with
+      #     XML-special chars (&, <, >, ", ') escaped
+      #   - any other codepoint: a numeric entity &#xHEX;
+      #
+      # Multiple codepoints are concatenated in codepoint order. The
+      # SVG spec accepts this for ligature-style mappings.
+      def format_codepoints(codepoints)
+        codepoints.map { |cp| format_codepoint(cp) }.join
+      end
+
+      def format_codepoint(cp)
+        if printable_ascii?(cp)
+          escape_xml(cp.chr(Encoding::UTF_8))
+        else
+          "&#x#{cp.to_s(16).upcase};"
+        end
+      end
+
+      def printable_ascii?(cp)
+        (0x20..0x7E).cover?(cp)
+      end
 
       # Build SVG path for a contour with Y-axis transformation
       #

--- a/spec/fontisan/converters/svg_generator_spec.rb
+++ b/spec/fontisan/converters/svg_generator_spec.rb
@@ -104,5 +104,96 @@ RSpec.describe Fontisan::Converters::SvgGenerator do
       expect(svg).to be_a(String)
       expect(svg).to include("<svg")
     end
+
+    context "with per-glyph unicode and glyph-name attributes (issue #80)" do
+      let(:svg) { generator.convert(font)[:svg_xml] }
+
+      it "emits glyph-name on every <glyph> element" do
+        # Every glyph — including .notdef — should carry a glyph-name.
+        # post v2.0 fonts supply canonical names; the gidN fallback
+        # covers any gaps.
+        glyph_lines = svg.scan(/<glyph [^>]*\/>/)
+        expect(glyph_lines).not_to be_empty
+        expect(glyph_lines).to all(match(/glyph-name="[^"]+"/))
+      end
+
+      it "emits unicode on <glyph> elements that have cmap mappings" do
+        # At least the ASCII range should appear as unicode="...". We
+        # pick a few printable ASCII characters that MonaSans-ExtraLightItalic
+        # is guaranteed to map (letters, digits, common punctuation).
+        expect(svg).to match(/unicode="[A-Za-z0-9]"/)
+      end
+
+      it "renders non-ASCII codepoints as numeric entities" do
+        # Any glyph whose cmap mapping includes a codepoint > 0x7E must
+        # surface that codepoint as a &#xHEX; entity in the unicode
+        # attribute. We don't pin a specific codepoint — fonts differ
+        # in cmap ordering — but every CJK/Latin-Extended font has at
+        # least one.
+        entities = svg.scan(/unicode="[^"]*(&#x[0-9A-Fa-f]+;)[^"]*"/)
+          .map(&:first).uniq
+        expect(entities).not_to be_empty
+
+        # Every matched entity must be a codepoint above printable ASCII
+        # (the whole point of entity-encoding).
+        entities.each do |entity|
+          hex = entity.match(/^&#x([0-9A-Fa-f]+);$/).captures.first
+          expect(hex.to_i(16)).to be > 0x7E
+        end
+      end
+
+      it "escapes XML-special ASCII codepoints rather than emitting them raw" do
+        # If the font maps any of <, >, &, ", ' to a glyph, that codepoint
+        # must appear in `unicode=` as the named entity (&lt; &gt; &amp;
+        # &quot; &apos;), never as the raw character inside an attribute.
+        # These are all in printable ASCII so they go through the
+        # char-then-escape path, not the hex-entity path.
+        cmap = font.table("cmap")
+        named_entities = {
+          0x3C => "&lt;",
+          0x3E => "&gt;",
+          0x26 => "&amp;",
+          0x22 => "&quot;",
+          0x27 => "&apos;",
+        }
+        present = named_entities.select { |cp, _| cmap.unicode_mappings.key?(cp) }
+        skip "font has no XML-special codepoints in cmap" if present.empty?
+
+        present.each_value { |entity| expect(svg).to include(%(unicode="#{entity}")) }
+
+        # No attribute value should contain a raw < or unescaped &.
+        svg.scan(/unicode="([^"]*)"/).each do |(value)|
+          stripped = value
+            .gsub("&lt;", "").gsub("&gt;", "").gsub("&quot;", "")
+            .gsub("&apos;", "").gsub("&amp;", "").gsub(/&#x[0-9A-Fa-f]+;/, "")
+          expect(stripped).not_to include("<")
+          expect(stripped).not_to include("&")
+        end
+      end
+
+      it "omits unicode= on .notdef (no cmap mapping)" do
+        notdef_line = svg.scan(/<glyph [^>]*\/>/).find { |l| l.include?('glyph-name=".notdef"') }
+        expect(notdef_line).not_to be_nil
+        expect(notdef_line).not_to include("unicode=")
+      end
+
+      it "supports glyphs mapped from multiple codepoints" do
+        # Find a glyph mapped from >1 codepoint (common: space and
+        # non-breaking space share a glyph). The unicode attribute
+        # should carry both, concatenated.
+        cmap = font.table("cmap")
+        gid_to_cps = cmap.unicode_mappings.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(cp, gid), h|
+          h[gid] << cp
+        end
+        multi_cps_gid = gid_to_cps.find { |_gid, cps| cps.size > 1 }&.first
+        skip "font has no multi-codepoint glyph" unless multi_cps_gid
+
+        # Build the expected unicode string and verify it appears.
+        expected = gid_to_cps[multi_cps_gid].map do |cp|
+          (0x20..0x7E).cover?(cp) ? cp.chr(Encoding::UTF_8) : "&#x#{cp.to_s(16).upcase};"
+        end.join
+        expect(svg).to include(%(unicode="#{expected}"))
+      end
+    end
   end
 end

--- a/spec/fontisan/svg/font_generator_spec.rb
+++ b/spec/fontisan/svg/font_generator_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Fontisan::Svg::FontGenerator do
     {
       0 => {
         outline: nil,
-        unicode: nil,
+        codepoints: [],
         name: ".notdef",
         advance: 500,
       },
       65 => {
         outline: create_test_outline(65),
-        unicode: "A",
+        codepoints: [0x41],
         name: "A",
         advance: 600,
       },

--- a/spec/fontisan/svg/glyph_generator_spec.rb
+++ b/spec/fontisan/svg/glyph_generator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Fontisan::Svg::GlyphGenerator do
     it "generates glyph XML element" do
       xml = generator.generate_glyph_xml(
         outline,
-        unicode: "A",
+        codepoints: [0x41],
         advance_width: 600,
       )
 
@@ -59,7 +59,7 @@ RSpec.describe Fontisan::Svg::GlyphGenerator do
     it "includes glyph name when provided" do
       xml = generator.generate_glyph_xml(
         outline,
-        unicode: "A",
+        codepoints: [0x41],
         glyph_name: "A",
         advance_width: 600,
       )
@@ -86,14 +86,39 @@ RSpec.describe Fontisan::Svg::GlyphGenerator do
       expect(xml).not_to include("d=")
     end
 
-    it "escapes XML characters in unicode" do
+    it "escapes XML-special ASCII codepoints" do
       xml = generator.generate_glyph_xml(
         outline,
-        unicode: "<",
+        codepoints: [0x3C], # "<"
         advance_width: 600,
       )
 
       expect(xml).to include('unicode="&lt;"')
+    end
+
+    it "emits numeric entities for non-ASCII codepoints" do
+      xml = generator.generate_glyph_xml(
+        outline,
+        codepoints: [0x2026], # "…"
+        advance_width: 600,
+      )
+
+      expect(xml).to include('unicode="&#x2026;"')
+    end
+
+    it "concatenates multiple codepoints into one unicode attribute" do
+      xml = generator.generate_glyph_xml(
+        outline,
+        codepoints: [0x41, 0x42], # "AB"
+        advance_width: 600,
+      )
+
+      expect(xml).to include('unicode="AB"')
+    end
+
+    it "omits the unicode attribute when codepoints is empty" do
+      xml = generator.generate_glyph_xml(outline, advance_width: 600)
+      expect(xml).not_to include("unicode=")
     end
 
     it "uses custom indentation" do


### PR DESCRIPTION
## Summary

- `SvgGenerator#extract_glyph_data` now reads `cmap.unicode_mappings` directly (replacing the broken `cmap.subtable(...)` path) and builds a glyph_id → [codepoint, ...] reverse map. Glyph names come from `post.glyph_names[gid]` with a `gidN` fallback for post v3 fonts.
- `GlyphGenerator#generate_glyph_xml` takes `codepoints:` (Array<Integer>) instead of `unicode:` (String). Each codepoint renders per SVG Fonts spec: printable ASCII as the character (XML-escaped), everything else as a numeric `&#xHEX;` entity. Multiple codepoints concatenate.

## Root cause

`SvgGenerator` was written against APIs that don't exist on the current `Tables::Cmap` and `Tables::Post`:

- `cmap.subtable(platform, encoding)` and `cmap.subtables.first` — neither exists; only `cmap.unicode_mappings` is the real API. Every lookup raised `NoMethodError`, got rescued to nil, and `unicode_map` came back empty.
- `post.glyph_name_for(gid)` — also doesn't exist; the real API is `post.glyph_names` (Array<String> indexed by gid).

So the generator emitted `<glyph d="..."/>` with no `unicode` or `glyph-name` attributes, forcing downstream consumers (like essenfont) to rebuild the cmap → gid mapping externally and couple to fontisan's GID-ordering assumption.

## Output now matches SVG 1.1 Fonts spec

```xml
<glyph unicode="A" glyph-name="A" d="..."/>
<glyph unicode="&#x2026;" glyph-name="ellipsis" d="..."/>
<glyph glyph-name=".notdef" d="..."/>
```

## Spec coverage

- `glyph_generator_spec.rb`: new tests for codepoint-to-attribute formatting (printable ASCII, non-ASCII entities, multi-codepoint concatenation, empty codepoints omits attribute, XML-special escaping).
- `svg_generator_spec.rb`: end-to-end coverage on MonaSans-ExtraLightItalic, including non-ASCII entity formatting, XML-special escaping invariant (no raw `<` or `&` in attribute values), `.notdef` has no `unicode=`, multi-codepoint glyph support.
- `font_generator_spec.rb`: fixture data updated to the new `codepoints:` shape.

## Test plan

- [x] `bundle exec rspec spec/fontisan/svg/ spec/fontisan/converters/svg_generator_spec.rb` — 80 examples, 0 failures, 1 pending (font has no multi-codepoint glyph)
- [x] `bundle exec rspec` — 5712 examples, 0 failures, 3 pre-existing pending
- [x] `bundle exec rubocop` — clean

Closes #80.
