### PR TITLE
stitcher: add remap: kwarg to add_source for non-canonical donors (fixes #81)

### DIFF
--- a/lib/fontisan/stitcher.rb
+++ b/lib/fontisan/stitcher.rb
@@ -52,8 +52,8 @@ module Fontisan
       @deduplicate = deduplicate
     end
 
-    def add_source(label, font)
-      @sources[label.to_sym] = Source.new(font)
+    def add_source(label, font, remap: nil)
+      @sources[label.to_sym] = Source.new(font, remap: remap)
     end
 
     def include_range(range, from:, into:)

--- a/lib/fontisan/stitcher/source.rb
+++ b/lib/fontisan/stitcher/source.rb
@@ -15,14 +15,49 @@ module Fontisan
     # #bitmap_mode. When a source is :cbdt, the Stitcher propagates
     # the raw CBDT/CBLC tables into the output instead of extracting
     # outlines. The glyph data lives in the bitmap tables, not in glyf.
+    #
+    # = Codepoint remap
+    #
+    # Some donor fonts ship glyphs at non-canonical codepoints — a
+    # keyboard-mapped font whose "A" is at U+0041, or a PUA-allocated
+    # pre-Unicode font. Pass a +remap:+ hash at construction to expose
+    # those glyphs at their canonical codepoints without mutating the
+    # donor font's cmap:
+    #
+    #   Source.new(font, remap: { 0x41 => 0x11DB0 })
+    #
+    # With a remap set, the source answers +gid_for_codepoint+ for the
+    # *target* codepoints (0x11DB0 in the example) by translating them
+    # to the donor's *source* codepoints (0x41). Source codepoints not
+    # listed in the remap are hidden — only the remapped coverage is
+    # exposed. This matches the typical "use this donor for exactly
+    # these output characters" intent, and avoids leaking the donor's
+    # ASCII/PUA noise into the output.
     class Source
       MAX_COMPOUND_DEPTH = 32
 
-      attr_reader :font
+      attr_reader :font, :remap
 
-      def initialize(font)
+      # @param font [TrueTypeFont, OpenTypeFont, Ufo::Font] donor font
+      # @param remap [Hash{Integer=>Integer}, nil] optional
+      #   {source_codepoint => target_codepoint}. When present (even
+      #   empty), source codepoints not listed are hidden from
+      #   lookups. Pass +nil+ (the default) for the passthrough
+      #   behavior — every donor codepoint is exposed as-is.
+      def initialize(font, remap: nil)
         @font = font
         @bin_data_cache = nil
+
+        # Distinguish "no remap kwarg" (nil → passthrough) from
+        # "explicit empty remap" ({} → drop everything). The latter
+        # still flips the source into remapped mode, just with no
+        # entries — every donor codepoint gets filtered out.
+        return unless remap
+
+        @remap = remap.to_h.transform_keys(&:to_i).transform_values(&:to_i)
+        @inverse_remap = @remap.each_with_object({}) do |(src, target), h|
+          h[target] = src
+        end
       end
 
       # @return [Symbol] :ufo, :ttf, :otf
@@ -57,12 +92,21 @@ module Fontisan
       end
 
       # Find the gid for a Unicode codepoint in this source.
+      #
+      # When +remap+ was set at construction, +codepoint+ is treated as
+      # a *target* codepoint — the source codepoint that maps to it via
+      # +remap+ is what actually gets looked up. Returns +nil+ for
+      # codepoints the remap does not cover.
+      #
       # @param codepoint [Integer]
       # @return [Integer, nil]
       def gid_for_codepoint(codepoint)
+        src_cp = source_codepoint_for(codepoint)
+        return nil unless src_cp
+
         case @font
-        when Fontisan::Ufo::Font then ufo_gid_for(codepoint)
-        else bin_data_gid_for(codepoint)
+        when Fontisan::Ufo::Font then ufo_gid_for(src_cp)
+        else bin_data_gid_for(src_cp)
         end
       end
 
@@ -317,13 +361,50 @@ module Fontisan
       end
 
       # Add Unicode codepoints from the cmap that map to this gid.
+      #
+      # When +remap+ was set at construction, the source's raw codepoints
+      # are translated through the remap (source→target), and source
+      # codepoints not in the remap are dropped. Otherwise the raw cmap
+      # codepoints are attached as-is.
       def add_cmap_unicodes(gid, glyph)
-        cmap = @font.table("cmap")
-        return unless cmap
+        effective_codepoints_for_gid(gid).each { |cp| glyph.add_unicode(cp) }
+      end
 
-        (cmap.unicode_mappings || {}).each do |cp, g|
-          glyph.add_unicode(cp) if g == gid
+      # Translate a caller-facing codepoint to the donor's own codepoint.
+      # Without remap, the two are identical. With remap, the caller's
+      # codepoint is the *target*; look up the source codepoint that
+      # maps to it. Returns +nil+ if no remap entry covers the target.
+      def source_codepoint_for(codepoint)
+        return codepoint unless @remap
+
+        @inverse_remap[codepoint]
+      end
+
+      # Codepoints that should be attached to a glyph at the given gid,
+      # after applying the remap (if any).
+      def effective_codepoints_for_gid(gid)
+        raw_cmap = self.raw_cmap
+        raw_cmap.each_with_object([]) do |(src_cp, g), cps|
+          next unless g == gid
+
+          if @remap
+            target = @remap[src_cp]
+            cps << target if target
+          else
+            cps << src_cp
+          end
         end
+      end
+
+      # The raw cmap hash from the donor's table. Always {src_cp => gid};
+      # never remapped. UFO sources return {} (no cmap table).
+      def raw_cmap
+        cmap = @font.table("cmap")
+        return {} unless cmap
+
+        cmap.unicode_mappings || {}
+      rescue StandardError
+        {}
       end
     end
   end

--- a/spec/fontisan/stitcher/source_remap_spec.rb
+++ b/spec/fontisan/stitcher/source_remap_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/stitcher"
+
+# Issue #81: Stitcher#add_source(label, font, remap:) gives donors
+# whose glyphs live at non-canonical codepoints a first-class API for
+# exposing those glyphs at their canonical targets, without callers
+# reaching into the donor's cached cmap.
+RSpec.describe Fontisan::Stitcher::Source, "#remap" do
+  let(:donor) { Fontisan::FontLoader.load("spec/fixtures/fonttools/TestTTF.ttf") }
+
+  # TestTTF has 5 cmap entries: U+0000, U+000D, U+0020 (space),
+  # U+002E (period), U+2026 (ellipsis). Of these, gids 1-3 (whitespace
+  # / control) have no outlines — extract_truetype_glyph returns nil
+  # for them. Gid 4 (period) is the simplest glyph with real outlines,
+  # so use it for tests that need to inspect the extracted glyph.
+  let(:source_cp) { 0x2E } # period
+  let(:source_gid) { donor.table("cmap").unicode_mappings[source_cp] }
+
+  describe "without remap (default)" do
+    let(:source) { described_class.new(donor) }
+
+    it "looks up the donor's raw codepoints directly" do
+      expect(source.gid_for_codepoint(source_cp)).to eq(source_gid)
+    end
+
+    it "exposes every codepoint the donor's cmap has" do
+      expect(source.remap).to be_nil
+    end
+
+    it "attaches the donor's raw codepoints to extracted glyphs" do
+      glyph = source.glyph_for_gid(source_gid)
+      expect(glyph.unicodes).to include(source_cp)
+    end
+  end
+
+  describe "with a remap" do
+    # Pretend the donor's space + period glyphs are actually letters
+    # of a hypothetical script that lives at U+11DB0.. (essenfont's
+    # Tolong Siki range). The remap exposes those glyphs at the new
+    # targets while keeping the donor's cmap untouched.
+    let(:remap) do
+      { source_cp => 0x11DB0 }
+    end
+    let(:source) { described_class.new(donor, remap: remap) }
+
+    it "exposes the remap hash on the #remap reader" do
+      expect(source.remap).to eq(remap)
+    end
+
+    it "looks up target codepoints via the remap (translates to source)" do
+      expect(source.gid_for_codepoint(0x11DB0)).to eq(source_gid)
+    end
+
+    it "returns nil for codepoints the remap does not cover" do
+      # Source cps not in the remap are hidden — looking up the raw
+      # source cp directly must return nil.
+      expect(source.gid_for_codepoint(source_cp)).to be_nil
+      # And codepoints the remap doesn't target are nil too.
+      expect(source.gid_for_codepoint(0x11DB5)).to be_nil
+    end
+
+    it "does not mutate the donor's cmap" do
+      original_mappings = donor.table("cmap").unicode_mappings
+      original_size = original_mappings.size
+
+      # Force a lookup that runs the remap path.
+      source.gid_for_codepoint(0x11DB0)
+
+      expect(donor.table("cmap").unicode_mappings.size).to eq(original_size)
+      expect(donor.table("cmap").unicode_mappings[source_cp]).to eq(source_gid)
+    end
+
+    it "attaches target codepoints (not source codepoints) to extracted glyphs" do
+      glyph = source.glyph_for_gid(source_gid)
+      expect(glyph.unicodes).to include(0x11DB0)
+      expect(glyph.unicodes).not_to include(source_cp)
+    end
+
+    it "accepts string keys and coerces to Integer" do
+      # Some manifests (YAML loaders) hand back string keys. Coerce
+      # rather than blow up — matches the issue body's proposal.
+      source_with_strings = described_class.new(donor, remap: { source_cp.to_s => 0x11DB0.to_s })
+      expect { source_with_strings.gid_for_codepoint(0x11DB0) }.not_to raise_error
+    end
+
+    it "supports multiple sources with different remaps on one Stitcher" do
+      stitcher = Fontisan::Stitcher.new
+      stitcher.add_source(:remapped, donor, remap: { source_cp => 0x11DB0 })
+      stitcher.add_source(:passthrough, donor)
+
+      remapped_gid = stitcher.instance_variable_get(:@sources)[:remapped].gid_for_codepoint(0x11DB0)
+      passthrough_gid = stitcher.instance_variable_get(:@sources)[:passthrough].gid_for_codepoint(source_cp)
+
+      expect(remapped_gid).to eq(source_gid)
+      expect(passthrough_gid).to eq(source_gid)
+    end
+  end
+
+  describe "with an empty remap" do
+    let(:source) { described_class.new(donor, remap: {}) }
+
+    it "exposes no codepoints (every source cp is dropped by design)" do
+      expect(source.gid_for_codepoint(source_cp)).to be_nil
+    end
+
+    it "does not attach any codepoints to extracted glyphs" do
+      glyph = source.glyph_for_gid(source_gid)
+      attached = glyph.unicodes & donor.table("cmap").unicode_mappings.keys
+      expect(attached).to be_empty
+    end
+  end
+
+  describe Fontisan::Stitcher, "#add_source with remap:" do
+    it "forwards the remap to the Source it constructs" do
+      stitcher = described_class.new
+      stitcher.add_source(:tolong_siki, donor, remap: { source_cp => 0x11DB0 })
+
+      source = stitcher.instance_variable_get(:@sources)[:tolong_siki]
+      expect(source).to be_a(Fontisan::Stitcher::Source)
+      expect(source.remap).to eq(source_cp => 0x11DB0)
+    end
+
+    it "defaults remap to nil when omitted (backwards-compatible)" do
+      stitcher = described_class.new
+      stitcher.add_source(:plain, donor)
+
+      source = stitcher.instance_variable_get(:@sources)[:plain]
+      expect(source.remap).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `Stitcher#add_source(label, font, remap:)` accepts an optional `{src_cp => target_cp}` hash and forwards it to `Source.new`.
- `Source` stores the remap alongside a precomputed inverse. `gid_for_codepoint` and `add_cmap_unicodes` consult the inverse to translate target codepoints → source codepoints before touching the donor's raw cmap.
- The donor's cmap is never mutated. The remap is purely a translation layer at the front of the source's API.

## API

```ruby
# Before — caller mutates the cached cmap and prays it stays cached:
cmap = font.table("cmap")
cmap.unicode_mappings.replace(new_map)
stitcher.add_source(:tolong_siki, font)

# After — one keyword, no internals:
stitcher.add_source(:tolong_siki, font, remap: { 0x41 => 0x11DB0, ... })
```

Semantics:
- `remap: nil` (default) — passthrough; every donor codepoint is exposed as-is. Backwards-compatible.
- `remap: { src => target, ... }` — source codepoints not listed are hidden; only remapped coverage is exposed.
- `remap: {}` (explicit empty) — every source codepoint is dropped. Matches the "use this donor for exactly these output characters" intent.

## Spec coverage (`spec/fontisan/stitcher/source_remap_spec.rb`, 14 examples)

- Passthrough behavior unchanged when no remap is given.
- Target lookups translate through the inverse to source gids; codepoints the remap doesn't cover return nil.
- Donor's cmap is never mutated (size + values pinned before and after a remapped lookup).
- Extracted glyphs carry target codepoints, not source codepoints (no leaking donor noise).
- String keys in the remap are coerced to Integer (YAML manifest interop).
- Empty remap hides every source codepoint.
- Multiple sources with different remaps on one Stitcher.
- `Stitcher#add_source` forwards the kwarg; defaults to nil when omitted.

## Test plan

- [x] `bundle exec rspec spec/fontisan/stitcher/source_remap_spec.rb` — 14 examples, 0 failures
- [x] `bundle exec rspec` — 5717 examples, 0 failures, 2 pre-existing pending
- [x] `bundle exec rubocop` — clean across 686 files

Closes #81.
