### PR TITLE
ufo: Transformations filter + Transformation#apply (DRY affine math, refs #46)

### DIFF
--- a/lib/fontisan/stitcher/source.rb
+++ b/lib/fontisan/stitcher/source.rb
@@ -336,10 +336,15 @@ module Fontisan
 
       # Apply a 2×3 affine matrix [a, b, c, d, e, f] to each point of
       # a simple component, appending the transformed contours.
-      #   x' = a*x + c*y + e
-      #   y' = b*x + d*y + f
+      # The math is delegated to +Transformation#apply+ so the
+      # affine-matrix logic lives in one place (DRY) — same code path
+      # the UFO Transformations filter uses.
       def flatten_simple_component(simple, ufo_glyph, matrix)
-        a, b, c, d, e, f = matrix
+        transform = Ufo::Transformation.new(
+          a: matrix[0], b: matrix[1],
+          c: matrix[2], d: matrix[3],
+          e: matrix[4], f: matrix[5]
+        )
         num_contours = simple.end_pts_of_contours&.size || 0
         return if num_contours.zero?
 
@@ -350,13 +355,12 @@ module Fontisan
           ufo_points = points.map do |pt|
             x = (pt[:x] || pt["x"]).to_f
             y = (pt[:y] || pt["y"]).to_f
-            tx = a * x + c * y + e
-            ty = b * x + d * y + f
+            tx, ty = transform.apply(x, y)
             on_curve = pt[:on_curve].nil? || pt[:on_curve]
             type = on_curve ? "line" : "offcurve"
-            Fontisan::Ufo::Point.new(x: tx, y: ty, type: type)
+            Ufo::Point.new(x: tx, y: ty, type: type)
           end
-          ufo_glyph.add_contour(Fontisan::Ufo::Contour.new(ufo_points))
+          ufo_glyph.add_contour(Ufo::Contour.new(ufo_points))
         end
       end
 

--- a/lib/fontisan/ufo/compile/filters.rb
+++ b/lib/fontisan/ufo/compile/filters.rb
@@ -20,6 +20,8 @@ module Fontisan
                  "fontisan/ufo/compile/filters/decompose_components"
         autoload :FlattenComponents,
                  "fontisan/ufo/compile/filters/flatten_components"
+        autoload :Transformations,
+                 "fontisan/ufo/compile/filters/transformations"
 
         # Filters that MUST run for TTF output (TrueType only
         # supports quadratic curves + clockwise outer winding).
@@ -38,6 +40,7 @@ module Fontisan
           cubic_to_quadratic: CubicToQuadratic,
           decompose_components: DecomposeComponents,
           flatten_components: FlattenComponents,
+          transformations: Transformations,
         }.freeze
 
         # @param names [Array<Symbol>] filter names from REGISTRY

