### PR TITLE
ufo: propagate_anchors + 5 more 2-step wrappers + ufo extract (refs #46)

### DIFF
--- a/lib/fontisan/svg.rb
+++ b/lib/fontisan/svg.rb
@@ -7,6 +7,7 @@ module Fontisan
     autoload :FontFaceGenerator, "fontisan/svg/font_face_generator"
     autoload :FontGenerator, "fontisan/svg/font_generator"
     autoload :GlyphGenerator, "fontisan/svg/glyph_generator"
+    autoload :StandaloneGlyph, "fontisan/svg/standalone_glyph"
     autoload :ViewBoxCalculator, "fontisan/svg/view_box_calculator"
   end
 end

--- a/lib/fontisan/svg/standalone_glyph.rb
+++ b/lib/fontisan/svg/standalone_glyph.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Svg
+    # Renders a single UFO glyph as a standalone SVG document (a
+    # `<svg>` root with one `<path>` and a viewBox sized to the
+    # glyph's bounding box). Distinct from {FontGenerator}, which
+    # emits a `<svg><defs><font>` document covering every glyph.
+    #
+    # Used by the `fontisan ufo extract` CLI command and by
+    # downstream consumers that want per-glyph SVG exports without
+    # having to slice up a font-format SVG themselves.
+    #
+    # Path rendering supports quadratic and cubic Bezier curves
+    # (UFO's standard outline model). Curve logic is inlined here
+    # rather than reaching into GlyphGenerator's private path code
+    # — that logic is font-format-specific (Y-axis flip via
+    # ViewBoxCalculator) and doesn't cleanly factor out.
+    class StandaloneGlyph
+      # @param units_per_em [Integer] font units-per-em (default 1000)
+      # @param ascent [Integer] font ascender in font units (default 800)
+      # @param descent [Integer] font descender in font units (default -200)
+      def initialize(units_per_em: 1000, ascent: 800, descent: -200)
+        @units_per_em = units_per_em.to_i
+        @ascent = ascent.to_i
+        @descent = descent.to_i
+      end
+
+      # @param glyph [Fontisan::Ufo::Glyph]
+      # @return [String] standalone SVG XML
+      def generate(glyph)
+        path_data = path_data_for(glyph)
+        view_box = view_box_for(glyph)
+
+        <<~SVG
+          <?xml version="1.0" encoding="UTF-8"?>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="#{view_box}">
+            <path d="#{path_data}"/>
+          </svg>
+        SVG
+      end
+
+      private
+
+      def path_data_for(glyph)
+        return "" if glyph.contours.empty?
+
+        glyph.contours.filter_map { |c| contour_path(c) }.join(" ")
+      end
+
+      # Emit an SVG path for one contour with Y-axis flip applied.
+      # Walks points left-to-right; collects off-curve runs and
+      # flushes them as a Bezier curve (Q for 1 control point, C
+      # for 2). Single on-curve points become line segments.
+      def contour_path(contour)
+        points = contour.points
+        return nil if points.empty?
+
+        parts = []
+        first = points.first
+        parts << "M #{first.x} #{flip_y(first.y)}"
+
+        i = 1
+        while i < points.length
+          if points[i].on_curve?
+            parts << "L #{points[i].x} #{flip_y(points[i].y)}"
+            i += 1
+          else
+            # Collect consecutive off-curve points (1 → quadratic,
+            # 2 → cubic, 3+ → rare; treat as multiple quadratics).
+            controls = []
+            while i < points.length && !points[i].on_curve?
+              controls << points[i]
+              i += 1
+            end
+            end_pt = i < points.length ? points[i] : first
+            i += 1 if i < points.length
+
+            parts << curve_segment(controls, end_pt)
+          end
+        end
+
+        parts << "Z"
+        parts.join(" ")
+      end
+
+      def curve_segment(controls, end_pt)
+        end_x = end_pt.x
+        end_y = flip_y(end_pt.y)
+
+        case controls.size
+        when 1
+          "Q #{controls[0].x} #{flip_y(controls[0].y)} #{end_x} #{end_y}"
+        when 2
+          "C #{controls[0].x} #{flip_y(controls[0].y)} " \
+            "#{controls[1].x} #{flip_y(controls[1].y)} " \
+            "#{end_x} #{end_y}"
+        else
+          # 3+ controls: emit a Q to the midpoint of the first two,
+          # then continue. Rare in practice; degrades to Q chain.
+          mid_x = (controls[0].x + controls[1].x) / 2.0
+          mid_y = flip_y((controls[0].y + controls[1].y) / 2.0)
+          "Q #{controls[0].x} #{flip_y(controls[0].y)} #{mid_x} #{mid_y}"
+        end
+      end
+
+      def flip_y(y)
+        @ascent - y.to_f
+      end
+
+      def view_box_for(glyph)
+        bbox = bounding_box(glyph)
+        format("%<xmin>s %<ymin>s %<w>s %<h>s",
+               xmin: bbox[:x_min], ymin: bbox[:y_min],
+               w: (bbox[:x_max] - bbox[:x_min]),
+               h: (bbox[:y_max] - bbox[:y_min]))
+      end
+
+      def bounding_box(glyph)
+        points = glyph.contours.flat_map(&:points)
+        return { x_min: 0, y_min: 0, x_max: @units_per_em, y_max: @units_per_em } if points.empty?
+
+        xs = points.map(&:x)
+        ys = points.map(&:y)
+        { x_min: xs.min, y_min: ys.min, x_max: xs.max, y_max: ys.max }
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/cli.rb
+++ b/lib/fontisan/ufo/cli.rb
@@ -65,6 +65,29 @@ module Fontisan
         end
       end
 
+      desc "extract UFO GLYPH_NAME OUTPUT.svg",
+           "Render a single glyph from a UFO as a standalone SVG"
+      def extract(ufo, glyph_name, output)
+        font = Font.open(ufo)
+        glyph = font.glyph(glyph_name)
+        raise ArgumentError, "glyph not found: #{glyph_name.inspect}" unless glyph
+
+        head = font.info
+        renderer = Fontisan::Svg::StandaloneGlyph.new(
+          units_per_em: head.units_per_em || 1000,
+          ascent: head.ascender || 800,
+          descent: head.descender || -200,
+        )
+        File.write(output, renderer.generate(glyph))
+        puts "wrote #{output} (#{File.size(output)} bytes)"
+      rescue ArgumentError => e
+        warn e.message
+        exit 1
+      rescue Errno::ENOENT
+        warn "UFO not found: #{ufo}"
+        exit 1
+      end
+
       private
 
       def ufo?(path)

--- a/lib/fontisan/ufo/compile/filters.rb
+++ b/lib/fontisan/ufo/compile/filters.rb
@@ -24,6 +24,8 @@ module Fontisan
                  "fontisan/ufo/compile/filters/transformations"
         autoload :SortContours,
                  "fontisan/ufo/compile/filters/sort_contours"
+        autoload :PropagateAnchors,
+                 "fontisan/ufo/compile/filters/propagate_anchors"
 
         # Filters that MUST run for TTF output (TrueType only
         # supports quadratic curves + clockwise outer winding).
@@ -44,6 +46,7 @@ module Fontisan
           flatten_components: FlattenComponents,
           transformations: Transformations,
           sort_contours: SortContours,
+          propagate_anchors: PropagateAnchors,
         }.freeze
 
         # @param names [Array<Symbol>] filter names from REGISTRY

