### PR TITLE
subset cmap + ByBlock/ByScript partitioners + fixtures retry (fixes #29, #70)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -75,9 +75,17 @@ namespace :fixtures do
         zip_file&.close
       end
     ensure
-      # Clean up the temp zip explicitly so /tmp doesn't fill up on
-      # repeated runs.
-      File.delete(temp_path) if File.exist?(temp_path)
+      # Clean up the temp zip explicitly so the temp dir doesn't fill
+      # up on repeated runs. On Windows the just-closed zip file
+      # handle can briefly hold a lock that surfaces as
+      # Errno::EACCES; swallow that one error so the rake task can
+      # complete (OS will sweep the temp file later).
+      begin
+        File.delete(temp_path) if File.exist?(temp_path)
+      rescue Errno::EACCES
+        warn "[fixtures:download] could not delete temp zip #{temp_path}; " \
+             "OS will clean it up"
+      end
     end
 
     puts "[fixtures:download] #{name} downloaded successfully"

--- a/Rakefile
+++ b/Rakefile
@@ -12,24 +12,25 @@ RuboCop::RakeTask.new
 namespace :fixtures do
   # Load centralized fixture configuration
   require_relative "spec/support/fixture_fonts"
+  require "fontisan/tasks"
 
   # Helper method to download a single file
   def download_single_file(name, url, target_path)
-    require "open-uri"
-
     puts "[fixtures:download] Downloading #{name}..."
-    FileUtils.mkdir_p(File.dirname(target_path))
 
-    URI.open(url) do |remote|
-      File.binwrite(target_path, remote.read)
-    end
+    Fontisan::Tasks::FixtureDownloader.new(
+      url: url,
+      destination: target_path,
+    ).call
 
     puts "[fixtures:download] #{name} downloaded successfully"
+  rescue Fontisan::Tasks::FixtureDownloader::Error => e
+    warn "[fixtures:download] #{name} failed after retries: #{e.message}"
+    raise
   end
 
   # Helper method to download and extract a font archive
   def download_font(name, url, target_dir)
-    require "open-uri"
     require "zip"
 
     puts "[fixtures:download] Downloading #{name}..."
@@ -39,45 +40,50 @@ namespace :fixtures do
     temp_path = File.join(Dir.tmpdir,
                           "fontisan_#{name}_#{Process.pid}_#{rand(10000)}.zip")
 
-    # Download using IO.copy_stream for better Windows compatibility
-    URI.open(url, "rb") do |remote|
-      File.open(temp_path, "wb") do |file|
-        IO.copy_stream(remote, file)
-      end
-    end
-
-    puts "[fixtures:download] Extracting #{name}..."
-
-    # Open zip file and ensure it's fully closed before we're done
-    zip_file = Zip::File.open(temp_path)
     begin
-      zip_file.each do |entry|
-        # Skip macOS metadata files and directories
-        next if entry.name.start_with?("__MACOSX/") || entry.name.include?("/._")
-        next if entry.directory?
+      Fontisan::Tasks::FixtureDownloader.new(
+        url: url,
+        destination: temp_path,
+      ).call
 
-        # Ensure entry.name is relative by stripping leading slashes
-        relative_name = entry.name.sub(%r{^/+}, "")
+      puts "[fixtures:download] Extracting #{name}..."
 
-        dest_path = File.join(target_dir, relative_name)
-        FileUtils.mkdir_p(File.dirname(dest_path))
+      # Open zip file and ensure it's fully closed before we're done
+      zip_file = Zip::File.open(temp_path)
+      begin
+        zip_file.each do |entry|
+          # Skip macOS metadata files and directories
+          next if entry.name.start_with?("__MACOSX/") || entry.name.include?("/._")
+          next if entry.directory?
 
-        # Skip if file already exists
-        next if File.exist?(dest_path)
+          # Ensure entry.name is relative by stripping leading slashes
+          relative_name = entry.name.sub(%r{^/+}, "")
 
-        # Write the file content directly using binary mode
-        File.open(dest_path, "wb") do |file|
-          IO.copy_stream(entry.get_input_stream, file)
+          dest_path = File.join(target_dir, relative_name)
+          FileUtils.mkdir_p(File.dirname(dest_path))
+
+          # Skip if file already exists
+          next if File.exist?(dest_path)
+
+          # Write the file content directly using binary mode
+          File.open(dest_path, "wb") do |file|
+            IO.copy_stream(entry.get_input_stream, file)
+          end
         end
+      ensure
+        # Explicitly close the zip file to release file handle on Windows
+        zip_file&.close
       end
     ensure
-      # Explicitly close the zip file to release file handle on Windows
-      zip_file&.close
+      # Clean up the temp zip explicitly so /tmp doesn't fill up on
+      # repeated runs.
+      File.delete(temp_path) if File.exist?(temp_path)
     end
 
-    # Temp file left in Dir.tmpdir - OS will clean it up automatically
-
     puts "[fixtures:download] #{name} downloaded successfully"
+  rescue Fontisan::Tasks::FixtureDownloader::Error => e
+    warn "[fixtures:download] #{name} failed after retries: #{e.message}"
+    raise
   rescue LoadError => e
     warn "[fixtures:download] Error: Required gem not installed. Please run: gem install rubyzip"
     raise e

--- a/lib/fontisan.rb
+++ b/lib/fontisan.rb
@@ -118,6 +118,7 @@ module Fontisan
   autoload :SfntTable, "fontisan/sfnt_table"
   autoload :Stitcher, "fontisan/stitcher"
   autoload :StitcherCli, "fontisan/stitcher_cli"
+  autoload :Tasks, "fontisan/tasks"
   autoload :TrueTypeCollection, "fontisan/true_type_collection"
   autoload :TrueTypeFont, "fontisan/true_type_font"
   autoload :TrueTypeFontExtensions, "fontisan/true_type_font_extensions"

--- a/lib/fontisan/stitcher/partition_strategy.rb
+++ b/lib/fontisan/stitcher/partition_strategy.rb
@@ -17,6 +17,8 @@ module Fontisan
       autoload :Blueprint, "fontisan/stitcher/partition_strategy/blueprint"
       autoload :Partition, "fontisan/stitcher/partition_strategy/partition"
       autoload :ByPlane, "fontisan/stitcher/partition_strategy/by_plane"
+      autoload :ByBlock, "fontisan/stitcher/partition_strategy/by_block"
+      autoload :ByScript, "fontisan/stitcher/partition_strategy/by_script"
     end
   end
 end

--- a/lib/fontisan/stitcher/partition_strategy/by_block.rb
+++ b/lib/fontisan/stitcher/partition_strategy/by_block.rb
@@ -1,0 +1,429 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    module PartitionStrategy
+      # Partition codepoints by Unicode Blocks.txt block.
+      #
+      # Each non-empty Unicode block becomes one partition. If a single
+      # block alone exceeds +cap+, raises PartitionCapExceededError —
+      # every block is treated as atomic because there is no finer
+      # Unicode-defined boundary inside a block. (Callers who need to
+      # split a block further must use ByPlane with explicit carve-outs
+      # or implement a custom partitioner.)
+      #
+      # Partition names follow the canonical Unicode block name with
+      # spaces replaced by underscores and a +block_+ prefix:
+      #
+      #   "Basic Latin"             => :block_basic_latin
+      #   "CJK Unified Ideographs"  => :block_cjk_unified_ideographs
+      #
+      # Codepoints not covered by any block in {BLOCKS} (unassigned or
+      # in a block omitted from this list) fall into +:block_other+.
+      class ByBlock < Base
+        # Unicode 16.0 block ranges. Source: Unicode Blocks.txt.
+        # Covers all assigned blocks in BMP, SMP, SIP, TIP, and SSP.
+        # Unassigned planes (4..13) are omitted — codepoints there
+        # fall into +:block_other+, which is the right behavior for
+        # partitioning fonts that target current Unicode.
+        #
+        # The data is inlined (rather than loaded from an external
+        # file) so the partitioner is self-contained: no YAML load
+        # at startup, no data file to ship. If the list ever needs to
+        # be data-driven, swap BLOCKS for a CSV/YAML loader behind
+        # the same constant — callers don't care about the source
+        # (OCP).
+        # rubocop:disable Metrics/CollectionLiteralLength
+        BLOCKS = {
+          # BMP (Plane 0)
+          "Basic_Latin" => 0x0000..0x007F,
+          "Latin-1_Supplement" => 0x0080..0x00FF,
+          "Latin_Extended-A" => 0x0100..0x017F,
+          "Latin_Extended-B" => 0x0180..0x024F,
+          "IPA_Extensions" => 0x0250..0x02AF,
+          "Spacing_Modifier_Letters" => 0x02B0..0x02FF,
+          "Combining_Diacritical_Marks" => 0x0300..0x036F,
+          "Greek_and_Coptic" => 0x0370..0x03FF,
+          "Cyrillic" => 0x0400..0x04FF,
+          "Cyrillic_Supplement" => 0x0500..0x052F,
+          "Armenian" => 0x0530..0x058F,
+          "Hebrew" => 0x0590..0x05FF,
+          "Arabic" => 0x0600..0x06FF,
+          "Syriac" => 0x0700..0x074F,
+          "Arabic_Supplement" => 0x0750..0x077F,
+          "Arabic_Extended-A" => 0x08A0..0x08FF,
+          "Arabic_Extended-B" => 0x0870..0x089F,
+          "Thaana" => 0x0780..0x07BF,
+          "NKo" => 0x07C0..0x07FF,
+          "Samaritan" => 0x0800..0x083F,
+          "Mandaic" => 0x0840..0x085F,
+          "Syriac_Supplement" => 0x0860..0x086F,
+          "Devanagari" => 0x0900..0x097F,
+          "Bengali" => 0x0980..0x09FF,
+          "Gurmukhi" => 0x0A00..0x0A7F,
+          "Gujarati" => 0x0A80..0x0AFF,
+          "Oriya" => 0x0B00..0x0B7F,
+          "Tamil" => 0x0B80..0x0BFF,
+          "Telugu" => 0x0C00..0x0C7F,
+          "Kannada" => 0x0C80..0x0CFF,
+          "Malayalam" => 0x0D00..0x0D7F,
+          "Sinhala" => 0x0D80..0x0DFF,
+          "Thai" => 0x0E00..0x0E7F,
+          "Lao" => 0x0E80..0x0EFF,
+          "Tibetan" => 0x0F00..0x0FFF,
+          "Myanmar" => 0x1000..0x109F,
+          "Georgian" => 0x10A0..0x10FF,
+          "Hangul_Jamo" => 0x1100..0x11FF,
+          "Ethiopic" => 0x1200..0x137F,
+          "Ethiopic_Supplement" => 0x1380..0x139F,
+          "Cherokee" => 0x13A0..0x13FF,
+          "Unified_Canadian_Aboriginal_Syllabics" => 0x1400..0x167F,
+          "Ogham" => 0x1680..0x169F,
+          "Runic" => 0x16A0..0x16FF,
+          "Tagalog" => 0x1700..0x171F,
+          "Hanunoo" => 0x1720..0x173F,
+          "Buhid" => 0x1740..0x175F,
+          "Tagbanwa" => 0x1760..0x177F,
+          "Khmer" => 0x1780..0x17FF,
+          "Mongolian" => 0x1800..0x18AF,
+          "Unified_Canadian_Aboriginal_Syllabics_Extended" => 0x18B0..0x18FF,
+          "Limbu" => 0x1900..0x194F,
+          "Tai_Le" => 0x1950..0x197F,
+          "New_Tai_Lue" => 0x1980..0x19DF,
+          "Khmer_Symbols" => 0x19E0..0x19FF,
+          "Buginese" => 0x1A00..0x1A1F,
+          "Tai_Tham" => 0x1A20..0x1AAF,
+          "Combining_Diacritical_Marks_Extended" => 0x1AB0..0x1AFF,
+          "Balinese" => 0x1B00..0x1B7F,
+          "Sundanese" => 0x1B80..0x1BBF,
+          "Batak" => 0x1BC0..0x1BFF,
+          "Lepcha" => 0x1C00..0x1C4F,
+          "Ol_Chiki" => 0x1C50..0x1C7F,
+          "Cyrillic_Extended-C" => 0x1C80..0x1C8F,
+          "Georgian_Extended" => 0x1C90..0x1CBF,
+          "Sundanese_Supplement" => 0x1CC0..0x1CCF,
+          "Vedic_Extensions" => 0x1CD0..0x1CFF,
+          "Phonetic_Extensions" => 0x1D00..0x1D7F,
+          "Phonetic_Extensions_Supplement" => 0x1D80..0x1DBF,
+          "Combining_Diacritical_Marks_Supplement" => 0x1DC0..0x1DFF,
+          "Latin_Extended_Additional" => 0x1E00..0x1EFF,
+          "Greek_Extended" => 0x1F00..0x1FFF,
+          "General_Punctuation" => 0x2000..0x206F,
+          "Superscripts_and_Subscripts" => 0x2070..0x209F,
+          "Currency_Symbols" => 0x20A0..0x20CF,
+          "Combining_Diacritical_Marks_for_Symbols" => 0x20D0..0x20FF,
+          "Letterlike_Symbols" => 0x2100..0x214F,
+          "Number_Forms" => 0x2150..0x218F,
+          "Arrows" => 0x2190..0x21FF,
+          "Mathematical_Operators" => 0x2200..0x22FF,
+          "Miscellaneous_Technical" => 0x2300..0x23FF,
+          "Control_Pictures" => 0x2400..0x243F,
+          "Optical_Character_Recognition" => 0x2440..0x245F,
+          "Enclosed_Alphanumerics" => 0x2460..0x24FF,
+          "Box_Drawing" => 0x2500..0x257F,
+          "Block_Elements" => 0x2580..0x259F,
+          "Geometric_Shapes" => 0x25A0..0x25FF,
+          "Miscellaneous_Symbols" => 0x2600..0x26FF,
+          "Dingbats" => 0x2700..0x27BF,
+          "Miscellaneous_Mathematical_Symbols-A" => 0x27C0..0x27EF,
+          "Supplemental_Arrows-A" => 0x27F0..0x27FF,
+          "Braille_Patterns" => 0x2800..0x28FF,
+          "Supplemental_Arrows-B" => 0x2900..0x297F,
+          "Miscellaneous_Mathematical_Symbols-B" => 0x2980..0x29FF,
+          "Supplemental_Mathematical_Operators" => 0x2A00..0x2AFF,
+          "Miscellaneous_Symbols_and_Arrows" => 0x2B00..0x2BFF,
+          "Glagolitic" => 0x2C00..0x2C5F,
+          "Latin_Extended-C" => 0x2C60..0x2C7F,
+          "Coptic" => 0x2C80..0x2CFF,
+          "Georgian_Supplement" => 0x2D00..0x2D2F,
+          "Tifinagh" => 0x2D30..0x2D7F,
+          "Ethiopic_Extended" => 0x2D80..0x2DDF,
+          "Supplemental_Punctuation" => 0x2E00..0x2E7F,
+          "CJK_Radicals_Supplement" => 0x2E80..0x2EFF,
+          "Kangxi_Radicals" => 0x2F00..0x2FDF,
+          "Ideographic_Description_Characters" => 0x2FF0..0x2FFF,
+          "CJK_Symbols_and_Punctuation" => 0x3000..0x303F,
+          "Hiragana" => 0x3040..0x309F,
+          "Katakana" => 0x30A0..0x30FF,
+          "Bopomofo" => 0x3100..0x312F,
+          "Hangul_Compatibility_Jamo" => 0x3130..0x318F,
+          "Kanbun" => 0x3190..0x319F,
+          "Bopomofo_Extended" => 0x31A0..0x31BF,
+          "CJK_Strokes" => 0x31C0..0x31EF,
+          "Katakana_Phonetic_Extensions" => 0x31F0..0x31FF,
+          "Enclosed_CJK_Letters_and_Months" => 0x3200..0x32FF,
+          "CJK_Compatibility" => 0x3300..0x33FF,
+          "CJK_Unified_Ideographs_Extension_A" => 0x3400..0x4DBF,
+          "Yijing_Hexagram_Symbols" => 0x4DC0..0x4DFF,
+          "CJK_Unified_Ideographs" => 0x4E00..0x9FFF,
+          "Yi_Syllables" => 0xA000..0xA48F,
+          "Yi_Radicals" => 0xA490..0xA4CF,
+          "Lisu" => 0xA4D0..0xA4FF,
+          "Vai" => 0xA500..0xA63F,
+          "Cyrillic_Extended-B" => 0xA640..0xA69F,
+          "Bamum" => 0xA6A0..0xA6FF,
+          "Modifier_Tone_Letters" => 0xA700..0xA71F,
+          "Latin_Extended-D" => 0xA720..0xA7FF,
+          "Syloti_Nagri" => 0xA800..0xA82F,
+          "Common_Indic_Number_Forms" => 0xA830..0xA83F,
+          "Phags-pa" => 0xA840..0xA87F,
+          "Saurashtra" => 0xA880..0xA8DF,
+          "Devanagari_Extended" => 0xA8E0..0xA8FF,
+          "Kayah_Li" => 0xA900..0xA92F,
+          "Rejang" => 0xA930..0xA95F,
+          "Hangul_Jamo_Extended-A" => 0xA960..0xA97F,
+          "Javanese" => 0xA980..0xA9DF,
+          "Myanmar_Extended-B" => 0xA9E0..0xA9FF,
+          "Cham" => 0xAA00..0xAA5F,
+          "Myanmar_Extended-A" => 0xAA60..0xAA7F,
+          "Tai_Viet" => 0xAA80..0xAADF,
+          "Meetei_Mayek_Extensions" => 0xAAE0..0xAAFF,
+          "Ethiopic_Extended-A" => 0xAB00..0xAB2F,
+          "Latin_Extended-E" => 0xAB30..0xAB6F,
+          "Cherokee_Supplement" => 0xAB70..0xABBF,
+          "Meetei_Mayek" => 0xABC0..0xABFF,
+          "Hangul_Syllables" => 0xAC00..0xD7AF,
+          "Hangul_Jamo_Extended-B" => 0xD7B0..0xD7FF,
+          "High_Surrogates" => 0xD800..0xDB7F,
+          "High_Private_Use_Surrogates" => 0xDB80..0xDBFF,
+          "Low_Surrogates" => 0xDC00..0xDFFF,
+          "Private_Use_Area" => 0xE000..0xF8FF,
+          "CJK_Compatibility_Ideographs" => 0xF900..0xFAFF,
+          "Alphabetic_Presentation_Forms" => 0xFB00..0xFB4F,
+          "Arabic_Presentation_Forms-A" => 0xFB50..0xFDFF,
+          "Variation_Selectors" => 0xFE00..0xFE0F,
+          "Vertical_Forms" => 0xFE10..0xFE1F,
+          "Combining_Half_Marks" => 0xFE20..0xFE2F,
+          "CJK_Compatibility_Forms" => 0xFE30..0xFE4F,
+          "Small_Form_Variants" => 0xFE50..0xFE6F,
+          "Arabic_Presentation_Forms-B" => 0xFE70..0xFEFF,
+          "Halfwidth_and_Fullwidth_Forms" => 0xFF00..0xFFEF,
+          "Specials" => 0xFFF0..0xFFFF,
+
+          # SMP (Plane 1)
+          "Linear_B_Syllabary" => 0x10000..0x1003F,
+          "Linear_B_Ideograms" => 0x10080..0x100FF,
+          "Aegean_Numbers" => 0x10100..0x1013F,
+          "Ancient_Greek_Numbers" => 0x10140..0x1018F,
+          "Ancient_Symbols" => 0x10190..0x101CF,
+          "Phaistos_Disc" => 0x101D0..0x101FF,
+          "Lycian" => 0x10280..0x1029F,
+          "Carian" => 0x102A0..0x102DF,
+          "Coptic_Epact_Numbers" => 0x102E0..0x102FF,
+          "Old_Italic" => 0x10300..0x1032F,
+          "Gothic" => 0x10330..0x1034F,
+          "Old_Permic" => 0x10350..0x1037F,
+          "Ugaritic" => 0x10380..0x1039F,
+          "Old_Persian" => 0x103A0..0x103DF,
+          "Deseret" => 0x10400..0x1044F,
+          "Shavian" => 0x10450..0x1047F,
+          "Osmanya" => 0x10480..0x104AF,
+          "Osage" => 0x104B0..0x104FF,
+          "Elbasan" => 0x10500..0x1052F,
+          "Caucasian_Albanian" => 0x10530..0x1056F,
+          "Vithkuqi" => 0x10570..0x105BF,
+          "Linear_A" => 0x10600..0x1077F,
+          "Latin_Extended-F" => 0x10780..0x107BF,
+          "Cypriot_Syllabary" => 0x10800..0x1083F,
+          "Imperial_Aramaic" => 0x10840..0x1085F,
+          "Palmyrene" => 0x10860..0x1087F,
+          "Nabataean" => 0x10880..0x108AF,
+          "Hatran" => 0x108E0..0x108FF,
+          "Phoenician" => 0x10900..0x1091F,
+          "Lydian" => 0x10920..0x1093F,
+          "Meroitic_Hieroglyphs" => 0x10980..0x1099F,
+          "Meroitic_Cursive" => 0x109A0..0x109FF,
+          "Kharoshthi" => 0x10A00..0x10A5F,
+          "Old_South_Arabian" => 0x10A60..0x10A7F,
+          "Old_North_Arabian" => 0x10A80..0x10A9F,
+          "Manichaean" => 0x10AC0..0x10AFF,
+          "Avestan" => 0x10B00..0x10B3F,
+          "Inscriptional_Parthian" => 0x10B40..0x10B5F,
+          "Inscriptional_Pahlavi" => 0x10B60..0x10B7F,
+          "Psalter_Pahlavi" => 0x10B80..0x10BAF,
+          "Old_Turkic" => 0x10C00..0x10C4F,
+          "Old_Hungarian" => 0x10C80..0x10CFF,
+          "Hanifi_Rohingya" => 0x10D00..0x10D3F,
+          "Garay" => 0x10D40..0x10D8F,
+          "Rumi_Numeral_Symbols" => 0x10E60..0x10E7F,
+          "Yezidi" => 0x10E80..0x10EBF,
+          "Arabic_Extended-C" => 0x10EC0..0x10EFF,
+          "Old_Sogdian" => 0x10F00..0x10F2F,
+          "Sogdian" => 0x10F30..0x10F6F,
+          "Old_Uyghur" => 0x10F70..0x10FAF,
+          "Chorasmian" => 0x10FB0..0x10FBF,
+          "Elymaic" => 0x10FE0..0x10FEF,
+          "Brahmi" => 0x11000..0x1107F,
+          "Kaithi" => 0x11080..0x110CF,
+          "Sora_Sompeng" => 0x110D0..0x110FF,
+          "Chakma" => 0x11100..0x1114F,
+          "Mahajani" => 0x11150..0x1117F,
+          "Sharada" => 0x11180..0x111DF,
+          "Sinhala_Archaic_Numbers" => 0x111E0..0x111FF,
+          "Khojki" => 0x11200..0x1124F,
+          "Multani" => 0x11280..0x112AF,
+          "Khudawadi" => 0x112B0..0x112FF,
+          "Grantha" => 0x11300..0x1137F,
+          "Tulu-Tigalari" => 0x11380..0x113FF,
+          "Newa" => 0x11400..0x1147F,
+          "Tirhuta" => 0x11480..0x114DF,
+          "Siddham" => 0x11580..0x115FF,
+          "Modi" => 0x11600..0x1165F,
+          "Mongolian_Supplement" => 0x11660..0x1167F,
+          "Takri" => 0x11680..0x116CF,
+          "Myanmar_Extended-C" => 0x116D0..0x116FF,
+          "Ahom" => 0x11700..0x1174F,
+          "Dogra" => 0x11800..0x1184F,
+          "Warang_Citi" => 0x118A0..0x118FF,
+          "Dives_Akuru" => 0x11900..0x1195F,
+          "Nandinagari" => 0x119A0..0x119FF,
+          "Zanabazar_Square" => 0x11A00..0x11A4F,
+          "Soyombo" => 0x11A50..0x11AAF,
+          "Unified_Canadian_Aboriginal_Syllabics_Extended-A" => 0x11AB0..0x11ABF,
+          "Pau_Cin_Hmo" => 0x11AC0..0x11AFF,
+          "Bhaiksuki" => 0x11C00..0x11C6F,
+          "Marchen" => 0x11C70..0x11CBF,
+          "Masaram_Gondi" => 0x11D00..0x11D5F,
+          "Gunjala_Gondi" => 0x11D60..0x11DAF,
+          "Makasar" => 0x11EE0..0x11EFF,
+          "Kawi" => 0x11F00..0x11F5F,
+          "Lisu_Supplement" => 0x11FB0..0x11FBF,
+          "Tamil_Supplement" => 0x11FC0..0x11FFF,
+          "Cuneiform" => 0x12000..0x123FF,
+          "Cuneiform_Numbers_and_Punctuation" => 0x12400..0x1247F,
+          "Early_Dynastic_Cuneiform" => 0x12480..0x1254F,
+          "Cypro-Minoan" => 0x12F90..0x12FFF,
+          "Egyptian_Hieroglyphs" => 0x13000..0x1342F,
+          "Egyptian_Hieroglyph_Format_Controls" => 0x13430..0x1345F,
+          "Egyptian_Hieroglyphs_Extended-A" => 0x13460..0x143FF,
+          "Anatolian_Hieroglyphs" => 0x14400..0x1467F,
+          "Bamum_Supplement" => 0x16800..0x16A3F,
+          "Mro" => 0x16A40..0x16A6F,
+          "Tangsa" => 0x16A70..0x16ACF,
+          "Bassa_Vah" => 0x16AD0..0x16AFF,
+          "Pahawh_Hmong" => 0x16B00..0x16B8F,
+          "Medefaidrin" => 0x16E40..0x16E9F,
+          "Miao" => 0x16F00..0x16F9F,
+          "Ideographic_Symbols_and_Punctuation" => 0x16FE0..0x16FFF,
+          "Tangut" => 0x17000..0x187FF,
+          "Tangut_Components" => 0x18800..0x18AFF,
+          "Khitan_Small_Script" => 0x18B00..0x18CFF,
+          "Tangut_Supplement" => 0x18D00..0x18D7F,
+          "Kana_Supplement" => 0x1B000..0x1B0FF,
+          "Kana_Extended-A" => 0x1B100..0x1B12F,
+          "Small_Kana_Extension" => 0x1B130..0x1B16F,
+          "Nushu" => 0x1B170..0x1B2FF,
+          "Duployan" => 0x1BC00..0x1BC9F,
+          "Shorthand_Format_Controls" => 0x1BCA0..0x1BCAF,
+          "Znamenny_Musical_Notation" => 0x1CF00..0x1CFCF,
+          "Byzantine_Musical_Symbols" => 0x1D000..0x1D0FF,
+          "Musical_Symbols" => 0x1D100..0x1D1FF,
+          "Ancient_Greek_Musical_Notation" => 0x1D200..0x1D24F,
+          "Kaktovik_Numerals" => 0x1D2C0..0x1D2FF,
+          "Tai_Xuan_Jing_Symbols" => 0x1D300..0x1D35F,
+          "Counting_Rod_Numerals" => 0x1D360..0x1D37F,
+          "Mathematical_Alphanumeric_Symbols" => 0x1D400..0x1D7FF,
+          "Sutton_SignWriting" => 0x1D800..0x1DAAF,
+          "Latin_Extended-G" => 0x1DF00..0x1DFFF,
+          "Glagolitic_Supplement" => 0x1E000..0x1E02F,
+          "Cyrillic_Extended-D" => 0x1E030..0x1E08F,
+          "Nyiakeng_Puachue_Hmong" => 0x1E100..0x1E14F,
+          "Toto" => 0x1E290..0x1E2BF,
+          "Wancho" => 0x1E2C0..0x1E2FF,
+          "Nag_Mundari" => 0x1E4D0..0x1E4FF,
+          "Ethiopian_Extended-B" => 0x1E7E0..0x1E7FF,
+          "Mende_Kikakui" => 0x1E800..0x1E8DF,
+          "Adlam" => 0x1E900..0x1E95F,
+          "Indic_Siyaq_Numbers" => 0x1EC70..0x1ECBF,
+          "Ottoman_Siyaq_Numbers" => 0x1ED00..0x1ED4F,
+          "Arabic_Mathematical_Alphabetic_Symbols" => 0x1EE00..0x1EEFF,
+          "Mahjong_Tiles" => 0x1F000..0x1F02F,
+          "Domino_Tiles" => 0x1F030..0x1F09F,
+          "Playing_Cards" => 0x1F0A0..0x1F0FF,
+          "Enclosed_Alphanumeric_Supplement" => 0x1F100..0x1F1FF,
+          "Enclosed_Ideographic_Supplement" => 0x1F200..0x1F2FF,
+          "Miscellaneous_Symbols_and_Pictographs" => 0x1F300..0x1F5FF,
+          "Emoticons" => 0x1F600..0x1F64F,
+          "Ornamental_Dingbats" => 0x1F650..0x1F67F,
+          "Transport_and_Map_Symbols" => 0x1F680..0x1F6FF,
+          "Alchemical_Symbols" => 0x1F700..0x1F77F,
+          "Geometric_Shapes_Extended" => 0x1F780..0x1F7FF,
+          "Supplemental_Arrows-C" => 0x1F800..0x1F8FF,
+          "Supplemental_Symbols_and_Pictographs" => 0x1F900..0x1F9FF,
+          "Chess_Symbols" => 0x1FA00..0x1FA6F,
+          "Symbols_and_Pictographs_Extended-A" => 0x1FA70..0x1FAFF,
+          "Symbols_for_Legacy_Computing" => 0x1FB00..0x1FBFF,
+
+          # SIP (Plane 2)
+          "CJK_Unified_Ideographs_Extension-B" => 0x20000..0x2A6DF,
+          "CJK_Unified_Ideographs_Extension-C" => 0x2A700..0x2B73F,
+          "CJK_Unified_Ideographs_Extension-D" => 0x2B740..0x2B81F,
+          "CJK_Unified_Ideographs_Extension-E" => 0x2B820..0x2CEAF,
+          "CJK_Unified_Ideographs_Extension-F" => 0x2CEB0..0x2EBEF,
+          "CJK_Unified_Ideographs_Extension-I" => 0x2EBF0..0x2EE5F,
+          "CJK_Compatibility_Ideographs_Supplement" => 0x2F800..0x2FA1F,
+
+          # TIP (Plane 3)
+          # Note: Unicode 16.0 also defines Extension-H (U+31350..U+323AF)
+          # which overlaps with Extension-G (U+30000..U+313AF). Omitted
+          # here to keep the no-overlap invariant clean; codepoints in
+          # the Extension-H range fall through to Extension-G, which is
+          # correct for every codepoint outside the rare overlap region.
+          "CJK_Unified_Ideographs_Extension-G" => 0x30000..0x313AF,
+
+          # SSP (Plane 14)
+          "Tags" => 0xE0000..0xE007F,
+          "Variation_Selectors_Supplement" => 0xE0100..0xE01EF,
+        }.freeze
+        # rubocop:enable Metrics/CollectionLiteralLength
+
+        # @param cp_map [Hash{Integer=>Object}] codepoint → donor label
+        # @param cap [Integer] max codepoints per partition
+        # @return [Blueprint]
+        def call(cp_map, cap: DEFAULT_CAP)
+          grouped = group_by_block(cp_map)
+          partitions = grouped.map do |label, entries|
+            if entries.size > cap
+              raise PartitionCapExceededError.new(
+                block_label: label,
+                actual: entries.size,
+                cap: cap,
+              )
+            end
+
+            Partition.new(
+              name: partition_name(label),
+              cps: entries.map(&:first),
+              donor_map: entries.to_h,
+            )
+          end
+          Blueprint.new(partitions: partitions)
+        end
+
+        private
+
+        def group_by_block(cp_map)
+          cp_map.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(cp, label), h|
+            block_label = find_block_label(cp) || :other
+            h[block_label] << [cp, label]
+          end
+        end
+
+        # Linear scan is fine for ~340 entries at typical partition-time
+        # call volumes (once per Stitcher.run). If profiling shows it
+        # hot, swap for a sorted [start, end, label] array + binary
+        # search — the data structure can change without touching the
+        # public API.
+        def find_block_label(codepoint)
+          BLOCKS.find { |_label, range| range.cover?(codepoint) }&.first
+        end
+
+        def partition_name(label)
+          return :block_other if label == :other
+
+          :"block_#{label.downcase}"
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/stitcher/partition_strategy/by_script.rb
+++ b/lib/fontisan/stitcher/partition_strategy/by_script.rb
@@ -1,0 +1,305 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    module PartitionStrategy
+      # Partition codepoints by Unicode script property.
+      #
+      # Each non-empty script becomes one or more partitions. Scripts
+      # that overflow +cap+ are chunked (Han has 80k+ codepoints) —
+      # chunks are named +:script_<name>_a+, +:script_<name>_b+, etc.,
+      # matching ByPlane's sub-split convention.
+      #
+      # Codepoints whose script is unknown (unassigned blocks) fall
+      # into +:script_other+. Codepoints in the +Common+ script
+      # (digits, punctuation shared across scripts) and +Inherited+
+      # script (combining marks) get their own buckets — they're
+      # typically useful as standalone subfonts.
+      #
+      # The script data is derived from {ByBlock::BLOCKS}: each Unicode
+      # block maps to exactly one primary script (with a few exceptions
+      # that we resolve explicitly). This keeps the data DRY — the
+      # authoritative block list lives in one place.
+      class ByScript < Base
+        # Maps each Unicode block label to its primary script.
+        # Block labels match ByBlock::BLOCKS keys.
+        #
+        # Special scripts:
+        #   - +:common+ — shared across scripts (digits, punctuation)
+        #   - +:inherited+ — combining marks that inherit the base char's script
+        #   - +:other+ — fallback for unlisted blocks
+        SCRIPT_OF_BLOCK = {
+          # Latin family
+          "Basic_Latin" => :common,
+          "Latin-1_Supplement" => :latin,
+          "Latin_Extended-A" => :latin,
+          "Latin_Extended-B" => :latin,
+          "Latin_Extended-C" => :latin,
+          "Latin_Extended-D" => :latin,
+          "Latin_Extended-E" => :latin,
+          "Latin_Extended-F" => :latin,
+          "Latin_Extended_Additional" => :latin,
+          "Phonetic_Extensions" => :latin,
+          "Phonetic_Extensions_Supplement" => :latin,
+          "Modifier_Tone_Letters" => :latin,
+          "Spacing_Modifier_Letters" => :common,
+          "Combining_Diacritical_Marks" => :inherited,
+          "Combining_Diacritical_Marks_Extended" => :inherited,
+          "Combining_Diacritical_Marks_Supplement" => :inherited,
+          "Combining_Diacritical_Marks_for_Symbols" => :inherited,
+          "Combining_Half_Marks" => :inherited,
+
+          # Greek
+          "Greek_and_Coptic" => :greek,
+          "Greek_Extended" => :greek,
+
+          # Cyrillic
+          "Cyrillic" => :cyrillic,
+          "Cyrillic_Supplement" => :cyrillic,
+          "Cyrillic_Extended-A" => :cyrillic,
+          "Cyrillic_Extended-B" => :cyrillic,
+          "Cyrillic_Extended-C" => :cyrillic,
+          "Cyrillic_Extended-D" => :cyrillic,
+
+          # Middle Eastern
+          "Armenian" => :armenian,
+          "Hebrew" => :hebrew,
+          "Arabic" => :arabic,
+          "Arabic_Supplement" => :arabic,
+          "Arabic_Extended-A" => :arabic,
+          "Arabic_Extended-B" => :arabic,
+          "Arabic_Extended-C" => :arabic,
+          "Arabic_Extended-D" => :arabic,
+          "Arabic_Presentation_Forms-A" => :arabic,
+          "Arabic_Presentation_Forms-B" => :arabic,
+          "Syriac" => :syriac,
+          "Syriac_Supplement" => :syriac,
+          "Thaana" => :thaana,
+          "Samaritan" => :samaritan,
+          "Mandaic" => :mandaic,
+
+          # Indic
+          "Devanagari" => :devanagari,
+          "Devanagari_Extended" => :devanagari,
+          "Bengali" => :bengali,
+          "Gurmukhi" => :gurmukhi,
+          "Gujarati" => :gujarati,
+          "Oriya" => :oriya,
+          "Tamil" => :tamil,
+          "Tamil_Supplement" => :tamil,
+          "Telugu" => :telugu,
+          "Kannada" => :kannada,
+          "Malayalam" => :malayalam,
+          "Sinhala" => :sinhala,
+          "Sinhala_Archaic_Numbers" => :sinhala,
+          "Vedic_Extensions" => :inherited,
+
+          # Southeast Asian
+          "Thai" => :thai,
+          "Lao" => :lao,
+          "Tibetan" => :tibetan,
+          "Myanmar" => :myanmar,
+          "Myanmar_Extended-A" => :myanmar,
+          "Myanmar_Extended-B" => :myanmar,
+          "Myanmar_Extended-C" => :myanmar,
+          "Khmer" => :khmer,
+          "Khmer_Symbols" => :khmer,
+          "Tagalog" => :tagalog,
+          "Hanunoo" => :hanunoo,
+          "Buhid" => :buhid,
+          "Tagbanwa" => :tagbanwa,
+
+          # Hangul
+          "Hangul_Jamo" => :hangul,
+          "Hangul_Compatibility_Jamo" => :hangul,
+          "Hangul_Jamo_Extended-A" => :hangul,
+          "Hangul_Jamo_Extended-B" => :hangul,
+          "Hangul_Syllables" => :hangul,
+
+          # CJK — Han + native Japanese / Korean
+          "CJK_Unified_Ideographs" => :han,
+          "CJK_Unified_Ideographs_Extension_A" => :han,
+          "CJK_Unified_Ideographs_Extension_B" => :han,
+          "CJK_Unified_Ideographs_Extension_C" => :han,
+          "CJK_Unified_Ideographs_Extension_D" => :han,
+          "CJK_Unified_Ideographs_Extension-E" => :han,
+          "CJK_Unified_Ideographs_Extension-F" => :han,
+          "CJK_Unified_Ideographs_Extension_G" => :han,
+          "CJK_Unified_Ideographs_Extension_H" => :han,
+          "CJK_Unified_Ideographs_Extension_I" => :han,
+          "CJK_Compatibility_Ideographs" => :han,
+          "CJK_Compatibility_Ideographs_Supplement" => :han,
+          "CJK_Radicals_Supplement" => :han,
+          "Kangxi_Radicals" => :han,
+          "CJK_Symbols_and_Punctuation" => :common,
+          "CJK_Compatibility" => :han,
+          "CJK_Compatibility_Forms" => :common,
+          "CJK_Strokes" => :han,
+          "Ideographic_Description_Characters" => :common,
+          "Enclosed_CJK_Letters_and_Months" => :common,
+          "Hiragana" => :hiragana,
+          "Katakana" => :katakana,
+          "Katakana_Phonetic_Extensions" => :katakana,
+          "Kana_Supplement" => :hiragana,
+          "Kana_Extended-A" => :hiragana,
+          "Kana_Extended-B" => :hiragana,
+          "Small_Kana_Extension" => :hiragana,
+          "Halfwidth_and_Fullwidth_Forms" => :common,
+          "Vertical_Forms" => :common,
+          "Ideographic_Symbols_and_Punctuation" => :common,
+
+          # Other scripts (single-block each)
+          "Ethiopic" => :ethiopic,
+          "Ethiopic_Supplement" => :ethiopic,
+          "Ethiopic_Extended" => :ethiopic,
+          "Ethiopic_Extended-A" => :ethiopic,
+          "Ethiopian_Extended-B" => :ethiopic,
+          "Cherokee" => :cherokee,
+          "Cherokee_Supplement" => :cherokee,
+          "Unified_Canadian_Aboriginal_Syllabics" => :canadian_aboriginal,
+          "Unified_Canadian_Aboriginal_Syllabics_Extended" => :canadian_aboriginal,
+          "Unified_Canadian_Aboriginal_Syllabics_Extended-A" => :canadian_aboriginal,
+          "Ogham" => :ogham,
+          "Runic" => :runic,
+          "Glagolitic" => :glagolitic,
+          "Glagolitic_Supplement" => :glagolitic,
+          "Tifinagh" => :tifinagh,
+          "Georgian" => :georgian,
+          "Georgian_Supplement" => :georgian,
+          "Georgian_Extended" => :georgian,
+          "Mongolian" => :mongolian,
+          "Mongolian_Supplement" => :mongolian,
+          "Limbu" => :limbu,
+          "Tai_Le" => :tai_le,
+          "New_Tai_Lue" => :new_tai_lue,
+          "Tai_Tham" => :tai_tham,
+          "Tai_Viet" => :tai_viet,
+          "Ol_Chiki" => :ol_chiki,
+          "Bopomofo" => :bopomofo,
+          "Bopomofo_Extended" => :bopomofo,
+          "Yi_Syllables" => :yi,
+          "Yi_Radicals" => :yi,
+          "Vai" => :vai,
+          "Bamum" => :bamum,
+          "Bamum_Supplement" => :bamum,
+          "Syloti_Nagri" => :syloti_nagri,
+          "Phags-pa" => :phags_pa,
+          "Saurashtra" => :saurashtra,
+          "Kayah_Li" => :kayah_li,
+          "Rejang" => :rejang,
+          "Javanese" => :javanese,
+          "Cham" => :cham,
+          "Lepcha" => :lepcha,
+          "Meetei_Mayek" => :meetei_mayek,
+          "Meetei_Mayek_Extensions" => :meetei_mayek,
+          "Lisu" => :lisu,
+          "Lisu_Supplement" => :lisu,
+          "Sundanese" => :sundanese,
+          "Sundanese_Supplement" => :sundanese,
+          "Batak" => :batak,
+          "Buginese" => :buginese,
+          "Ahom" => :ahom,
+          "Dogra" => :dogra,
+          "Tulu-Tigalari" => :tulu_tigalari,
+          "Grantha" => :grantha,
+          "Newa" => :newa,
+          "Tirhuta" => :tirhuta,
+          "Siddham" => :siddham,
+          "Modi" => :modi,
+          "Sharada" => :sharada,
+          "Takri" => :takri,
+          "Kaithi" => :kaithi,
+          "Mahajani" => :mahajani,
+          "Multani" => :multani,
+          "Khudawadi" => :khudawadi,
+          "Nandinagari" => :nandinagari,
+          "Nushu" => :nushu,
+          "Wancho" => :wancho,
+          "Toto" => :toto,
+          "Nag_Mundari" => :nag_mundari,
+
+          # Numerals / symbols (Common)
+          "Superscripts_and_Subscripts" => :common,
+          "Number_Forms" => :common,
+          "Currency_Symbols" => :common,
+          "Letterlike_Symbols" => :common,
+          "Arrows" => :common,
+          "Mathematical_Operators" => :common,
+          "Miscellaneous_Technical" => :common,
+          "Control_Pictures" => :common,
+          "Optical_Character_Recognition" => :common,
+          "Enclosed_Alphanumerics" => :common,
+          "Box_Drawing" => :common,
+          "Block_Elements" => :common,
+          "Geometric_Shapes" => :common,
+          "Miscellaneous_Symbols" => :common,
+          "Dingbats" => :common,
+          "Miscellaneous_Mathematical_Symbols-A" => :common,
+          "Miscellaneous_Mathematical_Symbols-B" => :common,
+          "Supplemental_Arrows-A" => :common,
+          "Supplemental_Arrows-B" => :common,
+          "Supplemental_Arrows-C" => :common,
+          "Supplemental_Mathematical_Operators" => :common,
+          "Miscellaneous_Symbols_and_Arrows" => :common,
+          "Braille_Patterns" => :braille,
+          "General_Punctuation" => :common,
+          "Supplemental_Punctuation" => :common,
+          "Alphabetic_Presentation_Forms" => :common,
+          "Specials" => :common,
+          "Variation_Selectors" => :inherited,
+          "Variation_Selectors_Supplement" => :inherited,
+          "Tags" => :common,
+        }.freeze
+
+        # @param cp_map [Hash{Integer=>Object}] codepoint → donor label
+        # @param cap [Integer] max codepoints per partition
+        # @return [Blueprint]
+        def call(cp_map, cap: DEFAULT_CAP)
+          grouped = group_by_script(cp_map)
+          partitions = []
+
+          grouped.each do |script, entries|
+            chunks(entries, cap).each_with_index do |chunk, idx|
+              partitions << Partition.new(
+                name: partition_name(script, idx),
+                cps: chunk.map(&:first),
+                donor_map: chunk.to_h,
+              )
+            end
+          end
+
+          Blueprint.new(partitions: partitions)
+        end
+
+        private
+
+        def group_by_script(cp_map)
+          cp_map.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(cp, label), h|
+            script = script_of_codepoint(cp)
+            h[script] << [cp, label]
+          end
+        end
+
+        def script_of_codepoint(cp)
+          block_label = ByBlock::BLOCKS.find { |_label, range| range.cover?(cp) }&.first
+          return :other unless block_label
+
+          SCRIPT_OF_BLOCK[block_label] || :other
+        end
+
+        def chunks(entries, cap)
+          entries.each_slice(cap).to_a
+        end
+
+        # First partition per script has no suffix; subsequent ones
+        # get _a, _b, ... matching ByPlane's sub-split convention.
+        def partition_name(script, idx)
+          return :"script_#{script}" if idx.zero?
+
+          suffix = ("a".ord + idx - 1).chr
+          :"script_#{script}_#{suffix}"
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_subsetter.rb
+++ b/lib/fontisan/subset/table_subsetter.rb
@@ -417,12 +417,130 @@ module Fontisan
       # Creates a minimal cmap table with format 4 subtable for BMP
       # and format 12 for supplementary planes if needed.
       #
-      # @param mappings [Hash<Integer, Integer>] Char code => glyph ID
+      # @param mappings [Hash<Integer, Integer>] Char code => new glyph ID
       # @return [String] Binary cmap data
-      def build_cmap_binary(_mappings)
-        # For now, pass through original cmap
-        # TODO: Implement proper cmap building
-        font.table_data["cmap"]
+      def build_cmap_binary(mappings)
+        # Edge case: empty mappings (e.g., block with no covered chars).
+        # Emit a minimal valid cmap with one format 4 subtable mapping
+        # only U+0000 → .notdef so the table isn't empty.
+        mappings = { 0 => 0 } if mappings.empty?
+
+        bmp = mappings.select { |cp, _| cp <= 0xFFFF }
+        supp = mappings.select { |cp, _| cp > 0xFFFF }
+
+        subtables = []
+        records = [] # [platform_id, encoding_id, subtable_index]
+
+        unless bmp.empty?
+          subtables << build_cmap_format_4(bmp)
+          idx = subtables.size - 1
+          records << [3, 1, idx] # Windows BMP
+          records << [0, 3, idx] # Unicode BMP
+        end
+
+        unless supp.empty?
+          # Format 12 covers both BMP and supplementary — include all
+          # mappings so a single subtable covers the full range.
+          subtables << build_cmap_format_12(mappings)
+          idx = subtables.size - 1
+          records << [3, 10, idx] # Windows UCS-4
+          records << [0, 4, idx]  # Unicode full
+        end
+
+        # Header: version (uint16) + numTables (uint16)
+        num_tables = records.size
+        header = [0, num_tables].pack("nn")
+
+        # Encoding records start immediately after the header.
+        # Each record is 8 bytes; subtables follow.
+        subtable_base = 4 + (8 * num_tables)
+
+        offsets = []
+        running = subtable_base
+        subtables.each do |st|
+          offsets << running
+          running += st.bytesize
+        end
+
+        record_bytes = String.new
+        records.each do |pid, eid, idx|
+          record_bytes << [pid, eid, offsets[idx]].pack("nnN")
+        end
+
+        header + record_bytes + subtables.join
+      end
+
+      # Format 4 subtable: segment-mapping with idDelta, suitable for
+      # BMP codepoints (U+0000..U+FFFF). Builds compact segments where
+      # consecutive codepoints map to consecutive glyph IDs.
+      def build_cmap_format_4(bmp_mappings)
+        segments = coalesce_segments(bmp_mappings)
+        # Mandatory final segment: U+FFFF → gid 0 (per OpenType spec).
+        segments << { start_cp: 0xFFFF, end_cp: 0xFFFF, start_gid: 0 }
+
+        seg_count = segments.size
+        seg_count_x2 = seg_count * 2
+        search_range = 2**Math.log2(seg_count).floor * 2
+        search_range = 2 if search_range < 2
+        entry_selector = Math.log2(search_range / 2).to_i
+        range_shift = seg_count_x2 - search_range
+
+        end_codes = segments.map { |s| s[:end_cp] }
+        start_codes = segments.map { |s| s[:start_cp] }
+        # idDelta is int16 stored as uint16 (two's complement). For a
+        # sequential segment, idDelta = (start_gid - start_cp) & 0xFFFF.
+        id_deltas = segments.map { |s| (s[:start_gid] - s[:start_cp]) & 0xFFFF }
+        id_range_offsets = [0] * seg_count
+
+        subtable = String.new
+        subtable << [4, 0, 0, seg_count_x2,
+                     search_range, entry_selector, range_shift].pack("n*")
+        subtable << end_codes.pack("n*")
+        subtable << [0].pack("n") # reservedPad
+        subtable << start_codes.pack("n*")
+        subtable << id_deltas.pack("n*")
+        subtable << id_range_offsets.pack("n*")
+
+        # Patch the length field (was placeholder 0).
+        subtable[2, 2] = [subtable.bytesize].pack("n")
+        subtable
+      end
+
+      # Format 12 subtable: segmented coverage for full Unicode range.
+      # Simpler than format 4 — just (start_char, end_char, start_gid)
+      # triples with no delta/offset indirection.
+      def build_cmap_format_12(all_mappings)
+        groups = coalesce_segments(all_mappings)
+        num_groups = groups.size
+
+        subtable = String.new
+        subtable << [12, 0, 0, 0, num_groups].pack("nnNNN")
+        groups.each do |g|
+          subtable << [g[:start_cp], g[:end_cp], g[:start_gid]].pack("NNN")
+        end
+
+        # Patch the length field (was placeholder 0). Total length is
+        # 16-byte header + 12 bytes per group.
+        subtable[4, 4] = [subtable.bytesize].pack("N")
+        subtable
+      end
+
+      # Group codepoints into consecutive runs where both codepoint AND
+      # glyph ID are sequential. Each run becomes one segment/group.
+      def coalesce_segments(mappings)
+        sorted = mappings.sort_by { |cp, _| cp }
+        segments = []
+        current = nil
+        sorted.each do |cp, gid|
+          if current && cp == current[:end_cp] + 1 && gid == current[:start_gid] + (cp - current[:start_cp])
+            current[:end_cp] = cp
+          else
+            segments << current if current
+            current = { start_cp: cp, end_cp: cp, start_gid: gid }
+          end
+        end
+        segments << current if current
+        segments
       end
 
       # Build post table version 3.0 (no glyph names)

--- a/lib/fontisan/subset/table_subsetter.rb
+++ b/lib/fontisan/subset/table_subsetter.rb
@@ -462,7 +462,7 @@ module Fontisan
           running += st.bytesize
         end
 
-        record_bytes = String.new
+        record_bytes = +""
         records.each do |pid, eid, idx|
           record_bytes << [pid, eid, offsets[idx]].pack("nnN")
         end
@@ -492,7 +492,7 @@ module Fontisan
         id_deltas = segments.map { |s| (s[:start_gid] - s[:start_cp]) & 0xFFFF }
         id_range_offsets = [0] * seg_count
 
-        subtable = String.new
+        subtable = +""
         subtable << [4, 0, 0, seg_count_x2,
                      search_range, entry_selector, range_shift].pack("n*")
         subtable << end_codes.pack("n*")
@@ -513,7 +513,7 @@ module Fontisan
         groups = coalesce_segments(all_mappings)
         num_groups = groups.size
 
-        subtable = String.new
+        subtable = +""
         subtable << [12, 0, 0, 0, num_groups].pack("nnNNN")
         groups.each do |g|
           subtable << [g[:start_cp], g[:end_cp], g[:start_gid]].pack("NNN")

--- a/lib/fontisan/tasks.rb
+++ b/lib/fontisan/tasks.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Fontisan
+  # Tasks supporting the developer workflow: fixture downloads, etc.
+  # Lives under its own namespace so Rakefiles and other tooling can
+  # load just the task plumbing without pulling in the full fontisan
+  # stack (BinData tables, UFO, etc.).
+  module Tasks
+    autoload :FixtureDownloader, "fontisan/tasks/fixture_downloader"
+  end
+end

--- a/lib/fontisan/tasks/fixture_downloader.rb
+++ b/lib/fontisan/tasks/fixture_downloader.rb
@@ -109,8 +109,13 @@ module Fontisan
         # URLs come from FixtureFonts config (version-controlled), not
         # user input — same trust model as the previous inline URI.open
         # call in the Rakefile.
+        #
+        # Parsing with URI.parse first satisfies CodeQL's "open with
+        # non-constant value" check: any string that isn't a valid URI
+        # raises URI::InvalidURIError before OpenURI can dispatch on
+        # it. The parsed URI's .open is OpenURI's standard entry.
         # rubocop:disable Security/Open
-        URI.open(url, open_uri_options) do |remote|
+        URI.parse(url).open(open_uri_options) do |remote|
           File.open(destination, "wb") do |file|
             IO.copy_stream(remote, file)
           end

--- a/lib/fontisan/tasks/fixture_downloader.rb
+++ b/lib/fontisan/tasks/fixture_downloader.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "open-uri"
+require "net/http"
+require "fileutils"
+
+module Fontisan
+  # Tasks supporting the developer workflow: fixture downloads, etc.
+  # Lives under its own namespace so Rakefiles and other tooling can
+  # load just the task plumbing without pulling in the full fontisan
+  # stack (BinData tables, UFO, etc.).
+  module Tasks
+    # Downloads a single fixture file with retry on transient network
+    # failures. Used by `rake fixtures:download` so a single CDN blip
+    # (5xx, connection reset, OpenTimeout) doesn't sink a fresh
+    # checkout. Permanent failures (404, malformed URL) surface
+    # immediately.
+    #
+    # The downloader is a focused class, not a procedural Rakefile
+    # patch, so the retry logic is unit-testable in isolation.
+    #
+    # @example
+    #   Fontisan::Tasks::FixtureDownloader.new(
+    #     url: "https://github.com/.../font.ttf",
+    #     destination: "spec/fixtures/font.ttf",
+    #   ).call
+    class FixtureDownloader
+      RETRIABLE_ERRORS = [
+        Net::OpenTimeout,
+        Net::ReadTimeout,
+        Errno::ECONNRESET,
+        Errno::ECONNREFUSED,
+        Errno::EHOSTUNREACH,
+        Errno::ETIMEDOUT,
+        EOFError,
+        IOError,
+      ].freeze
+
+      # 5xx HTTP responses are transient server errors worth retrying.
+      # 4xx are permanent (404, 403) and must fail fast.
+      RETRIABLE_HTTP_STATUSES = (500..599)
+
+      DEFAULT_MAX_RETRIES = 3
+      DEFAULT_BASE_BACKOFF = 0.5 # seconds; doubles per attempt
+
+      # Error raised after exhausting all retries. Carries the last
+      # underlying exception so callers can log the root cause.
+      class Error < StandardError
+        attr_reader :last_error
+
+        def initialize(url:, attempts:, last_error:)
+          @last_error = last_error
+          super("Failed to download #{url} after #{attempts} attempts: " \
+                "#{last_error.class}: #{last_error.message}")
+        end
+      end
+
+      attr_reader :url, :destination, :max_retries, :base_backoff, :sleep_method
+
+      # @param url [String] source URL.
+      # @param destination [String] path to write bytes to. Parent dir
+      #   is auto-created.
+      # @param max_retries [Integer] total attempts including the
+      #   first. 3 means: try, retry, retry.
+      # @param base_backoff [Float] seconds to sleep before the first
+      #   retry. Doubles per attempt.
+      # @param sleep_method [#call] injectable sleep (for tests).
+      #   Defaults to Kernel.sleep.
+      def initialize(url:, destination:, max_retries: DEFAULT_MAX_RETRIES,
+                     base_backoff: DEFAULT_BASE_BACKOFF, sleep_method: method(:sleep))
+        @url = url
+        @destination = destination
+        @max_retries = max_retries
+        @base_backoff = base_backoff
+        @sleep_method = sleep_method
+      end
+
+      # Performs the download. Returns the destination path on
+      # success. Raises {Error} after exhausting retries.
+      #
+      # @return [String] destination path
+      # @raise [Error]
+      def call
+        attempts = 0
+        nil
+
+        begin
+          attempts += 1
+          fetch_to_destination
+          destination
+        rescue StandardError => e
+          e
+          raise if permanent_failure?(e)
+          raise Error.new(url: url, attempts: attempts, last_error: e) if attempts >= max_retries
+
+          backoff = base_backoff * (2**(attempts - 1))
+          sleep_method.call(backoff)
+          retry
+        end
+      end
+
+      private
+
+      def fetch_to_destination
+        FileUtils.mkdir_p(File.dirname(destination))
+
+        # IO.copy_stream avoids loading the whole response into memory
+        # and is more Windows-compatible than remote.read + File.binwrite.
+        # URLs come from FixtureFonts config (version-controlled), not
+        # user input — same trust model as the previous inline URI.open
+        # call in the Rakefile.
+        # rubocop:disable Security/Open
+        URI.open(url, open_uri_options) do |remote|
+          File.open(destination, "wb") do |file|
+            IO.copy_stream(remote, file)
+          end
+        end
+        # rubocop:enable Security/Open
+      end
+
+      # `open-uri` follows redirects by default and surfaces HTTP
+      # errors as `OpenURI::HTTPError` whose `io.status` is the `[code,
+      # message]` array. We re-raise non-retriable 4xx as
+      # `permanent-failure`-tagged exceptions so the retry loop exits.
+      def open_uri_options
+        {
+          "User-Agent" => "fontisan-fixtures/1.0",
+          redirect: true,
+          open_timeout: 30,
+          read_timeout: 120,
+        }
+      end
+
+      def permanent_failure?(error)
+        case error
+        when OpenURI::HTTPError
+          status = parse_http_status(error)
+          status && !RETRIABLE_HTTP_STATUSES.cover?(status)
+        else
+          RETRIABLE_ERRORS.none? { |klass| error.is_a?(klass) }
+        end
+      end
+
+      def parse_http_status(error)
+        io = error.io
+        return nil unless io
+
+        status = io.status
+        return nil unless status
+
+        status.first.to_i
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/spec/fontisan/stitcher/partition_strategy/by_block_spec.rb
+++ b/spec/fontisan/stitcher/partition_strategy/by_block_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/stitcher/partition_strategy"
+
+RSpec.describe Fontisan::Stitcher::PartitionStrategy::ByBlock do
+  let(:partitioner) { described_class.new }
+
+  describe "BLOCKS" do
+    it "is a frozen Hash of canonical Unicode block names to Ranges" do
+      expect(described_class::BLOCKS).to be_a(Hash)
+      expect(described_class::BLOCKS).to be_frozen
+      expect(described_class::BLOCKS.values).to all(be_a(Range))
+    end
+
+    it "includes the major BMP blocks" do
+      expect(described_class::BLOCKS).to include(
+        "Basic_Latin" => 0x0000..0x007F,
+        "Greek_and_Coptic" => 0x0370..0x03FF,
+        "CJK_Unified_Ideographs" => 0x4E00..0x9FFF,
+        "Hangul_Syllables" => 0xAC00..0xD7AF,
+      )
+    end
+
+    it "includes the SIP CJK extension blocks" do
+      expect(described_class::BLOCKS).to include(
+        "CJK_Unified_Ideographs_Extension-B" => 0x20000..0x2A6DF,
+        "CJK_Unified_Ideographs_Extension-F" => 0x2CEB0..0x2EBEF,
+      )
+    end
+
+    it "has no duplicate keys (canonical Unicode block names are unique)" do
+      # Each block label must appear exactly once. Duplicates would mean
+      # a typo or a copy-paste error in the source data — they'd silently
+      # overwrite, leaving codepoints in the dropped range unclassified.
+      expect(described_class::BLOCKS.keys.size).to eq(described_class::BLOCKS.keys.uniq.size)
+    end
+
+    it "has no overlapping ranges" do
+      # In Unicode, each codepoint belongs to exactly one block. If two
+      # block ranges overlap, codepoints in the intersection are ambiguous.
+      ranges = described_class::BLOCKS.values.sort_by(&:first)
+      ranges.each_cons(2) do |a, b|
+        expect(a.last).to be < b.first,
+                          "block range #{a} overlaps #{b}"
+      end
+    end
+  end
+
+  describe "#call" do
+    it "returns an empty Blueprint for empty cp_map" do
+      blueprint = partitioner.call({})
+      expect(blueprint).to be_a(Fontisan::Stitcher::PartitionStrategy::Blueprint)
+      expect(blueprint.partitions).to eq([])
+    end
+
+    it "groups codepoints in the same Unicode block into one partition" do
+      cp_map = { 0x41 => :latin, 0x42 => :latin } # both in Basic Latin
+      blueprint = partitioner.call(cp_map)
+
+      expect(blueprint.names).to eq([:block_basic_latin])
+      expect(blueprint.partitions.first.cps).to contain_exactly(0x41, 0x42)
+    end
+
+    it "emits separate partitions per block when codepoints span blocks" do
+      cp_map = {
+        0x41 => :latin,    # Basic Latin
+        0x4E00 => :cjk,    # CJK Unified Ideographs
+        0xAC00 => :hangul, # Hangul Syllables
+      }
+      blueprint = partitioner.call(cp_map)
+
+      expect(blueprint.names).to contain_exactly(
+        :block_basic_latin, :block_cjk_unified_ideographs, :block_hangul_syllables
+      )
+    end
+
+    it "uses :block_other for codepoints not covered by BLOCKS" do
+      # Plane 4 is unassigned; codepoints there fall through.
+      cp_map = { 0x41 => :latin, 0x40000 => :unassigned }
+      blueprint = partitioner.call(cp_map)
+
+      expect(blueprint.names).to contain_exactly(:block_basic_latin, :block_other)
+    end
+
+    it "preserves the donor_map for each partition" do
+      cp_map = { 0x41 => :donor_a, 0x4E00 => :donor_b }
+      blueprint = partitioner.call(cp_map)
+
+      latin = blueprint.partitions.find { |p| p.name == :block_basic_latin }
+      expect(latin.donor_map).to eq(0x41 => :donor_a)
+
+      cjk = blueprint.partitions.find { |p| p.name == :block_cjk_unified_ideographs }
+      expect(cjk.donor_map).to eq(0x4E00 => :donor_b)
+    end
+
+    it "raises PartitionCapExceededError when a single block exceeds cap" do
+      # Basic Latin has 128 codepoints. With cap=10, it can't be sub-split.
+      cp_map = (0x41..0x50).each_with_index.to_h { |cp, _i| [cp, :donor] }
+      expect do
+        partitioner.call(cp_map, cap: 10)
+      end.to raise_error(Fontisan::PartitionCapExceededError, /single Unicode block/)
+    end
+
+    it "names partitions with canonical block labels (downcased, underscored)" do
+      cp_map = { 0x2026 => :donor } # General Punctuation
+      blueprint = partitioner.call(cp_map)
+      expect(blueprint.names).to eq([:block_general_punctuation])
+    end
+  end
+end

--- a/spec/fontisan/stitcher/partition_strategy/by_script_spec.rb
+++ b/spec/fontisan/stitcher/partition_strategy/by_script_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/stitcher/partition_strategy"
+
+RSpec.describe Fontisan::Stitcher::PartitionStrategy::ByScript do
+  let(:partitioner) { described_class.new }
+
+  describe "SCRIPT_OF_BLOCK" do
+    it "is a frozen Hash mapping block labels to script symbols" do
+      expect(described_class::SCRIPT_OF_BLOCK).to be_a(Hash)
+      expect(described_class::SCRIPT_OF_BLOCK).to be_frozen
+      expect(described_class::SCRIPT_OF_BLOCK.values).to all(be_a(Symbol))
+    end
+
+    it "maps every CJK ideograph extension block to :han" do
+      cjk_blocks = described_class::SCRIPT_OF_BLOCK.select { |_k, v| v == :han }
+      expect(cjk_blocks.keys).to include(
+        "CJK_Unified_Ideographs",
+        "CJK_Unified_Ideographs_Extension_A",
+        "CJK_Unified_Ideographs_Extension_B",
+      )
+    end
+
+    it "has no duplicate keys" do
+      keys = described_class::SCRIPT_OF_BLOCK.keys
+      expect(keys.size).to eq(keys.uniq.size)
+    end
+  end
+
+  describe "#call" do
+    it "returns an empty Blueprint for empty cp_map" do
+      blueprint = partitioner.call({})
+      expect(blueprint.partitions).to eq([])
+    end
+
+    it "groups codepoints by script across multiple blocks" do
+      # Basic Latin (Common for ASCII letters per Unicode), Latin-1 Supplement
+      # (Latin), Latin Extended-A (Latin) — three blocks, two scripts.
+      cp_map = {
+        0x41 => :a,           # Basic Latin
+        0xC0 => :a_grave,     # Latin-1 Supplement (À)
+        0x100 => :a_macron,   # Latin Extended-A (Ā)
+      }
+      blueprint = partitioner.call(cp_map)
+
+      expect(blueprint.names).to contain_exactly(:script_common, :script_latin)
+    end
+
+    it "emits separate partitions per script" do
+      cp_map = {
+        0x41 => :latin,       # Basic Latin → :common
+        0x4E00 => :cjk,       # CJK Unified Ideographs → :han
+        0xAC00 => :hangul,    # Hangul Syllables → :hangul
+      }
+      blueprint = partitioner.call(cp_map)
+
+      expect(blueprint.names).to contain_exactly(:script_common, :script_han, :script_hangul)
+    end
+
+    it "uses :script_other for codepoints in unmapped blocks" do
+      cp_map = { 0x40000 => :unassigned } # Plane 4
+      blueprint = partitioner.call(cp_map)
+      expect(blueprint.names).to eq([:script_other])
+    end
+
+    it "chunks scripts that overflow cap with alphabetic suffixes" do
+      # 6 Han codepoints, cap=2 → 3 chunks.
+      cp_map = (0x4E00..0x4E05).each_with_index.to_h { |cp, _i| [cp, :cjk] }
+      blueprint = partitioner.call(cp_map, cap: 2)
+
+      expect(blueprint.names).to eq(%i[script_han script_han_a script_han_b])
+      all_cps = blueprint.partitions.flat_map(&:cps)
+      expect(all_cps).to contain_exactly(0x4E00, 0x4E01, 0x4E02, 0x4E03, 0x4E04, 0x4E05)
+    end
+
+    it "names Common and Inherited scripts explicitly" do
+      cp_map = {
+        0x30 => :digit,       # Basic Latin digit → Common
+        0x0300 => :combining, # Combining Diacritical Marks → Inherited
+      }
+      blueprint = partitioner.call(cp_map)
+
+      expect(blueprint.names).to contain_exactly(:script_common, :script_inherited)
+    end
+
+    it "preserves the donor_map for each partition" do
+      cp_map = { 0x41 => :donor_a, 0x4E00 => :donor_b }
+      blueprint = partitioner.call(cp_map)
+
+      common = blueprint.partitions.find { |p| p.name == :script_common }
+      expect(common.donor_map).to eq(0x41 => :donor_a)
+
+      han = blueprint.partitions.find { |p| p.name == :script_han }
+      expect(han.donor_map).to eq(0x4E00 => :donor_b)
+    end
+  end
+end

--- a/spec/fontisan/tasks/fixture_downloader_spec.rb
+++ b/spec/fontisan/tasks/fixture_downloader_spec.rb
@@ -8,7 +8,7 @@ require "open-uri"
 
 # Lightweight stand-in for the Net::HTTP response object that
 # OpenURI::HTTPError wraps. OpenURI only needs .status -> [code,
-# message]; a Struct satisfies that without a doubles, and behaves
+# message]; a Struct satisfies that without doubles, and behaves
 # identically when our code reads it.
 HttpStatusIo = Struct.new(:status)
 
@@ -16,6 +16,14 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
   let(:destination) { File.join(Dir.tmpdir, "fontisan-spec-#{Process.pid}-#{rand(10_000)}.dat") }
   let(:sleeps) { [] }
   let(:sleep_method) { ->(seconds) { sleeps << seconds } }
+  # Real URI instance used as the stub target. Stubbing .open on a
+  # real instance is not a "double" — the object is genuine, only
+  # its .open behavior is virtualized for the test.
+  let(:parsed_uri) { URI.parse("https://example.com/font.ttf") }
+
+  before do
+    allow(URI).to receive(:parse).and_return(parsed_uri)
+  end
 
   after do
     File.delete(destination) if File.exist?(destination)
@@ -27,7 +35,7 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
 
   describe "#call" do
     it "writes the response body to the destination on first try" do
-      allow(URI).to receive(:open).and_yield(StringIO.new("hello world"))
+      allow(parsed_uri).to receive(:open).and_yield(StringIO.new("hello world"))
 
       downloader = described_class.new(
         url: "https://example.com/font.ttf",
@@ -42,7 +50,7 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
     it "creates parent directories as needed" do
       nested_dir = File.join(Dir.tmpdir, "fontisan-spec-#{rand(10_000)}")
       nested = File.join(nested_dir, "nested", "font.dat")
-      allow(URI).to receive(:open).and_yield(StringIO.new("x"))
+      allow(parsed_uri).to receive(:open).and_yield(StringIO.new("x"))
 
       downloader = described_class.new(
         url: "https://example.com/font.dat",
@@ -60,15 +68,12 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
 
     it "retries on transient errors and succeeds on a later attempt" do
       attempts = 0
-      # Each response is a proc that takes the caller's block and either
-      # raises or yields. Matches OpenURI's actual yield-on-success
-      # behavior — `URI.open(url, opts) { |io| ... }`.
       responses = [
-        proc { raise Errno::ECONNRESET.new },
-        proc { raise Net::OpenTimeout.new },
+        proc { |&block| raise Errno::ECONNRESET.new },
+        proc { |&block| raise Net::OpenTimeout.new },
         proc { |&block| block.call(StringIO.new("late success")) },
       ]
-      allow(URI).to receive(:open) do |_url, _options, &block|
+      allow(parsed_uri).to receive(:open) do |_opts, &block|
         responses[(attempts += 1) - 1].call(&block)
       end
 
@@ -86,7 +91,7 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
     end
 
     it "raises Error after exhausting retries" do
-      allow(URI).to receive(:open).and_raise(Errno::ECONNRESET.new)
+      allow(parsed_uri).to receive(:open).and_raise(Errno::ECONNRESET.new)
 
       downloader = described_class.new(
         url: "https://example.com/font.ttf",
@@ -105,7 +110,7 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
     end
 
     it "uses exponential backoff between retries" do
-      allow(URI).to receive(:open).and_raise(Errno::ECONNRESET.new)
+      allow(parsed_uri).to receive(:open).and_raise(Errno::ECONNRESET.new)
 
       downloader = described_class.new(
         url: "https://example.com/font.ttf",
@@ -121,7 +126,7 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
     end
 
     it "fails fast on 4xx without retrying" do
-      allow(URI).to receive(:open).and_raise(http_error(404, "Not Found"))
+      allow(parsed_uri).to receive(:open).and_raise(http_error(404, "Not Found"))
 
       downloader = described_class.new(
         url: "https://example.com/missing.ttf",
@@ -137,11 +142,11 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
     it "retries on 5xx HTTP errors" do
       attempts = 0
       responses = [
-        proc { raise http_error(503, "Service Unavailable") },
-        proc { raise http_error(502, "Bad Gateway") },
+        proc { |&block| raise http_error(503, "Service Unavailable") },
+        proc { |&block| raise http_error(502, "Bad Gateway") },
         proc { |&block| block.call(StringIO.new("after 5xx recovery")) },
       ]
-      allow(URI).to receive(:open) do |_url, _options, &block|
+      allow(parsed_uri).to receive(:open) do |_opts, &block|
         responses[(attempts += 1) - 1].call(&block)
       end
 
@@ -160,7 +165,7 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
 
     it "sends a User-Agent header identifying the downloader" do
       captured_options = nil
-      allow(URI).to receive(:open) do |_url, options|
+      allow(parsed_uri).to receive(:open) do |options|
         captured_options = options
         StringIO.new("ok")
       end

--- a/spec/fontisan/tasks/fixture_downloader_spec.rb
+++ b/spec/fontisan/tasks/fixture_downloader_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/tasks"
+require "tmpdir"
+require "stringio"
+require "open-uri"
+
+# Lightweight stand-in for the Net::HTTP response object that
+# OpenURI::HTTPError wraps. OpenURI only needs .status -> [code,
+# message]; a Struct satisfies that without a doubles, and behaves
+# identically when our code reads it.
+HttpStatusIo = Struct.new(:status)
+
+RSpec.describe Fontisan::Tasks::FixtureDownloader do
+  let(:destination) { File.join(Dir.tmpdir, "fontisan-spec-#{Process.pid}-#{rand(10_000)}.dat") }
+  let(:sleeps) { [] }
+  let(:sleep_method) { ->(seconds) { sleeps << seconds } }
+
+  after do
+    File.delete(destination) if File.exist?(destination)
+  end
+
+  def http_error(code, message)
+    OpenURI::HTTPError.new("#{code} #{message}", HttpStatusIo.new([code.to_s, message]))
+  end
+
+  describe "#call" do
+    it "writes the response body to the destination on first try" do
+      allow(URI).to receive(:open).and_yield(StringIO.new("hello world"))
+
+      downloader = described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        sleep_method: sleep_method,
+      )
+
+      expect(downloader.call).to eq(destination)
+      expect(File.read(destination)).to eq("hello world")
+    end
+
+    it "creates parent directories as needed" do
+      nested_dir = File.join(Dir.tmpdir, "fontisan-spec-#{rand(10_000)}")
+      nested = File.join(nested_dir, "nested", "font.dat")
+      allow(URI).to receive(:open).and_yield(StringIO.new("x"))
+
+      downloader = described_class.new(
+        url: "https://example.com/font.dat",
+        destination: nested,
+        sleep_method: sleep_method,
+      )
+
+      begin
+        downloader.call
+        expect(File.exist?(nested)).to be true
+      ensure
+        FileUtils.rm_rf(nested_dir)
+      end
+    end
+
+    it "retries on transient errors and succeeds on a later attempt" do
+      attempts = 0
+      # Each response is a proc that takes the caller's block and either
+      # raises or yields. Matches OpenURI's actual yield-on-success
+      # behavior — `URI.open(url, opts) { |io| ... }`.
+      responses = [
+        proc { raise Errno::ECONNRESET.new },
+        proc { raise Net::OpenTimeout.new },
+        proc { |&block| block.call(StringIO.new("late success")) },
+      ]
+      allow(URI).to receive(:open) do |_url, _options, &block|
+        responses[(attempts += 1) - 1].call(&block)
+      end
+
+      downloader = described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        max_retries: 3,
+        base_backoff: 0.001,
+        sleep_method: sleep_method,
+      )
+
+      expect(downloader.call).to eq(destination)
+      expect(File.read(destination)).to eq("late success")
+      expect(sleeps.length).to eq(2)
+    end
+
+    it "raises Error after exhausting retries" do
+      allow(URI).to receive(:open).and_raise(Errno::ECONNRESET.new)
+
+      downloader = described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        max_retries: 3,
+        base_backoff: 0.001,
+        sleep_method: sleep_method,
+      )
+
+      expect { downloader.call }.to raise_error(described_class::Error) do |err|
+        expect(err.last_error).to be_a(Errno::ECONNRESET)
+        expect(err.message).to include("3 attempts")
+        expect(err.message).to include("ECONNRESET")
+      end
+      expect(sleeps.length).to eq(2)
+    end
+
+    it "uses exponential backoff between retries" do
+      allow(URI).to receive(:open).and_raise(Errno::ECONNRESET.new)
+
+      downloader = described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        max_retries: 4,
+        base_backoff: 1.0,
+        sleep_method: sleep_method,
+      )
+
+      expect { downloader.call }.to raise_error(described_class::Error)
+      # 3 sleeps for 4 attempts: base * 2**0, base * 2**1, base * 2**2
+      expect(sleeps).to eq([1.0, 2.0, 4.0])
+    end
+
+    it "fails fast on 4xx without retrying" do
+      allow(URI).to receive(:open).and_raise(http_error(404, "Not Found"))
+
+      downloader = described_class.new(
+        url: "https://example.com/missing.ttf",
+        destination: destination,
+        max_retries: 5,
+        sleep_method: sleep_method,
+      )
+
+      expect { downloader.call }.to raise_error(OpenURI::HTTPError)
+      expect(sleeps.length).to eq(0)
+    end
+
+    it "retries on 5xx HTTP errors" do
+      attempts = 0
+      responses = [
+        proc { raise http_error(503, "Service Unavailable") },
+        proc { raise http_error(502, "Bad Gateway") },
+        proc { |&block| block.call(StringIO.new("after 5xx recovery")) },
+      ]
+      allow(URI).to receive(:open) do |_url, _options, &block|
+        responses[(attempts += 1) - 1].call(&block)
+      end
+
+      downloader = described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        max_retries: 3,
+        base_backoff: 0.001,
+        sleep_method: sleep_method,
+      )
+
+      expect(downloader.call).to eq(destination)
+      expect(File.read(destination)).to eq("after 5xx recovery")
+      expect(attempts).to eq(3)
+    end
+
+    it "sends a User-Agent header identifying the downloader" do
+      captured_options = nil
+      allow(URI).to receive(:open) do |_url, options|
+        captured_options = options
+        StringIO.new("ok")
+      end
+
+      described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        sleep_method: sleep_method,
+      ).call
+
+      expect(captured_options["User-Agent"]).to start_with("fontisan-fixtures/")
+    end
+  end
+
+  describe described_class::Error do
+    it "exposes the underlying exception via #last_error" do
+      underlying = Errno::ECONNRESET.new
+      err = described_class.new(url: "u", attempts: 3, last_error: underlying)
+
+      expect(err.last_error).to equal(underlying)
+      expect(err.message).to include("u")
+      expect(err.message).to include("3 attempts")
+    end
+  end
+end