--- a/lib/fontisan/ufo/compile/filters/transformations.rb
+++ b/lib/fontisan/ufo/compile/filters/transformations.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module Filters
+        # Applies a 2×3 affine transformation to every glyph's
+        # contours + components. The general-purpose filter — other
+        # filters (decompose_components, propagate_anchors) are
+        # special cases of geometric transforms applied to specific
+        # glyph subsets.
+        #
+        # Used for:
+        #   - Symmetric mirroring (e.g. italic→upright flip).
+        #   - Slant adjustment.
+        #   - Custom per-font offsets that callers want baked in at
+        #     compile time rather than carried as variation axis deltas.
+        #
+        # Identity matrix is a no-op fast path.
+        module Transformations
+          DEFAULT_OFFSET_X = 0.0
+          DEFAULT_OFFSET_Y = 0.0
+
+          # @param glyphs [Array<Fontisan::Ufo::Glyph>]
+          # @param matrix [Fontisan::Ufo::Transformation, Array<Numeric>, nil]
+          #   The affine matrix to apply. Accepts either a
+          #   +Transformation+ value object or the raw +[a, b, c, d, e, f]+
+          #   array. +nil+ (the default) is a no-op — leaves glyphs
+          #   unchanged.
+          # @return [Array<Fontisan::Ufo::Glyph>] the same array (mutated)
+          def self.run(glyphs, matrix: nil, **_opts)
+            return glyphs if matrix.nil?
+
+            transform = coerce_transformation(matrix)
+            return glyphs if transform.identity?
+
+            glyphs.each { |g| apply_to_glyph(g, transform) }
+            glyphs
+          end
+
+          class << self
+            private
+
+            # Coerce the matrix argument into a Transformation.
+            # Centralizes the "array, object, or nil?" decision so
+            # callers can pass any form.
+            def coerce_transformation(matrix)
+              return Fontisan::Ufo::Transformation.new if matrix.nil?
+              return matrix if matrix.is_a?(Fontisan::Ufo::Transformation)
+
+              Fontisan::Ufo::Transformation.new(
+                a: matrix[0], b: matrix[1],
+                c: matrix[2], d: matrix[3],
+                e: matrix[4], f: matrix[5]
+              )
+            end
+
+            # Apply the transform in place: each contour's points are
+            # rewritten with transformed coordinates; each component's
+            # +transformation+ is composed with the new one (so nested
+            # component refs chain correctly).
+            def apply_to_glyph(glyph, transform)
+              glyph.contours.each do |contour|
+                contour.points = contour.points.map do |pt|
+                  tx, ty = transform.apply(pt.x, pt.y)
+                  Fontisan::Ufo::Point.new(
+                    x: tx, y: ty,
+                    type: pt.type, smooth: pt.smooth
+                  )
+                end
+              end
+
+              glyph.components.map! do |component|
+                Fontisan::Ufo::Component.new(
+                  base_glyph: component.base_glyph,
+                  # Composition order: outer transform ∘ existing.
+                  # For a base-glyph point P, the component places it
+                  # at T_existing(P) in this glyph; the outer transform
+                  # then maps that to T_outer(T_existing(P)). So the
+                  # new component transformation is T_outer ∘ T_existing.
+                  transformation: compose(transform, component.transformation),
+                  identifier: component.identifier,
+                )
+              end
+            end
+
+            # Compose two affine transformations: result = outer ∘ inner
+            #   | outer.a outer.c outer.e |   | inner.a inner.c inner.e |
+            #   | outer.b outer.d outer.f | × | inner.b inner.d inner.f |
+            #   |   0        0        1   |   |   0        0        1   |
+            #
+            # Each input can be a Transformation, a 6-array, or nil
+            # (treated as identity — the default Component state).
+            # The result is always a Transformation.
+            def compose(outer, inner)
+              outer_t = coerce_transformation(outer)
+              inner_t = coerce_transformation(inner)
+
+              Fontisan::Ufo::Transformation.new(
+                a: outer_t.a * inner_t.a + outer_t.c * inner_t.b,
+                b: outer_t.b * inner_t.a + outer_t.d * inner_t.b,
+                c: outer_t.a * inner_t.c + outer_t.c * inner_t.d,
+                d: outer_t.b * inner_t.c + outer_t.d * inner_t.d,
+                e: outer_t.a * inner_t.e + outer_t.c * inner_t.f + outer_t.e,
+                f: outer_t.b * inner_t.e + outer_t.d * inner_t.f + outer_t.f,
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/transformation.rb
+++ b/lib/fontisan/ufo/transformation.rb
@@ -34,6 +34,17 @@ module Fontisan
       def to_a
         [a, b, c, d, e, f]
       end
+
+      # Apply this transformation to a single (x, y) coordinate.
+      #
+      # @param x [Numeric]
+      # @param y [Numeric]
+      # @return [Array(Float, Float)] the transformed [tx, ty]
+      def apply(x, y)
+        xf = x.to_f
+        yf = y.to_f
+        [a * xf + c * yf + e, b * xf + d * yf + f]
+      end
     end
   end
 end

--- a/spec/fontisan/ufo/compile/filters/transformations_spec.rb
+++ b/spec/fontisan/ufo/compile/filters/transformations_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/filters"
+
+RSpec.describe Fontisan::Ufo::Compile::Filters::Transformations do
+  let(:glyph) do
+    g = Fontisan::Ufo::Glyph.new(name: "test")
+    g.add_contour(Fontisan::Ufo::Contour.new([
+                                               Fontisan::Ufo::Point.new(x: 0, y: 0, type: "line"),
+                                               Fontisan::Ufo::Point.new(x: 100, y: 0, type: "line"),
+                                               Fontisan::Ufo::Point.new(x: 100, y: 100, type: "line"),
+                                             ]))
+    g.add_component(Fontisan::Ufo::Component.new(base_glyph: "A"))
+    g
+  end
+
+  describe ".run" do
+    it "is a no-op when matrix is nil" do
+      original_points = glyph.contours[0].points.map { |p| [p.x, p.y] }
+      described_class.run([glyph], matrix: nil)
+
+      expect(glyph.contours[0].points.map { |p| [p.x, p.y] }).to eq(original_points)
+      expect(glyph.components[0].transformation).to be_nil
+    end
+
+    it "is a no-op when matrix is identity" do
+      original_points = glyph.contours[0].points.map { |p| [p.x, p.y] }
+      described_class.run([glyph], matrix: [1, 0, 0, 1, 0, 0])
+
+      expect(glyph.contours[0].points.map { |p| [p.x, p.y] }).to eq(original_points)
+      expect(glyph.components[0].transformation).to be_nil
+    end
+
+    it "applies a translation to every contour point" do
+      described_class.run([glyph], matrix: [1, 0, 0, 1, 50, 100])
+
+      coords = glyph.contours[0].points.map { |p| [p.x, p.y] }
+      expect(coords).to eq([[50.0, 100.0], [150.0, 100.0], [150.0, 200.0]])
+    end
+
+    it "applies a uniform scale to every contour point" do
+      described_class.run([glyph], matrix: [2, 0, 0, 2, 0, 0])
+
+      coords = glyph.contours[0].points.map { |p| [p.x, p.y] }
+      expect(coords).to eq([[0.0, 0.0], [200.0, 0.0], [200.0, 200.0]])
+    end
+
+    it "applies a horizontal flip (mirror across vertical axis at x=50)" do
+      # a=-1, e=100 → x' = -x + 100. Point at x=0 → 100; x=100 → 0.
+      described_class.run([glyph], matrix: [-1, 0, 0, 1, 100, 0])
+
+      coords = glyph.contours[0].points.map { |p| [p.x, p.y] }
+      expect(coords).to eq([[100.0, 0.0], [0.0, 0.0], [0.0, 100.0]])
+    end
+
+    it "composes the transform onto each component's existing transformation (left-side composition)" do
+      # First translate the whole glyph by (50, 100). Component's
+      # transformation should now be the translate.
+      described_class.run([glyph], matrix: [1, 0, 0, 1, 50, 100])
+      expect(glyph.components[0].transformation.to_a).to eq([1.0, 0.0, 0.0, 1.0, 50.0, 100.0])
+
+      # Now apply scale(2,2). The new component transformation should
+      # be scale ∘ translate: x' = 2x + 100, y' = 2y + 200.
+      described_class.run([glyph], matrix: [2, 0, 0, 2, 0, 0])
+      expect(glyph.components[0].transformation.to_a).to eq([2.0, 0.0, 0.0, 2.0, 100.0, 200.0])
+    end
+
+    it "accepts a Transformation value object as the matrix" do
+      transform = Fontisan::Ufo::Transformation.new(a: 2, e: 10)
+      described_class.run([glyph], matrix: transform)
+
+      coords = glyph.contours[0].points.map { |p| [p.x, p.y] }
+      expect(coords).to eq([[10.0, 0.0], [210.0, 0.0], [210.0, 100.0]])
+    end
+
+    it "preserves point type and smoothness through the transform" do
+      glyph.contours[0].points[1] = Fontisan::Ufo::Point.new(
+        x: 100, y: 0, type: "offcurve", smooth: false,
+      )
+      described_class.run([glyph], matrix: [1, 0, 0, 1, 0, 0])
+      # No-op (identity), but verify type/smooth preserved through path.
+      expect(glyph.contours[0].points[1].type).to eq("offcurve")
+    end
+
+    it "returns the same glyph array (mutates in place)" do
+      glyphs = [glyph]
+      result = described_class.run(glyphs, matrix: [1, 0, 0, 1, 5, 5])
+      expect(result).to equal(glyphs)
+    end
+  end
+
+  describe "Filters::REGISTRY" do
+    it "registers Transformations under :transformations" do
+      expect(Fontisan::Ufo::Compile::Filters::REGISTRY[:transformations])
+        .to eq(described_class)
+    end
+
+    it "applies via the Filters hub by symbol" do
+      Fontisan::Ufo::Compile::Filters.apply([:transformations], [glyph],
+                                            matrix: [1, 0, 0, 1, 50, 100])
+      coords = glyph.contours[0].points.map { |p| [p.x, p.y] }
+      expect(coords.first).to eq([50.0, 100.0])
+    end
+  end
+end

--- a/spec/fontisan/ufo/transformation_apply_spec.rb
+++ b/spec/fontisan/ufo/transformation_apply_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/transformation"
+
+RSpec.describe Fontisan::Ufo::Transformation do
+  describe "#apply" do
+    it "returns the input unchanged for identity" do
+      t = described_class.new
+      expect(t.apply(50, 100)).to eq([50.0, 100.0])
+    end
+
+    it "translates by (e, f)" do
+      t = described_class.new(e: 10, f: 20)
+      expect(t.apply(5, 5)).to eq([15.0, 25.0])
+    end
+
+    it "scales by a, d" do
+      t = described_class.new(a: 3, d: 4)
+      expect(t.apply(2, 5)).to eq([6.0, 20.0])
+    end
+
+    it "rotates 90° counter-clockwise" do
+      # a=0, b=1, c=-1, d=0 → (x, y) → (-y, x)
+      t = described_class.new(a: 0, b: 1, c: -1, d: 0)
+      expect(t.apply(1, 0)).to eq([0.0, 1.0])
+      expect(t.apply(0, 1)).to eq([-1.0, 0.0])
+    end
+
+    it "coerces integer inputs to float" do
+      t = described_class.new(a: 1, b: 0, c: 0, d: 1, e: 0, f: 0)
+      expect(t.apply(1, 1)).to eq([1.0, 1.0])
+    end
+  end
+end


### PR DESCRIPTION
# TODO.new update

Refreshed `TODO.new/` to reflect the post-merge state:
- Deleted completed TODOs (#29, #42, #69, #70, #71, #72, #73, #74) — see git history / closed-issue comments.
- Updated `TODO.new/README.md` index: only #46 remains open.
- `TODO.new/46-ufo-source-parsing.md` carries the full UFO parity plan; this PR addresses its first focused sub-task (Transformations filter + Transformation#apply).

# PR

This PR implements the first sub-task of issue #46:

## Summary

- **`Fontisan::Ufo::Transformation#apply`** (new method) — single point of truth for the affine math (`x' = a*x + c*y + e`, `y' = b*x + d*y + f`).
- **`Fontisan::Ufo::Compile::Filters::Transformations`** (new module) — general-purpose affine filter, follows the existing filter pattern. Registered as `:transformations` in `Filters::REGISTRY` (OCP — one line).
- **`Stitcher::Source#flatten_simple_component`** refactored to use `Transformation#apply` instead of duplicating the math. Byte-identical behavior.

## Why this slice of #46

#46 is a multi-month umbrella (ufoLib2 + ufo2ft parity). A single PR attempting all of it would be unreviewable. The Transformations filter is:
- Self-contained — no dependency on other Phase 2 work.
- Useful immediately — general-purpose transform; powers italic→upright, slant adjustment, custom offsets.
- DRY-positive — extracts the affine math that was previously inlined in Stitcher::Source.
- Adds `Transformation#apply`, which future filters (propagate_anchors, remove_overlaps) will reuse.

## Architecture

Satisfies the project conventions:
- **OCP** — adding the filter = new file + `REGISTRY` entry, no edits to other filters.
- **DRY** — affine math lives in one method (`Transformation#apply`); used by both the new filter and the existing Stitcher.
- **No private send**, **no instance_variable_set/get**, **no respond_to?**, **no require_relative** (autoload via `Filters` hub).
- **No `double()` in specs** — real Glyph/Contour/Point/Component instances.
- **No nested classes** — `Transformations` is a module under `Filters` (sibling of existing filters).

## Spec coverage

16 examples across two files:
- `transformations_spec.rb`: filter behavior (translate, scale, flip, no-op paths, registry registration, hub symbol dispatch, composition semantics with chained filters).
- `transformation_apply_spec.rb`: pure math (identity, translate, scale, rotate, integer coercion).

## Test plan

- [x] `bundle exec rspec spec/fontisan/ufo/compile/filters/transformations_spec.rb spec/fontisan/ufo/transformation_apply_spec.rb` — 16 examples, 0 failures
- [x] `bundle exec rspec spec/fontisan/ufo/ spec/fontisan/stitcher/` — 294 examples, 0 failures, 1 pre-existing pending
- [x] `bundle exec rubocop` on changed files — clean

Refs #46 (does not close — multi-month umbrella; this is one focused sub-task).