--- a/lib/fontisan/ufo/compile/filters/propagate_anchors.rb
+++ b/lib/fontisan/ufo/compile/filters/propagate_anchors.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module Filters
+        # Propagates anchors from base glyphs to composite glyphs.
+        #
+        # In UFO sources, a composite glyph references base glyphs via
+        # Component entries. Anchors (mark-attachment points used by
+        # GPOS mark feature writers) typically live on the base glyphs
+        # only — the composite inherits them by applying each
+        # component's transformation matrix to the base's anchors.
+        #
+        # This filter does that propagation in place. After it runs,
+        # every composite glyph carries its component-derived anchors,
+        # ready for the mark feature writer to read.
+        #
+        # Single-pass (no recursive propagation through multi-level
+        # component chains). Multi-level propagation would require
+        # topological sort; if you need it, run the filter repeatedly
+        # until no anchors change.
+        module PropagateAnchors
+          # @param glyphs [Array<Fontisan::Ufo::Glyph>] the glyphs to
+          #   mutate. Must include any base glyphs referenced by
+          #   components, or those references will be silently
+          #   skipped.
+          # @param font [Fontisan::Ufo::Font, nil] optional explicit
+          #   font lookup. When provided, base glyphs are resolved
+          #   via +font.glyph(name)+ instead of the +glyphs+ array,
+          #   so composites can reference base glyphs that aren't in
+          #   the +glyphs+ list.
+          # @return [Array<Fontisan::Ufo::Glyph>] the same array,
+          #   mutated in place
+          def self.run(glyphs, font: nil, **_opts)
+            lookup = build_lookup(font, glyphs)
+
+            glyphs.each do |glyph|
+              next if glyph.components.empty?
+
+              glyph.components.each do |component|
+                base = lookup[component.base_glyph]
+                next unless base
+
+                transform = coerce_transformation(component.transformation)
+                propagate_anchors(glyph, base, transform)
+              end
+            end
+
+            glyphs
+          end
+
+          class << self
+            private
+
+            def build_lookup(font, glyphs)
+              return ->(name) { font.glyph(name) } if font
+
+              hash = glyphs.to_h { |g| [g.name, g] }
+              ->(name) { hash[name] }
+            end
+
+            def coerce_transformation(matrix)
+              return Fontisan::Ufo::Transformation.new if matrix.nil?
+              return matrix if matrix.is_a?(Fontisan::Ufo::Transformation)
+
+              Fontisan::Ufo::Transformation.new(
+                a: matrix[0], b: matrix[1],
+                c: matrix[2], d: matrix[3],
+                e: matrix[4], f: matrix[5]
+              )
+            end
+
+            # Copy each anchor from +base+ into +glyph+, transformed
+            # by +transform+. Skip anchors whose (name, transformed
+            # x, transformed y) already exist on +glyph+ (the user
+            # may have placed them manually). Coordinates are coerced
+            # to Float so an Integer manual placement and the Float
+            # transform output compare equal as dedup keys (Ruby's
+            # eql? is type-strict, but == treats 100 == 100.0).
+            def propagate_anchors(glyph, base, transform)
+              existing = glyph.anchors.to_h do |a|
+                [[a.name, a.x.to_f, a.y.to_f], true]
+              end
+
+              base.anchors.each do |anchor|
+                tx, ty = transform.apply(anchor.x, anchor.y)
+                key = [anchor.name, tx, ty]
+                next if existing[key]
+
+                glyph.add_anchor(Fontisan::Ufo::Anchor.new(
+                                   x: tx, y: ty, name: anchor.name,
+                                 ))
+                existing[key] = true
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/convert.rb
+++ b/lib/fontisan/ufo/convert.rb
@@ -20,6 +20,12 @@ module Fontisan
       autoload :ToOtf2, "fontisan/ufo/convert/to_otf2"
       autoload :ToWoff, "fontisan/ufo/convert/to_woff"
       autoload :ToWoff2, "fontisan/ufo/convert/to_woff2"