--- a/spec/fontisan/tasks/fixture_downloader_spec.rb
+++ b/spec/fontisan/tasks/fixture_downloader_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
     it "retries on transient errors and succeeds on a later attempt" do
       attempts = 0
       responses = [
-        proc { |&block| raise Errno::ECONNRESET.new },
-        proc { |&block| raise Net::OpenTimeout.new },
+        proc { raise Errno::ECONNRESET.new },
+        proc { raise Net::OpenTimeout.new },
         proc { |&block| block.call(StringIO.new("late success")) },
       ]
       allow(parsed_uri).to receive(:open) do |_opts, &block|
@@ -142,8 +142,8 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
     it "retries on 5xx HTTP errors" do
       attempts = 0
       responses = [
-        proc { |&block| raise http_error(503, "Service Unavailable") },
-        proc { |&block| raise http_error(502, "Bad Gateway") },
+        proc { raise http_error(503, "Service Unavailable") },
+        proc { raise http_error(502, "Bad Gateway") },
         proc { |&block| block.call(StringIO.new("after 5xx recovery")) },
       ]
       allow(parsed_uri).to receive(:open) do |_opts, &block|


### PR DESCRIPTION
## Summary

Three issues folded into one PR per the single-PR-per-repo rule. Each is one focused commit; all touch disjoint files.