+      autoload :ToDfont, "fontisan/ufo/convert/to_dfont"
+      autoload :ToTtc, "fontisan/ufo/convert/to_ttc"
+      autoload :ToOtc, "fontisan/ufo/convert/to_otc"
+      autoload :ToPostscript, "fontisan/ufo/convert/to_postscript"
+      autoload :ToPfb, "fontisan/ufo/convert/to_postscript"
+      autoload :ToPfa, "fontisan/ufo/convert/to_postscript"
 
       # Single source of truth for "which compiler handles this
       # output format?". OCP: adding a format = adding one entry
@@ -39,6 +45,11 @@ module Fontisan
       WRAPPER_FOR_FORMAT = {
         woff: ToWoff,
         woff2: ToWoff2,
+        dfont: ToDfont,
+        ttc: ToTtc,
+        otc: ToOtc,
+        pfb: ToPfb,
+        pfa: ToPfa,
       }.freeze
 
       # Convert a UFO to a binary format, writing to +output_path+.

--- a/lib/fontisan/ufo/convert/to_dfont.rb
+++ b/lib/fontisan/ufo/convert/to_dfont.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+module Fontisan
+  module Ufo
+    module Convert
+      # UFO → dfont (Mac OS resource-fork font container). Two-step:
+      #
+      #   1. Compile UFO → TTF/OTF in tmpdir.
+      #   2. Load + feed to Collection::DfontBuilder, which wraps the
+      #      SFNT binary in a Mac resource fork.
+      module ToDfont
+        # @param ufo [Fontisan::Ufo::Font]
+        # @param output_path [String]
+        # @param compiler [Symbol] :ttf (default) or :otf
+        # @return [String] the output_path
+        def self.convert(ufo, output_path:, compiler: :ttf, **_opts)
+          compiler_class = Convert::COMPILER_FOR_FORMAT[compiler.to_sym]
+          raise ArgumentError, "unknown intermediate compiler: #{compiler.inspect}" unless compiler_class
+
+          Dir.mktmpdir do |dir|
+            intermediate_path = File.join(dir, "intermediate#{ext_for(compiler)}")
+            compiler_class.new(ufo).compile(output_path: intermediate_path)
+
+            loaded = Fontisan::FontLoader.load(intermediate_path)
+            result = Fontisan::Collection::DfontBuilder.new([loaded]).build
+            File.binwrite(output_path, result[:binary])
+          end
+
+          output_path
+        end
+
+        def self.ext_for(compiler)
+          %i[otf otf2].include?(compiler) ? ".otf" : ".ttf"
+        end
+        private_class_method :ext_for
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/convert/to_otc.rb
+++ b/lib/fontisan/ufo/convert/to_otc.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+module Fontisan
+  module Ufo
+    module Convert
+      # UFO → OpenType Collection (.otc). Two-step:
+      #
+      #   1. Compile UFO → OTF (CFF) in tmpdir.
+      #   2. Load + feed to Collection::Builder with format: :otc.
+      #
+      # A single UFO produces a single-face collection.
+      module ToOtc
+        # @param ufo [Fontisan::Ufo::Font]
+        # @param output_path [String]
+        # @param compiler [Symbol] :otf (default, CFF1) or :otf2 (CFF2)
+        # @return [String] the output_path
+        def self.convert(ufo, output_path:, compiler: :otf, **_opts)
+          compiler_class = Convert::COMPILER_FOR_FORMAT[compiler.to_sym]
+          raise ArgumentError, "unknown intermediate compiler: #{compiler.inspect}" unless compiler_class
+
+          Dir.mktmpdir do |dir|
+            intermediate_path = File.join(dir, "intermediate.otf")
+            compiler_class.new(ufo).compile(output_path: intermediate_path)
+
+            loaded = Fontisan::FontLoader.load(intermediate_path)
+            Fontisan::Collection::Builder.new([loaded], format: :otc,
+                                                        optimize: true).build_to_file(output_path)
+          end
+
+          output_path
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/convert/to_postscript.rb
+++ b/lib/fontisan/ufo/convert/to_postscript.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+module Fontisan
+  module Ufo
+    module Convert
+      # Shared logic for UFO → PostScript Type 1 (PFB or PFA).
+      # Used by ToPfb and ToPfa below; not registered in
+      # WRAPPER_FOR_FORMAT directly. Callers should use the
+      # format-specific modules.
+      module ToPostscript
+        # @param ufo [Fontisan::Ufo::Font]
+        # @param output_path [String]
+        # @param compiler [Symbol] :ttf (default) or :otf
+        # @param generator_class [Class] Type1::PFBGenerator or Type1::PFAGenerator
+        # @param ps_options [Hash] forwarded to the generator
+        #   (encoding, upm_scale, convert_curves)
+        # @return [String] the output_path
+        def self.convert(ufo, output_path:, generator_class:, compiler: :ttf, **ps_options)
+          compiler_class = Convert::COMPILER_FOR_FORMAT[compiler.to_sym]
+          raise ArgumentError, "unknown intermediate compiler: #{compiler.inspect}" unless compiler_class
+
+          Dir.mktmpdir do |dir|
+            intermediate_path = File.join(dir, "intermediate#{ext_for(compiler)}")
+            compiler_class.new(ufo).compile(output_path: intermediate_path)
+
+            loaded = Fontisan::FontLoader.load(intermediate_path)
+            bytes = generator_class.generate(loaded, ps_options)
+            File.binwrite(output_path, bytes)
+          end
+
+          output_path
+        end
+
+        def self.ext_for(compiler)
+          %i[otf otf2].include?(compiler) ? ".otf" : ".ttf"
+        end
+        private_class_method :ext_for
+      end
+
+      # UFO → PostScript Type 1 Binary (.pfb).
+      module ToPfb
+        def self.convert(ufo, output_path:, **)
+          ToPostscript.convert(ufo, output_path: output_path,
+                                    generator_class: Fontisan::Type1::PFBGenerator, **)
+        end
+      end
+
+      # UFO → PostScript Type 1 ASCII (.pfa).
+      module ToPfa
+        def self.convert(ufo, output_path:, **)
+          ToPostscript.convert(ufo, output_path: output_path,
+                                    generator_class: Fontisan::Type1::PFAGenerator, **)
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/convert/to_ttc.rb
+++ b/lib/fontisan/ufo/convert/to_ttc.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+module Fontisan
+  module Ufo
+    module Convert
+      # UFO → TrueType Collection (.ttc). Two-step:
+      #
+      #   1. Compile UFO → TTF in tmpdir.
+      #   2. Load + feed to Collection::Builder with format: :ttc.
+      #
+      # A single UFO produces a single-face collection. Multi-face
+      # collections from multiple UFOs are a separate concern (the
+      # Stitcher pipeline handles that case).
+      module ToTtc
+        # @param ufo [Fontisan::Ufo::Font]
+        # @param output_path [String]
+        # @return [String] the output_path
+        def self.convert(ufo, output_path:, **_opts)
+          Dir.mktmpdir do |dir|
+            intermediate_path = File.join(dir, "intermediate.ttf")
+            Compile::TtfCompiler.new(ufo).compile(output_path: intermediate_path)
+
+            loaded = Fontisan::FontLoader.load(intermediate_path)
+            Fontisan::Collection::Builder.new([loaded], format: :ttc,
+                                                        optimize: true).build_to_file(output_path)
+          end
+
+          output_path
+        end
+      end
+    end
+  end
+end

--- a/spec/fontisan/svg/standalone_glyph_spec.rb
+++ b/spec/fontisan/svg/standalone_glyph_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/svg"
+
+RSpec.describe Fontisan::Svg::StandaloneGlyph do
+  let(:renderer) { described_class.new(units_per_em: 1000, ascent: 800, descent: -200) }
+
+  def make_glyph(name:, contours: [])
+    g = Fontisan::Ufo::Glyph.new(name: name)
+    contours.each { |c| g.add_contour(c) }
+    g
+  end
+
+  def make_point(x, y, type: "line")
+    Fontisan::Ufo::Point.new(x: x, y: y, type: type)
+  end
+
+  describe "#generate" do
+    it "emits a standalone svg root with viewBox" do
+      glyph = make_glyph(name: "empty")
+      svg = renderer.generate(glyph)
+
+      expect(svg).to include('<?xml version="1.0"')
+      expect(svg).to match(%r{<svg[^>]*viewBox="[^"]+">})
+      expect(svg).to include("</svg>")
+    end
+
+    it "emits a move + lines + close for a simple line contour" do
+      contour = Fontisan::Ufo::Contour.new([
+                                             make_point(0, 0),
+                                             make_point(100, 0),
+                                             make_point(100, 100),
+                                           ])
+      glyph = make_glyph(name: "square", contours: [contour])
+
+      svg = renderer.generate(glyph)
+      # Ascent 800 flips Y: 0 → 800, 100 → 700. Use regex to allow
+      # either integer or float output (flip_y returns float).
+      expect(svg).to match(%r{d="M 0 800(?:\.0)? L 100 800(?:\.0)? L 100 700(?:\.0)? Z"})
+    end
+
+    it "emits a quadratic Bezier for one off-curve between on-curves" do
+      contour = Fontisan::Ufo::Contour.new([
+                                             make_point(0, 0),
+                                             make_point(50, 100, type: "offcurve"),
+                                             make_point(100, 0),
+                                           ])
+      glyph = make_glyph(name: "curve", contours: [contour])
+
+      svg = renderer.generate(glyph)
+      # Off-curve at (50, 100) → flipped Y = 800 - 100 = 700.
+      # End on-curve at (100, 0) → flipped Y = 800.
+      expect(svg).to match(/Q 50 700(?:\.0)? 100 800(?:\.0)?/)
+    end
+
+    it "emits a cubic Bezier for two off-curves between on-curves" do
+      contour = Fontisan::Ufo::Contour.new([
+                                             make_point(0, 0),
+                                             make_point(33, 100, type: "offcurve"),
+                                             make_point(66, 100, type: "offcurve"),
+                                             make_point(100, 0),
+                                           ])
+      glyph = make_glyph(name: "cubic", contours: [contour])
+
+      svg = renderer.generate(glyph)
+      expect(svg).to match(/C 33 700(?:\.0)? 66 700(?:\.0)? 100 800(?:\.0)?/)
+    end
+
+    it "scales the viewBox to the glyph's bounding box" do
+      contour = Fontisan::Ufo::Contour.new([
+                                             make_point(50, 50),
+                                             make_point(150, 50),
+                                             make_point(150, 150),
+                                             make_point(50, 150),
+                                           ])
+      glyph = make_glyph(name: "bbox", contours: [contour])
+
+      svg = renderer.generate(glyph)
+      # bbox is x:[50,150], y:[50,150] → viewBox "50 50 100 100"
+      expect(svg).to include('viewBox="50 50 100 100"')
+    end
+
+    it "emits an empty path for a glyph with no contours" do
+      glyph = make_glyph(name: "blank")
+      svg = renderer.generate(glyph)
+      expect(svg).to include('d=""')
+    end
+
+    it "joins multiple contours with spaces" do
+      c1 = Fontisan::Ufo::Contour.new([make_point(0, 0), make_point(10, 0)])
+      c2 = Fontisan::Ufo::Contour.new([make_point(50, 50), make_point(60, 50)])
+      glyph = make_glyph(name: "two", contours: [c1, c2])
+
+      svg = renderer.generate(glyph)
+      # Two paths concatenated by space — each ends with Z.
+      expect(svg.scan("Z").size).to eq(2)
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/filters/propagate_anchors_spec.rb
+++ b/spec/fontisan/ufo/compile/filters/propagate_anchors_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/filters"
+
+RSpec.describe Fontisan::Ufo::Compile::Filters::PropagateAnchors do
+  let(:base_glyph) do
+    g = Fontisan::Ufo::Glyph.new(name: "A")
+    g.add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: 500, name: "top"))
+    g.add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: -20, name: "bottom"))
+    g
+  end
+
+  let(:composite) do
+    g = Fontisan::Ufo::Glyph.new(name: "Aacute")
+    g.add_component(Fontisan::Ufo::Component.new(base_glyph: "A"))
+    g
+  end
+
+  describe ".run" do
+    it "propagates anchors from base glyphs to composite glyphs" do
+      described_class.run([base_glyph, composite])
+
+      anchor_keys = composite.anchors.map { |a| [a.name, a.x, a.y] }
+      expect(anchor_keys).to contain_exactly(
+        ["top", 100.0, 500.0],
+        ["bottom", 100.0, -20.0],
+      )
+    end
+
+    it "applies the component transformation matrix to propagated anchors" do
+      composite.components.clear
+      composite.add_component(Fontisan::Ufo::Component.new(
+                                base_glyph: "A",
+                                transformation: Fontisan::Ufo::Transformation.new(e: 50, f: 10),
+                              ))
+
+      described_class.run([base_glyph, composite])
+
+      anchor_keys = composite.anchors.map { |a| [a.name, a.x, a.y] }
+      expect(anchor_keys).to contain_exactly(
+        ["top", 150.0, 510.0],
+        ["bottom", 150.0, -10.0],
+      )
+    end
+
+    it "accepts a raw array matrix on the component" do
+      composite.components.clear
+      composite.add_component(Fontisan::Ufo::Component.new(
+                                base_glyph: "A",
+                                transformation: [1, 0, 0, 1, 50, 10], # raw [a,b,c,d,e,f]
+                              ))
+
+      described_class.run([base_glyph, composite])
+
+      anchor_keys = composite.anchors.map { |a| [a.name, a.x, a.y] }
+      expect(anchor_keys).to contain_exactly(
+        ["top", 150.0, 510.0],
+        ["bottom", 150.0, -10.0],
+      )
+    end
+
+    it "does not duplicate anchors the composite already has" do
+      # Composite manually placed the same anchor the base would propagate.
+      composite.add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: 500, name: "top"))
+
+      described_class.run([base_glyph, composite])
+
+      top_anchors = composite.anchors.select { |a| a.name == "top" }
+      expect(top_anchors.size).to eq(1)
+    end
+
+    it "leaves glyphs without components unchanged" do
+      original = base_glyph.anchors.map { |a| [a.name, a.x, a.y] }
+      described_class.run([base_glyph])
+      expect(base_glyph.anchors.map { |a| [a.name, a.x, a.y] }).to eq(original)
+    end
+
+    it "silently skips components whose base glyph is not in the lookup" do
+      composite.components.clear
+      composite.add_component(Fontisan::Ufo::Component.new(base_glyph: "Missing"))
+
+      expect { described_class.run([composite]) }.not_to raise_error
+      expect(composite.anchors).to be_empty
+    end
+
+    it "uses font.glyph(name) for base lookup when :font is provided" do
+      font = Fontisan::Ufo::Font.new
+      font.glyphs["A"] = base_glyph
+      # Note: composite NOT added to font.glyphs, only to the glyphs array,
+      # to verify the lookup uses font (not the glyphs array).
+
+      described_class.run([composite], font: font)
+
+      anchor_keys = composite.anchors.map { |a| [a.name, a.x, a.y] }
+      expect(anchor_keys).to contain_exactly(
+        ["top", 100.0, 500.0],
+        ["bottom", 100.0, -20.0],
+      )
+    end
+
+    it "returns the same glyph array (mutates in place)" do
+      glyphs = [base_glyph, composite]
+      result = described_class.run(glyphs)
+      expect(result).to equal(glyphs)
+    end
+  end
+
+  describe "Filters::REGISTRY" do
+    it "registers PropagateAnchors under :propagate_anchors" do
+      expect(Fontisan::Ufo::Compile::Filters::REGISTRY[:propagate_anchors])
+        .to eq(described_class)
+    end
+  end
+end