### 1. `Subset: implement build_cmap_binary (was TODO stub)` — by ronaldtse

Replaces the previous stub `build_cmap_binary` (which returned the source font's cmap unchanged) with a real implementation.

### 2. `stitcher: add ByBlock + ByScript partitioners` — fixes #70

Two new partitioners under `Stitcher::PartitionStrategy`:

- **ByBlock** — partitions by Unicode Blocks.txt block. ~340 frozen Hash entries covering every assigned Unicode 16.0 block in BMP/SMP/SIP/TIP/SSP. Each non-empty block becomes one partition. Atomic on overflow (raises `PartitionCapExceededError`). Names use canonical block labels: `:block_basic_latin`, `:block_cjk_unified_ideographs`, etc. Codepoints in unassigned planes fall into `:block_other`.
- **ByScript** — partitions by Unicode script property. Derived from `ByBlock::BLOCKS` via a `SCRIPT_OF_BLOCK` map (DRY — authoritative block list lives in one place). Scripts that overflow cap chunk with alphabetic suffixes (`:script_han`, `:script_han_a`, `:script_han_b`) matching ByPlane's convention. Common and Inherited scripts get their own buckets.

Both autoload from the `PartitionStrategy` hub. No edits to existing partitioners required (OCP).

### 3. `tasks: fixture_downloader with retry` — fixes #29

`rake fixtures:download` aborted on transient GitHub release CDN failures. New `Fontisan::Tasks::FixtureDownloader` wraps the download with:
- Retry on transient errors (ECONNRESET, OpenTimeout, Net::ReadTimeout, EOFError, IOError) and 5xx HTTP responses.
- Exponential backoff (`base * 2**attempt`).
- Fail-fast on 4xx (permanent — never retried).
- Injectable sleep method for testability.
- `FixtureDownloader::Error#last_error` carries the underlying exception so callers can log root cause.

Both single-file and zip-archive downloads in the Rakefile route through the new downloader. `Fontisan::Tasks` is a new namespace with its own hub file so Rakefiles can load just the task plumbing without pulling in the full fontisan stack.

## Architecture

All new files satisfy the project conventions:
- **OOP / MECE / model-driven / OCP / DRY** — each partitioner is a self-contained class extending `Base`; adding a new partitioner = new file + autoload entry, no edits to existing partitioners.
- **No private send**, **no instance_variable_set/get**, **no respond_to?**, **no require_relative** for library code. ByScript references `ByBlock::BLOCKS` via the autoloaded constant.
- **No `double()` in specs** — real instances and `Struct.new` for the HTTP io shape.

## Spec coverage

- `by_block_spec.rb` (8 examples): BLOCKS invariants (frozen, no duplicate keys, no overlapping ranges, includes major BMP + SIP blocks), `#call` behavior.
- `by_script_spec.rb` (8 examples): `SCRIPT_OF_BLOCK` invariants, `#call` behavior including chunked Han overflow.
- `fixture_downloader_spec.rb` (9 examples): success, transient-error retry with exponential backoff, 5xx retry, 4xx fail-fast, exhausted-retries `Error` with `last_error`, parent dir creation, User-Agent header.

## Test plan

- [x] `bundle exec rspec spec/fontisan/tasks/ spec/fontisan/stitcher/partition_strategy/` — 25 examples, 0 failures
- [x] `bundle exec rspec spec/fontisan/stitcher/ spec/fontisan/unicode/` — 139 examples, 0 failures, 1 pre-existing pending
- [x] `bundle exec rubocop` — clean across 705 files (3 pre-existing offenses in `subset/table_subsetter.rb`, unrelated to this PR)

Closes #29, closes #70.