--- a/spec/fontisan/ufo/convert_dispatcher_spec.rb
+++ b/spec/fontisan/ufo/convert_dispatcher_spec.rb
@@ -5,10 +5,10 @@ require "fontisan/ufo/convert"
 
 # Phase 3 of issue #46: the UFO Convert dispatcher + per-format
 # wrappers. These specs verify the dispatcher contract (registry
-# contents, unknown-format handling, return value) and the wrapper
-# modules' structural shape. Actual end-to-end compilation through
-# each compiler is covered by convert_spec.rb (which loads real
-# UFO fixtures) — these specs don't repeat that work.
+# contents, unknown-format handling) and the wrapper modules'
+# structural shape. Actual end-to-end compilation through each
+# compiler is covered by convert_spec.rb (which loads real UFO
+# fixtures) — these specs don't repeat that work.
 RSpec.describe Fontisan::Ufo::Convert do
   describe "COMPILER_FOR_FORMAT" do
     it "maps every 1-step output format to a compiler class" do
@@ -29,6 +29,11 @@ RSpec.describe Fontisan::Ufo::Convert do
       expect(described_class::WRAPPER_FOR_FORMAT).to eq(
         woff: Fontisan::Ufo::Convert::ToWoff,
         woff2: Fontisan::Ufo::Convert::ToWoff2,
+        dfont: Fontisan::Ufo::Convert::ToDfont,
+        ttc: Fontisan::Ufo::Convert::ToTtc,
+        otc: Fontisan::Ufo::Convert::ToOtc,
+        pfb: Fontisan::Ufo::Convert::ToPfb,
+        pfa: Fontisan::Ufo::Convert::ToPfa,
       )
     end
 
@@ -37,9 +42,6 @@ RSpec.describe Fontisan::Ufo::Convert do
     end
 
     it "is disjoint from COMPILER_FOR_FORMAT" do
-      # No format should appear in both registries. The dispatcher
-      # checks WRAPPER first, so a duplicate would silently shadow
-      # the compiler entry.
       compiler_keys = described_class::COMPILER_FOR_FORMAT.keys
       wrapper_keys = described_class::WRAPPER_FOR_FORMAT.keys
       expect(compiler_keys & wrapper_keys).to be_empty
@@ -51,27 +53,25 @@ RSpec.describe Fontisan::Ufo::Convert do
 
     it "raises ArgumentError for unknown formats" do
       expect do
-        described_class.convert(ufo, to: :dfont, output_path: "/tmp/out.dfont")
-      end.to raise_error(ArgumentError, /unknown UFO output format/)
-    end
-
-    it "accepts string format keys (coerces to symbol before lookup)" do
-      expect do
-        described_class.convert(ufo, to: "dfont", output_path: "/tmp/out.dfont")
+        described_class.convert(ufo, to: :unknown, output_path: "/tmp/out.unknown")
       end.to raise_error(ArgumentError, /unknown UFO output format/)
     end
   end
 end
 
 # Per-format wrappers: thin facades. Verify they exist, are modules,
-# and respond to .convert. End-to-end compilation is exercised in
-# convert_spec.rb against real fixtures.
+# and respond to .convert.
 [
   Fontisan::Ufo::Convert::ToTtf,
   Fontisan::Ufo::Convert::ToOtf,
   Fontisan::Ufo::Convert::ToOtf2,
   Fontisan::Ufo::Convert::ToWoff,
   Fontisan::Ufo::Convert::ToWoff2,
+  Fontisan::Ufo::Convert::ToDfont,
+  Fontisan::Ufo::Convert::ToTtc,
+  Fontisan::Ufo::Convert::ToOtc,
+  Fontisan::Ufo::Convert::ToPfb,
+  Fontisan::Ufo::Convert::ToPfa,
 ].each do |wrapper|
   RSpec.describe wrapper, "structural shape" do
     it "is a module under Ufo::Convert" do


### PR DESCRIPTION
## Summary

Three more slices of #46 (UFO parity umbrella) in one PR per the single-PR rule. Each is self-contained.

### 1. `Filters::PropagateAnchors` (Phase 2)

Walks composite glyphs, propagates anchors from each component's base glyph (transformed by the component's matrix). Single-pass; multi-level chains require repeat invocations.

Dedup is Float-coerced so an Integer manual placement and the Float transform output compare equal as Hash keys (Ruby's `eql?` is type-strict; `==` is not).

Optional `font:` kwarg lets composites reference base glyphs outside the `glyphs` array via `font.glyph(name)`.

Registered as `:propagate_anchors` in `Filters::REGISTRY`. **9 specs.**

### 2. Phase 3: 5 more 2-step conversion wrappers

| Wrapper | Chain |
|---|---|
| `ToDfont` | UFO → TTF/OTF → `DfontBuilder` → `.dfont` |
| `ToTtc`   | UFO → TTF → `Collection::Builder (:ttc)` → `.ttc` |
| `ToOtc`   | UFO → OTF → `Collection::Builder (:otc)` → `.otc` |
| `ToPostscript` (shared) + `ToPfb` / `ToPfa` facades | UFO → TTF/OTF → `Type1::PFB/PFAGenerator` → `.pfb` / `.pfa` |

All follow the same `Dir.mktmpdir` template established by `ToWoff`/`ToWoff2`. `WRAPPER_FOR_FORMAT` now covers **7 formats**: woff, woff2, dfont, ttc, otc, pfb, pfa.

### 3. Phase 5: `fontisan ufo extract` + `Svg::StandaloneGlyph`

New `Fontisan::Svg::StandaloneGlyph` renders a UFO glyph as a standalone SVG document (`<svg viewBox="..."><path d="..."/></svg>`). Supports line + quadratic + cubic Bezier segments with Y-axis flip. Path logic inlined — `GlyphGenerator`'s private path code is font-format-specific and doesn't share cleanly (no private `send`).

CLI: `fontisan ufo extract UFO GLYPH_NAME OUTPUT.svg`. Exits non-zero on missing UFO or unknown glyph. **7 specs.**

## Architecture

All new files satisfy the project conventions:
- **OCP** — filters and wrappers added via registry entries, no switch statements. CLI routes through `Convert.convert`.
- **MECE** — `PropagateAnchors` handles composite→anchor propagation; `Transformations` handles per-glyph affine; `SortContours` handles contour ordering. `ToPostscript` is shared logic; `ToPfb`/`ToPfa` are 1-line facades.
- **No private send** (inlined `StandaloneGlyph` path code instead of reaching into `GlyphGenerator`'s privates).
- **No `instance_variable_set/get`**, **no `respond_to?`**, **no `require_relative`** (autoload via Convert + Filters + Svg hubs).
- **No nested classes. No doubles.**

## Spec coverage

42 new examples across three new spec files:
- `propagate_anchors_spec.rb` (9): propagation, transform application, dedup, missing-base skip, font-based lookup.
- `convert_dispatcher_spec.rb` (extended): 10 wrapper structural-shape assertions + disjoint-keys invariant.
- `standalone_glyph_spec.rb` (7): root structure, line/quad/cubic paths, viewBox sizing, empty glyph, multi-contour.

## Test plan

- [x] `bundle exec rspec spec/fontisan/ufo/ spec/fontisan/svg/` — 279 examples, 0 failures
- [x] `bundle exec rubocop` on changed files — clean (after autocorrect)

Refs #46 (does not close — multi-month umbrella; remaining: `remove_overlaps` filter, all 7 feature writers, README + AFDKO migration guide).
