### PR TITLE
ufo: complete feature writers (curs/mkmk/kern2) + remove_overlaps + Phase 5 docs (closes #46)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -60,11 +60,15 @@ Font compilation and assembly::
 * UFO → TTF compilation with cubic-to-quadratic conversion and winding-order correction (see link:docs/UFO_COMPILATION.adoc[UFO Compilation Guide])
 * UFO → OTF (CFF1) compilation with Type 2 charstring encoding
 * UFO → OTF (CFF2) compilation with variable-font blend/vsindex operators (see link:docs/CFF2_SUPPORT.adoc[CFF2 Support Guide])
+* UFO → all binary formats via the `Ufo::Convert` dispatcher: TTF, OTF, OTF2, WOFF, WOFF2, dfont, TTC, OTC, PFB, PFA
+* UFO feature writers: GDEF glyph classification, GPOS kern/mark/mkmk/curs (see link:docs/UFO_COMPILATION.adoc[UFO Compilation Guide — Filters + Feature Writers])
+* Glyph-processing filters: cubic_to_quadratic, decompose_components, flatten_components, reverse_contour_direction, transformations, sort_contours, propagate_anchors, remove_overlaps
 * Multi-source font stitching with explicit subfont declaration and TTC/OTC collection output (see link:docs/STITCHER_GUIDE.adoc[Stitcher Guide])
 * SVG path → UFO glyph conversion for chart-extracted glyphs (see link:docs/SVG_TO_GLYF.adoc[SVG to Glyph Guide])
 * Variable font compilation: fvar, gvar, HVAR, MVAR, avar, STAT tables
 * Signature-based glyph deduplication with 65,535 glyph cap enforcement
 * Compound (composite) TrueType glyph flattening
+* AFDKO migration: drop-in replacement for `makeotf`, `otf2ttf`, `ttx`, `mergeFonts`, `checkOutlinesUFO` (see link:docs/AFDKO_MIGRATION.adoc[AFDKO Migration Guide])
 
 Color fonts and collections::
 * Color font table builders: COLR v0, CPAL, SVG table, sbix, CBDT/CBLC (see link:docs/COLOR_FONTS.adoc[Color Fonts Guide])

--- a/docs/AFDKO_MIGRATION.adoc
+++ b/docs/AFDKO_MIGRATION.adoc
@@ -1,0 +1,175 @@
+= AFDKO Migration Guide
+
+This guide maps commands and concepts from Adobe Font Development
+Kit for OpenType (AFDKO) — `makeotf`, `otf2ttf`, `ttx`, `mergeFonts`,
+`rotateFont` — to their pure-Ruby equivalents in fontisan.
+
+fontisan's UFO pipeline replaces every AFDKO command for the
+compile/convert/validate workflows. No external toolchain required.
+
+== Command map
+
+[cols="1,1,3", options="header"]
+|===
+| AFDKO | fontisan | Notes
+
+| `makeotf -f font.ufo -o font.otf`
+| `fontisan ufo build font.ufo --output font.otf --to otf`
+| CFF1 output by default; pass `--to otf2` for CFF2 (variable fonts).
+
+| `makeotf -f font.ufo -o font.ttf`
+| `fontisan ufo build font.ufo --output font.ttf --to ttf`
+| TrueType (glyf) output. `cubic_to_quadratic` and
+  `reverse_contour_direction` filters run automatically.
+
+| `ttx font.ttf`
+| `fontisan ufo convert font.ttf font.ufo`
+| `ttx` produces XML; fontisan produces a typed UFO source directory.
+
+| `otf2ttf font.otf`
+| `fontisan convert font.otf font.ttf`
+| Outline conversion (CFF → glyf) is handled by the
+  `OutlineConverter` strategy; no Python required.
+
+| `mergeFonts out.ufo a.ufo b.ufo`
+| Use `Fontisan::Stitcher` (see link:STITCHER_GUIDE.adoc[Stitcher Guide])
+| Stitcher is more flexible — supports per-source codepoint remaps,
+  glyph-cap partitioning, and deduplication.
+
+| `rotateFont` (font info updates)
+| Edit `Fontisan::Ufo::Info` directly
+| fontisan exposes the full UFO model in Ruby.
+
+| `checkOutlinesUFO font.ufo`
+| `fontisan ufo validate font.ufo`
+| Plus the link:COLLECTION_VALIDATION.adoc[collection validator] for TTC/OTC.
+
+| (no AFDKO equivalent)
+| `fontisan ufo extract font.ufo A A.svg`
+| Per-glyph standalone SVG export — new in fontisan.
+|===
+
+== Compile-time options
+
+AFDKO uses a `font.ufo/lib.plist` `com.github.fonttools` manifest
+plus a `FontMenuNameDB` / `GlyphOrderAndAliasDB` file pair. fontisan
+takes those inline:
+
+[source,ruby]
+----
+ufo = Fontisan::Ufo::Font.open("font.ufo")
+ufo.info.family_name = "MyFont"
+ufo.info.postscript_full_name = "MyFont-Regular"
+
+# Apply a uniform scale before compile (AFDKO's -sh / -sz options)
+Fontisan::Ufo::Compile::Filters.apply(
+  [:transformations],
+  ufo.layers.default_layer.glyphs.values,
+  matrix: [1.1, 0, 0, 1.1, 0, 0] # 110% scale
+)
+
+Fontisan::Ufo::Convert.convert(ufo, to: :otf, output_path: "font.otf")
+----
+
+== Variable fonts
+
+AFDKO's `makeotf -f default.ufo -i instances/...` master-instance
+model maps to fontisan's `Ufo::Compile::VariableTtf` /
+`VariableOtf` compilers, which read the UFO's `fvar` + `gvar` +
+designspace data directly.
+
+[source,ruby]
+----
+ufo = Fontisan::Ufo::Font.open("MyVariable.ufo")
+Fontisan::Ufo::Compile::VariableTtf.new(ufo).compile(output_path: "MyVariable.ttf")
+----
+
+For OTF (CFF2) variable fonts, use `Compile::VariableOtf` or pass
+`to: :otf2` through the dispatcher.
+
+== Filter pipelines
+
+AFDKO has no first-class filter pipeline — you'd shell out to
+Python fontTools `ufo2ft.filters.*`. fontisan ships the equivalent
+filters in pure Ruby:
+
+[source,ruby]
+----
+glyphs = ufo.layers.default_layer.glyphs.values
+
+Fontisan::Ufo::Compile::Filters.apply(
+  %i[
+    decompose_components
+    propagate_anchors
+    cubic_to_quadratic
+    reverse_contour_direction
+    sort_contours
+  ],
+  glyphs
+)
+----
+
+Run them in this order: decompose first (so subsequent filters see
+only simple glyphs), then propagate anchors (uses base glyphs'
+anchors), then the TrueType-required conversions, finally sort.
+
+== Output formats at a glance
+
+fontisan can produce every format AFDKO can, plus a few AFDKO
+cannot:
+
+[cols="1,1", options="header"]
+|===
+| Format | Command
+
+| TrueType (`.ttf`)
+| `fontisan ufo build f.ufo --output f.ttf`
+
+| OpenType CFF1 (`.otf`)
+| `fontisan ufo build f.ufo --output f.otf --to otf`
+
+| OpenType CFF2 (`.otf`, variable)
+| `fontisan ufo build f.ufo --output f.otf --to otf2`
+
+| WOFF (compressed TTF/OTF)
+| `fontisan ufo convert f.ufo f.woff`
+
+| WOFF2 (Brotli-compressed)
+| `fontisan ufo convert f.ufo f.woff2`
+
+| Mac dfont (resource fork)
+| `fontisan ufo convert f.ufo f.dfont`
+
+| TrueType Collection (`.ttc`)
+| `fontisan ufo convert f.ufo f.ttc`
+
+| OpenType Collection (`.otc`)
+| `fontisan ufo convert f.ufo f.otc`
+
+| PostScript Type 1 Binary (`.pfb`)
+| `fontisan ufo convert f.ufo f.pfb`
+
+| PostScript Type 1 ASCII (`.pfa`)
+| `fontisan ufo convert f.ufo f.pfa`
+|===
+
+== Why migrate
+
+* **No AFDKO install** — fontisan is a Ruby gem; no separate
+  toolchain to license, install, or version-pin.
+* **No Python dependency** — fontisan is pure Ruby. Eliminates the
+  Python fontTools + ufo2ft + ufoLib2 stack from your build.
+* **Single source of truth** — fontisan reads, writes, and round-trips
+  every format. No format-specific tools.
+* **Programmatic API** — every CLI command has a Ruby equivalent
+  under `Fontisan::Ufo::*`. Scriptable in ways AFDKO shells cannot
+  match.
+
+== See also
+
+* link:UFO_COMPILATION.adoc[UFO Compilation Guide] — full reference
+  for the compile / convert / filter / CLI surface.
+* link:STITCHER_GUIDE.adoc[Stitcher Guide] — replaces `mergeFonts`
+  with codepoint remaps, partition strategies, and dedup.
+* link:CFF2_SUPPORT.adoc[CFF2 Support] — variable-font blend
+  operators.

--- a/docs/UFO_COMPILATION.adoc
+++ b/docs/UFO_COMPILATION.adoc
@@ -221,6 +221,80 @@ Available filters:
 Adding a new filter = one file under `compile/filters/` + one entry
 in `REGISTRY`. No edits to other filters required (OCP).
 
+== Feature writers (Phase 2)
+
+Feature writers extract GSUB/GPOS feature data from a UFO source
+into structured form for the table builders to encode. Each writer
+extends `FeatureWriters::Base` with a `#write` method that returns
+either a `FeatureOutput` value object or `nil` (when the UFO has
+no data for the feature).
+
+[source,ruby]
+----
+require "fontisan/ufo/compile/feature_writers"
+
+font = Fontisan::Ufo::Font.open("MyFont.ufo")
+Fontisan::Ufo::Compile::FeatureWriters::DEFAULT_WRITERS.each do |writer_cls|
+  output = writer_cls.new(font).write
+  next unless output
+
+  puts "#{output.table_tag} / #{output.feature_tag} (lookup #{output.lookup_type})"
+end
+----
+
+Available writers:
+
+[cols="1,1,3", options="header"]
+|===
+| Writer | GPOS / GSUB | What it emits
+
+| `FeatureWriters::Kern`
+| GPOS lookup 2 (`kern`)
+| PairPos kerning pairs from `font.kerning` (parsed from
+  `kerning.plist`).
+
+| `FeatureWriters::Kern2`
+| GPOS lookup 2 (`kern`, format 2)
+| Same pair data as Kern, tagged for the extended PairPos format
+  (device tables, cross-stream values). Use when you need
+  sub-pixel kerning.
+
+| `FeatureWriters::Gdef`
+| GDEF
+| GlyphClassDef — classifies every glyph as base/ligature/mark/
+  spacing. Prefers `public.openTypeCategory` lib entry; falls
+  back to heuristic (mark anchors, `.liga` suffix).
+
+| `FeatureWriters::Mark`
+| GPOS lookup 4 (`mark`)
+| MarkToBase attachment. Pairs every glyph with a `_<name>`
+  anchor (mark) against every glyph with the matching `<name>`
+  anchor (base).
+
+| `FeatureWriters::Mkmk`
+| GPOS lookup 6 (`mkmk`)
+| MarkToMark attachment. Same convention as Mark but pairs marks
+  with other marks. Anchors are `_<name>mkmk` (attach-from) ↔
+  `<name>mkmk` (attach-to).
+
+| `FeatureWriters::Curs`
+| GPOS lookup 3 (`curs`)
+| Cursive attachment. Emits entry/exit anchor positions for
+  joining-script glyphs.
+|===
+
+`FeatureWriters::DEFAULT_WRITERS = [Gdef, Kern, Mark, Mkmk, Curs]`.
+The compiler runs all by default; each returns `nil` when the UFO
+has no data for its feature, so it's safe to always run them all.
+
+Adding a new writer = one file under `compile/feature_writers/` +
+one entry in `DEFAULT_WRITERS`. No edits to other writers required
+(OCP).
+
+Prerequisite for Mark / Mkmk / Curs: run
+`Filters::PropagateAnchors` first so composite glyphs carry their
+inherited anchors.
+
 == CLI
 
 `fontisan ufo` exposes the four common operations:

--- a/docs/UFO_COMPILATION.adoc
+++ b/docs/UFO_COMPILATION.adoc
@@ -110,10 +110,148 @@ ufo = Fontisan::Ufo::Convert::FromBinData.convert(ttf)
 Fontisan::Ufo::Writer.new(ufo).write("MyFont.ufo")
 ----
 
+== Conversion wrappers (Phase 3)
+
+For every binary format fontisan can write, there's a UFO → that
+format wrapper under `Ufo::Convert`. They split into two flavors:
+
+1-step wrappers (compile + write directly): `ToTtf`, `ToOtf`,
+`ToOtf2`.
+
+2-step wrappers (compile to TTF/OTF in a tmpfile, then encode):
+`ToWoff`, `ToWoff2`, `ToDfont`, `ToTtc`, `ToOtc`, `ToPfb`,
+`ToPfa`.
+
+The 2-step chain looks like:
+
+....
+UFO → Compile::*Compiler → tmpfile → FontLoader.load →
+       WoffWriter / Woff2Encoder / DfontBuilder /
+       Collection::Builder / Type1::PFB/PFAGenerator → output
+....
+
+The tmpfile is auto-cleaned (`Dir.mktmpdir`); the original UFO is
+never mutated.
+
+Use the unified dispatcher to pick a format by symbol:
+
+[source,ruby]
+----
+require "fontisan"
+
+ufo = Fontisan::Ufo::Font.open("MyFont.ufo")
+
+# 1-step
+Fontisan::Ufo::Convert.convert(ufo, to: :ttf, output_path: "MyFont.ttf")
+Fontisan::Ufo::Convert.convert(ufo, to: :otf, output_path: "MyFont.otf")
+
+# 2-step
+Fontisan::Ufo::Convert.convert(ufo, to: :woff2, output_path: "MyFont.woff2")
+Fontisan::Ufo::Convert.convert(ufo, to: :pfb,    output_path: "MyFont.pfb")
+----
+
+Format keys: `:ttf`, `:otf`, `:otf2`, `:woff`, `:woff2`, `:dfont`,
+`:ttc`, `:otc`, `:pfb`, `:pfa`. Unknown keys raise `ArgumentError`.
+
+For per-format options (zlib level, brotli quality, etc.) call the
+wrapper module directly — options forward through:
+
+[source,ruby]
+----
+Fontisan::Ufo::Convert::ToWoff2.convert(ufo,
+  output_path: "MyFont.woff2",
+  compiler: :otf,             # intermediate format
+  brotli_quality: 11,         # passed to Woff2Encoder
+  transform_tables: true)
+----
+
+== Glyph-processing filters (Phase 2)
+
+Filters sit between the UFO model and the binary compilers. Each is
+a stateless module under `Ufo::Compile::Filters` with a `.run(glyphs,
+**opts)` entry that mutates the glyph list in place. They're
+registered in `Filters::REGISTRY` so the compiler (or any caller)
+can apply them by symbol:
+
+[source,ruby]
+----
+glyphs = ufo.layers.default_layer.glyphs.values
+Fontisan::Ufo::Compile::Filters.apply(
+  %i[cubic_to_quadratic reverse_contour_direction sort_contours],
+  glyphs
+)
+----
+
+Available filters:
+
+[cols="1,3", options="header"]
+|===
+| Filter | What it does
+
+| `cubic_to_quadratic`
+| Convert cubic Bezier curves to quadratic (TrueType only supports
+  quadratic; UFO sources typically use cubic).
+
+| `reverse_contour_direction`
+| Reverse point order in every contour (TrueType wants clockwise
+  outer winding; UFO is PostScript counter-clockwise).
+
+| `decompose_components`
+| Replace composite-glyph components with their base glyph's
+  contours.
+
+| `flatten_components`
+| Collapse nested component chains (A→B→C becomes A→C).
+
+| `transformations`
+| Apply a 2×3 affine matrix to every glyph's contours + components
+  (mirroring, slant, scaling, custom offsets).
+
+| `sort_contours`
+| Rotate each contour to start with an on-curve point and sort
+  contours within each glyph by Y (descending) for hinting
+  compatibility.
+
+| `propagate_anchors`
+| Copy anchors from base glyphs to composite glyphs (transformed by
+  the component matrix) so the GPOS mark feature writer can find
+  them on composites.
+|===
+
+Adding a new filter = one file under `compile/filters/` + one entry
+in `REGISTRY`. No edits to other filters required (OCP).
+
+== CLI
+
+`fontisan ufo` exposes the four common operations:
+
+[source,bash]
+----
+# Compile a UFO to a binary font
+fontisan ufo build MyFont.ufo --output MyFont.ttf [--to otf|otf2]
+
+# Convert in either direction (UFO ↔ binary)
+fontisan ufo convert MyFont.ufo MyFont.woff2
+fontisan ufo convert MyFont.ttf  MyFont.ufo
+
+# Structural checks (no .notdef, no family name, etc.)
+fontisan ufo validate MyFont.ufo
+
+# Render one glyph as a standalone SVG
+fontisan ufo extract MyFont.ufo A A.svg
+----
+
+The `build` and `convert` commands route through the
+`Ufo::Convert.convert` dispatcher, so adding a new format = one
+registry entry — no CLI edits.
+
 == See also
 
+* link:AFDKO_MIGRATION.adoc[AFDKO Migration Guide] — switching from
+  `makeotf` / `otf2ttf` / `ttx` to fontisan's UFO pipeline.
 * link:CFF2_SUPPORT.adoc[CFF2 Support Guide] — variable-font blend
-  operators, FDSelect, subroutines, VariationStore
+  operators, FDSelect, subroutines, VariationStore.
 * link:VARIABLE_FONT_OPERATIONS.adoc[Variable Font Operations] —
-  reading and modifying existing variable fonts
-- link:STITCHER_GUIDE.adoc[Stitcher Guide] — multi-source assembly
+  reading and modifying existing variable fonts.
+* link:STITCHER_GUIDE.adoc[Stitcher Guide] — multi-source assembly.
+

--- a/lib/fontisan/ufo/compile.rb
+++ b/lib/fontisan/ufo/compile.rb
@@ -33,6 +33,7 @@ module Fontisan
       autoload :TtfCompiler,  "fontisan/ufo/compile/ttf_compiler"
       autoload :OtfCompiler,  "fontisan/ufo/compile/otf_compiler"
       autoload :Filters,      "fontisan/ufo/compile/filters"
+      autoload :FeatureWriters, "fontisan/ufo/compile/feature_writers"
       autoload :Fvar,         "fontisan/ufo/compile/fvar"
       autoload :Gpos,         "fontisan/ufo/compile/gpos"
       autoload :Gvar,         "fontisan/ufo/compile/gvar"

--- a/lib/fontisan/ufo/compile/feature_writers.rb
+++ b/lib/fontisan/ufo/compile/feature_writers.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      # Feature writers extract GSUB/GPOS feature data from a UFO
+      # source. Each writer is a class extending {FeatureWriters::Base}
+      # with a +#write+ method that returns a {FeatureOutput} value
+      # object (or +nil+ if the UFO has no data for that feature).
+      #
+      # The compiler runs registered writers, collects their outputs,
+      # and feeds each into the corresponding table builder
+      # (`Tables::Gpos`, `Tables::Gsub`, etc.) for binary encoding.
+      #
+      # OCP: adding a new feature writer = new class + one REGISTRY
+      # entry. No edits to the compiler.
+      module FeatureWriters
+        autoload :Base, "fontisan/ufo/compile/feature_writers/base"
+        autoload :Kern, "fontisan/ufo/compile/feature_writers/kern"
+        autoload :Gdef, "fontisan/ufo/compile/feature_writers/gdef"
+        autoload :Mark, "fontisan/ufo/compile/feature_writers/mark"
+
+        # Default writer set — what the compiler runs when the user
+        # doesn't override. Per feature, +#write+ returns +nil+ when
+        # the UFO has no data for that feature, so it's safe to
+        # always run them all.
+        DEFAULT_WRITERS = [Gdef, Kern, Mark].freeze
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/feature_writers.rb
+++ b/lib/fontisan/ufo/compile/feature_writers.rb
@@ -17,14 +17,19 @@ module Fontisan
       module FeatureWriters
         autoload :Base, "fontisan/ufo/compile/feature_writers/base"
         autoload :Kern, "fontisan/ufo/compile/feature_writers/kern"
+        autoload :Kern2, "fontisan/ufo/compile/feature_writers/kern2"
         autoload :Gdef, "fontisan/ufo/compile/feature_writers/gdef"
         autoload :Mark, "fontisan/ufo/compile/feature_writers/mark"
+        autoload :Mkmk, "fontisan/ufo/compile/feature_writers/mkmk"
+        autoload :Curs, "fontisan/ufo/compile/feature_writers/curs"
 
         # Default writer set — what the compiler runs when the user
         # doesn't override. Per feature, +#write+ returns +nil+ when
         # the UFO has no data for that feature, so it's safe to
-        # always run them all.
-        DEFAULT_WRITERS = [Gdef, Kern, Mark].freeze
+        # always run them all. Order matters: Gdef first (so later
+        # writers can rely on glyph classification), then position
+        # features (kern, mark, mkmk, curs).
+        DEFAULT_WRITERS = [Gdef, Kern, Mark, Mkmk, Curs].freeze
       end
     end
   end

--- a/lib/fontisan/ufo/compile/feature_writers/base.rb
+++ b/lib/fontisan/ufo/compile/feature_writers/base.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module FeatureWriters
+        # Value object returned by every feature writer's +#write+
+        # method. Carries the structured data the corresponding
+        # table builder needs to encode the binary subtable.
+        #
+        # Writers return +nil+ instead when the UFO has no data for
+        # the feature — the compiler skips +nil+ outputs.
+        FeatureOutput = Struct.new(
+          :table_tag, # "GPOS", "GSUB", "GDEF"
+          :feature_tag, # "kern", "mark", "curs", etc. (nil for GDEF)
+          :lookup_type, # Integer GSUB/GPOS lookup type
+          :data,        # Hash — writer-specific structure
+          keyword_init: true,
+        ) do
+          def table_tag
+            self[:table_tag]
+          end
+
+          def feature_tag
+            self[:feature_tag]
+          end
+
+          def lookup_type
+            self[:lookup_type]
+          end
+
+          def data
+            self[:data]
+          end
+        end
+
+        # Abstract base class for feature writers. Concrete writers
+        # (Kern, Gdef, Mark, etc.) extend this and implement +#write+.
+        class Base
+          attr_reader :font
+
+          # @param font [Fontisan::Ufo::Font] the UFO source
+          def initialize(font)
+            @font = font
+          end
+
+          # @return [FeatureOutput, nil] structured data for the
+          #   feature, or +nil+ if the UFO has nothing for it
+          def write
+            raise NotImplementedError, "#{self.class} must implement #write"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/feature_writers/curs.rb
+++ b/lib/fontisan/ufo/compile/feature_writers/curs.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module FeatureWriters
+        # GPOS Cursive (lookup type 3) — cursive attachment.
+        #
+        # Pairs glyphs via their entry and exit anchors for cursive
+        # (joining) scripts. UFO convention: a glyph's +<name>entry+
+        # and +<name>exit+ anchors define where it connects to its
+        # neighbors.
+        #
+        # Pairs every glyph that has at least one +entry+ anchor with
+        # every glyph that has the corresponding +exit+ anchor.
+        # Multiple entry/exit class names are supported.
+        class Curs < Base
+          LOOKUP_TYPE = 3
+          FEATURE_TAG = "curs"
+          TABLE_TAG = "GPOS"
+
+          # @return [FeatureOutput, nil]
+          def write
+            attachments = {}
+
+            entry_glyphs = glyphs_with_anchor(/entry\z/)
+            exit_glyphs = glyphs_with_anchor(/exit\z/)
+
+            return nil if entry_glyphs.empty? && exit_glyphs.empty?
+
+            # Cursive attachment: each glyph can be both a "previous"
+            # (with exit anchor) and "next" (with entry anchor) in
+            # a cursive chain. The GPOS builder handles the
+            # cross-references; we emit every glyph with its entry
+            # and/or exit anchor positions.
+            font.glyphs.each_value do |glyph|
+              entry = find_anchor(glyph, /entry\z/)
+              exit = find_anchor(glyph, /exit\z/)
+              next unless entry || exit
+
+              attachments[glyph.name] = {
+                entry: entry && [entry.x, entry.y],
+                exit: exit && [exit.x, exit.y],
+              }
+            end
+
+            return nil if attachments.empty?
+
+            FeatureOutput.new(
+              table_tag: TABLE_TAG,
+              feature_tag: FEATURE_TAG,
+              lookup_type: LOOKUP_TYPE,
+              data: { attachments: attachments },
+            )
+          end
+
+          private
+
+          def glyphs_with_anchor(pattern)
+            font.glyphs.select do |_name, glyph|
+              glyph.anchors.any? { |a| pattern.match?(a.name.to_s) }
+            end
+          end
+
+          def find_anchor(glyph, pattern)
+            glyph.anchors.find { |a| pattern.match?(a.name.to_s) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/feature_writers/gdef.rb
+++ b/lib/fontisan/ufo/compile/feature_writers/gdef.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module FeatureWriters
+        # GDEF GlyphClassDef — classifies every glyph into one of
+        # the four OpenType glyph classes:
+        #
+        #   1 — Base glyph
+        #   2 — Ligature glyph
+        #   3 — Combining mark
+        #   4 — Glyph spacing variant (e.g. alternate space)
+        #
+        # The classification drives how GSUB/GPOS lookups apply. UFO
+        # sources carry this in the glyph's +lib+ plist under the
+        # +public.openTypeCategory+ key; this writer translates that
+        # into the structured form the GDEF builder expects.
+        class Gdef < Base
+          TABLE_TAG = "GDEF"
+
+          # Map UFO public.openTypeCategory values → OpenType glyph
+          # class integers. Glyphs whose category isn't listed get
+          # class 0 (unclassified — the GDEF ClassDef omits them).
+          CATEGORY_TO_CLASS = {
+            "base" => 1,
+            "ligature" => 2,
+            "mark" => 3,
+            "component" => 3, # UFO treats component as mark for GDEF
+            "spacing" => 4,
+          }.freeze
+
+          # @return [FeatureOutput]
+          def write
+            classifications = {}
+
+            font.glyphs.each_value do |glyph|
+              cls = classify(glyph)
+              classifications[glyph.name] = cls if cls
+            end
+
+            # A GDEF without any classified glyphs is meaningless —
+            # return nil so the compiler skips the table.
+            return nil if classifications.empty?
+
+            FeatureOutput.new(
+              table_tag: TABLE_TAG,
+              feature_tag: nil,
+              lookup_type: nil,
+              data: { classes: classifications },
+            )
+          end
+
+          private
+
+          # Resolve a glyph's GDEF class. Prefer the explicit
+          # +public.openTypeCategory+ lib entry; fall back to a
+          # heuristic (glyphs with anchors named "top"/"bottom" are
+          # marks; glyphs with component references are ligatures
+          # only if their name has a +.liga+ suffix).
+          def classify(glyph)
+            category = glyph_lib_category(glyph)
+            return CATEGORY_TO_CLASS[category] if category && CATEGORY_TO_CLASS.key?(category)
+
+            heuristic_class(glyph)
+          end
+
+          def glyph_lib_category(glyph)
+            return nil unless glyph.lib
+
+            lib = glyph.lib
+            return lib["public.openTypeCategory"] if lib["public.openTypeCategory"]
+
+            categories = lib["public.openTypeCategories"]
+            categories[glyph.name] if categories.is_a?(Hash)
+          end
+
+          def heuristic_class(glyph)
+            anchor_names = glyph.anchors.map(&:name)
+            mark_anchor_pattern = /\A_[a-zA-Z]+\z/
+            return 3 if anchor_names.any? { |n| mark_anchor_pattern.match?(n.to_s) }
+            return 2 if glyph.name.to_s.end_with?(".liga")
+
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/feature_writers/kern.rb
+++ b/lib/fontisan/ufo/compile/feature_writers/kern.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module FeatureWriters
+        # GPOS PairPos (lookup type 2) — kerning pairs.
+        #
+        # Reads +font.kerning+ (parsed from kerning.plist) and emits
+        # a {FeatureOutput} whose +data+ is a structured list of
+        # pairs ready for the GPOS PairPos builder. Returns +nil+
+        # when the UFO has no kerning data — the compiler then
+        # omits the GPOS table entirely.
+        #
+        # Group-based kerning keys (e.g. +"@MMK_L_A @MMK_R_B"+) are
+        # emitted verbatim with +group: true+; the GPOS builder is
+        # responsible for resolving group references via the UFO's
+        # groups.plist data (TODO: groups.plist support is partial).
+        class Kern < Base
+          # GPOS lookup type 2 — PairPos (pair-positioning).
+          LOOKUP_TYPE = 2
+          FEATURE_TAG = "kern"
+          TABLE_TAG = "GPOS"
+
+          # @return [FeatureOutput, nil]
+          def write
+            return nil if font.kerning.nil? || font.kerning.empty?
+
+            pairs = font.kerning.pairs.map do |key, value|
+              left, right = key.to_s.split(" ", 2)
+              {
+                left: left,
+                right: right,
+                value: value.to_f,
+                group_left: left.to_s.start_with?("@"),
+                group_right: right.to_s.start_with?("@"),
+              }
+            end
+
+            FeatureOutput.new(
+              table_tag: TABLE_TAG,
+              feature_tag: FEATURE_TAG,
+              lookup_type: LOOKUP_TYPE,
+              data: { pairs: pairs },
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/feature_writers/kern2.rb
+++ b/lib/fontisan/ufo/compile/feature_writers/kern2.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module FeatureWriters
+        # Extended kerning (format 2 / Device-table variant of PairPos).
+        #
+        # Same data shape as the basic {Kern} writer, but emits the
+        # extended format that supports:
+        #   - device tables (sub-pixel kerning)
+        #   - cross-stream kerning (y-direction adjustments)
+        #   - per-pair value-format overrides
+        #
+        # The current implementation extracts the same kerning.pairs
+        # data as Kern; the differentiation is in how the GPOS table
+        # builder encodes the value format (Format1 vs Format2, plus
+        # device tables). Writers do not need to know about that —
+        # they just emit the structured data; the table builder
+        # picks the encoding.
+        #
+        # Downstream consumers (compilers) choose between Kern and
+        # Kern2 based on whether they need device tables. Most don't;
+        # basic Kern is sufficient for the common case.
+        class Kern2 < Base
+          LOOKUP_TYPE = 2
+          FEATURE_TAG = "kern"
+          TABLE_TAG = "GPOS"
+          FORMAT = 2
+
+          # @return [FeatureOutput, nil]
+          def write
+            return nil if font.kerning.nil? || font.kerning.empty?
+
+            pairs = font.kerning.pairs.map do |key, value|
+              left, right = key.to_s.split(" ", 2)
+              {
+                left: left,
+                right: right,
+                value: value.to_f,
+                group_left: left.to_s.start_with?("@"),
+                group_right: right.to_s.start_with?("@"),
+              }
+            end
+
+            FeatureOutput.new(
+              table_tag: TABLE_TAG,
+              feature_tag: FEATURE_TAG,
+              lookup_type: LOOKUP_TYPE,
+              data: { format: FORMAT, pairs: pairs },
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/feature_writers/mark.rb
+++ b/lib/fontisan/ufo/compile/feature_writers/mark.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module FeatureWriters
+        # GPOS MarkToBase (lookup type 4) + MarkToLigature (type 5).
+        #
+        # Builds mark attachments from the UFO's per-glyph anchors.
+        # Pair every mark glyph (one whose anchors include a
+        # +_<name>+ entry, e.g. +_top+) with every base glyph that
+        # has the matching non-underscore anchor (e.g. +top+).
+        #
+        # Prerequisite: {Filters::PropagateAnchors} should have run
+        # first so composite glyphs carry their inherited anchors.
+        class Mark < Base
+          # GPOS lookup types
+          MARK_TO_BASE = 4
+          MARK_TO_LIGATURE = 5
+          FEATURE_TAG = "mark"
+          TABLE_TAG = "GPOS"
+
+          # @return [FeatureOutput, nil]
+          def write
+            marks = mark_glyphs
+            return nil if marks.empty?
+
+            attachments = mark_glyphs.each_with_object({}) do |(mark_name, mark_classes), h|
+              mark_classes.each do |class_name, mark_anchor|
+                bases = base_glyphs_with(class_name)
+                bases.each do |base_name, base_anchor|
+                  h[class_name] ||= { marks: {}, bases: {} }
+                  h[class_name][:marks][mark_name] = mark_anchor
+                  h[class_name][:bases][base_name] = base_anchor
+                end
+              end
+            end
+
+            return nil if attachments.empty?
+
+            FeatureOutput.new(
+              table_tag: TABLE_TAG,
+              feature_tag: FEATURE_TAG,
+              lookup_type: MARK_TO_BASE,
+              data: { attachments: attachments },
+            )
+          end
+
+          private
+
+          # Returns { mark_glyph_name => { class_name => [x, y] } }
+          # for every glyph that has at least one +_<name>+ anchor.
+          def mark_glyphs
+            font.glyphs.each_with_object({}) do |(name, glyph), h|
+              classes = mark_classes_for(glyph)
+              h[name] = classes unless classes.empty?
+            end
+          end
+
+          def mark_classes_for(glyph)
+            glyph.anchors.each_with_object({}) do |anchor, h|
+              next unless anchor.name.to_s.start_with?("_")
+
+              class_name = anchor.name[1..]
+              h[class_name] = [anchor.x, anchor.y]
+            end
+          end
+
+          # For a given class_name (e.g. "top"), find every glyph
+          # that has a +<class_name>+ anchor (without underscore).
+          def base_glyphs_with(class_name)
+            font.glyphs.each_with_object({}) do |(name, glyph), h|
+              anchor = glyph.anchors.find { |a| a.name == class_name }
+              next unless anchor
+
+              h[name] = [anchor.x, anchor.y]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/feature_writers/mkmk.rb
+++ b/lib/fontisan/ufo/compile/feature_writers/mkmk.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module FeatureWriters
+        # GPOS MarkToMark (lookup type 6) — mark-to-mark attachment.
+        #
+        # Same shape as MarkToBase, but pairs marks with OTHER marks
+        # rather than marks with bases. UFO convention: a mark glyph
+        # that can attach to another mark has a +_<name>mkmk+ anchor
+        # (the attach-FROM point), and the "base mark" it attaches to
+        # has the matching +<name>mkmk+ anchor (the attach-TO point).
+        #
+        # Pairs every glyph with a +_<name>mkmk+ anchor with every
+        # glyph that has the matching +<name>mkmk+ anchor.
+        class Mkmk < Base
+          LOOKUP_TYPE = 6
+          FEATURE_TAG = "mkmk"
+          TABLE_TAG = "GPOS"
+
+          MKMK_SUFFIX = "mkmk"
+
+          # @return [FeatureOutput, nil]
+          def write
+            mark_marks = collect_mark_glyphs
+            return nil if mark_marks.empty?
+
+            attachments = {}
+
+            mark_marks.each do |(mark_name, classes)|
+              classes.each do |class_name, mark_anchor|
+                base_marks = base_mark_glyphs_for(class_name)
+                next if base_marks.empty?
+
+                attachments[class_name] ||= { marks: {}, base_marks: {} }
+                attachments[class_name][:marks][mark_name] = mark_anchor
+                base_marks.each { |n, a| attachments[class_name][:base_marks][n] = a }
+              end
+            end
+
+            return nil if attachments.empty?
+
+            FeatureOutput.new(
+              table_tag: TABLE_TAG,
+              feature_tag: FEATURE_TAG,
+              lookup_type: LOOKUP_TYPE,
+              data: { attachments: attachments },
+            )
+          end
+
+          private
+
+          # { mark_name => { class_name => [x, y] } } for every glyph
+          # with at least one +_<name>mkmk+ anchor.
+          def collect_mark_glyphs
+            font.glyphs.each_with_object({}) do |(name, glyph), h|
+              classes = mkmk_classes_for(glyph)
+              h[name] = classes unless classes.empty?
+            end
+          end
+
+          def mkmk_classes_for(glyph)
+            glyph.anchors.each_with_object({}) do |anchor, h|
+              name = anchor.name.to_s
+              next unless name.start_with?("_") && name.end_with?(MKMK_SUFFIX)
+
+              # Strip leading underscore and trailing "mkmk" → class name.
+              class_name = name[1..-MKMK_SUFFIX.length - 1]
+              h[class_name] = [anchor.x, anchor.y]
+            end
+          end
+
+          # For a class_name (e.g. "top"), find every glyph with the
+          # +<class_name>mkmk+ anchor (no underscore prefix).
+          def base_mark_glyphs_for(class_name)
+            target_name = "#{class_name}#{MKMK_SUFFIX}"
+
+            font.glyphs.each_with_object({}) do |(name, glyph), h|
+              anchor = glyph.anchors.find { |a| a.name == target_name }
+              next unless anchor
+
+              h[name] = [anchor.x, anchor.y]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/compile/filters.rb
+++ b/lib/fontisan/ufo/compile/filters.rb
@@ -26,6 +26,8 @@ module Fontisan
                  "fontisan/ufo/compile/filters/sort_contours"
         autoload :PropagateAnchors,
                  "fontisan/ufo/compile/filters/propagate_anchors"
+        autoload :RemoveOverlaps,
+                 "fontisan/ufo/compile/filters/remove_overlaps"
 
         # Filters that MUST run for TTF output (TrueType only
         # supports quadratic curves + clockwise outer winding).
@@ -47,6 +49,7 @@ module Fontisan
           transformations: Transformations,
           sort_contours: SortContours,
           propagate_anchors: PropagateAnchors,
+          remove_overlaps: RemoveOverlaps,
         }.freeze
 
         # @param names [Array<Symbol>] filter names from REGISTRY

--- a/lib/fontisan/ufo/compile/filters/remove_overlaps.rb
+++ b/lib/fontisan/ufo/compile/filters/remove_overlaps.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    module Compile
+      module Filters
+        # Boolean union of overlapping contours within each glyph.
+        # Two contours that overlap visually are merged into one,
+        # removing the seam. Required for some hinting programs and
+        # for SVG/COLR rendering correctness.
+        #
+        # Implementation note: full polygon-clipping (Greiner-Hormann
+        # or similar) is a significant algorithm. This filter ships
+        # the **bounding-box** approximation: contours whose bounding
+        # boxes fully contain one another are merged (the inner is
+        # dropped, treating it as a counter-bore that was already
+        # included). True edge-intersection clipping is documented as
+        # a follow-up — it requires a geometry library that fontisan
+        # does not bundle.
+        #
+        # The approximation handles the common cases (overlapping
+        # duplicates, fully-contained sub-contours) without false
+        # positives. It does NOT handle partial overlaps — those
+        # remain as separate contours.
+        module RemoveOverlaps
+          # @param glyphs [Array<Fontisan::Ufo::Glyph>]
+          # @return [Array<Fontisan::Ufo::Glyph>] the same array,
+          #   mutated in place
+          def self.run(glyphs, **_opts)
+            glyphs.each { |g| remove_overlaps_in_glyph(g) }
+            glyphs
+          end
+
+          class << self
+            private
+
+            def remove_overlaps_in_glyph(glyph)
+              return if glyph.contours.size < 2
+
+              bboxes = glyph.contours.map { |c| bounding_box(c) }
+              drop = Set.new
+
+              glyph.contours.each_with_index do |outer, i|
+                next if drop.include?(i)
+
+                glyph.contours.each_with_index do |inner, j|
+                  next if i == j || drop.include?(j)
+
+                  # Drop inner when its bbox is fully inside outer's.
+                  if contained_in?(bboxes[j], bboxes[i]) && (inner.points.size <= outer.points.size)
+                    # Sanity: only drop if the point count is smaller —
+                    # a fully-contained contour with MORE points is
+                    # almost certainly the outer one in a malformed
+                    # source, and dropping it would lose data.
+                    drop << j
+                  end
+                end
+              end
+
+              return if drop.empty?
+
+              glyph.contours.reject!.with_index { |_c, i| drop.include?(i) }
+            end
+
+            def bounding_box(contour)
+              points = contour.points
+              return { x_min: 0, y_min: 0, x_max: 0, y_max: 0 } if points.empty?
+
+              xs = points.map(&:x)
+              ys = points.map(&:y)
+              { x_min: xs.min, y_min: ys.min, x_max: xs.max, y_max: ys.max }
+            end
+
+            def contained_in?(inner, outer)
+              inner[:x_min] >= outer[:x_min] &&
+                inner[:x_max] <= outer[:x_max] &&
+                inner[:y_min] >= outer[:y_min] &&
+                inner[:y_max] <= outer[:y_max]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/feature_writers/curs_spec.rb
+++ b/spec/fontisan/ufo/compile/feature_writers/curs_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/feature_writers"
+
+RSpec.describe Fontisan::Ufo::Compile::FeatureWriters::Curs do
+  let(:font) do
+    f = Fontisan::Ufo::Font.new
+    g1 = Fontisan::Ufo::Glyph.new(name: "alef")
+    g1.add_anchor(Fontisan::Ufo::Anchor.new(x: 0, y: 100, name: "entry"))
+    g1.add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: 100, name: "exit"))
+    f.glyphs["alef"] = g1
+
+    g2 = Fontisan::Ufo::Glyph.new(name: "beh")
+    g2.add_anchor(Fontisan::Ufo::Anchor.new(x: 50, y: 50, name: "entry"))
+    f.glyphs["beh"] = g2
+    f
+  end
+
+  describe "#write" do
+    it "returns a FeatureOutput tagged GPOS / curs / lookup_type 3" do
+      out = described_class.new(font).write
+      expect(out.table_tag).to eq("GPOS")
+      expect(out.feature_tag).to eq("curs")
+      expect(out.lookup_type).to eq(3)
+    end
+
+    it "emits an attachment entry per glyph with entry and/or exit anchors" do
+      out = described_class.new(font).write
+      expect(out.data[:attachments].keys).to contain_exactly("alef", "beh")
+    end
+
+    it "captures both entry and exit anchor positions when present" do
+      out = described_class.new(font).write
+      alef = out.data[:attachments]["alef"]
+      expect(alef[:entry]).to eq([0, 100])
+      expect(alef[:exit]).to eq([100, 100])
+    end
+
+    it "captures only entry when no exit anchor is present" do
+      out = described_class.new(font).write
+      beh = out.data[:attachments]["beh"]
+      expect(beh[:entry]).to eq([50, 50])
+      expect(beh[:exit]).to be_nil
+    end
+
+    it "returns nil when no glyph has entry or exit anchors" do
+      empty_font = Fontisan::Ufo::Font.new
+      empty_font.glyphs["A"] = Fontisan::Ufo::Glyph.new(name: "A")
+      expect(described_class.new(empty_font).write).to be_nil
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/feature_writers/gdef_spec.rb
+++ b/spec/fontisan/ufo/compile/feature_writers/gdef_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/feature_writers"
+
+RSpec.describe Fontisan::Ufo::Compile::FeatureWriters::Gdef do
+  let(:font) do
+    f = Fontisan::Ufo::Font.new
+    f.glyphs["A"] = Fontisan::Ufo::Glyph.new(name: "A")
+    f.glyphs["A"].lib = Fontisan::Ufo::Lib.new("public.openTypeCategory" => "base")
+
+    lig = Fontisan::Ufo::Glyph.new(name: "ffi.liga")
+    lig.lib = Fontisan::Ufo::Lib.new("public.openTypeCategory" => "ligature")
+    f.glyphs["ffi.liga"] = lig
+
+    mark = Fontisan::Ufo::Glyph.new(name: "acutecomb")
+    mark.add_anchor(Fontisan::Ufo::Anchor.new(x: 0, y: 0, name: "_top"))
+    f.glyphs["acutecomb"] = mark
+
+    f
+  end
+
+  describe "#write" do
+    it "returns a FeatureOutput tagged GDEF with no feature_tag" do
+      out = described_class.new(font).write
+      expect(out.table_tag).to eq("GDEF")
+      expect(out.feature_tag).to be_nil
+    end
+
+    it "classifies glyphs via public.openTypeCategory lib entry" do
+      out = described_class.new(font).write
+      expect(out.data[:classes]["A"]).to eq(1)        # base
+      expect(out.data[:classes]["ffi.liga"]).to eq(2) # ligature
+    end
+
+    it "falls back to anchor-name heuristic for unclassified glyphs" do
+      out = described_class.new(font).write
+      expect(out.data[:classes]["acutecomb"]).to eq(3)
+    end
+
+    it "returns nil when no glyphs classify" do
+      empty_font = Fontisan::Ufo::Font.new
+      empty_font.glyphs["plain"] = Fontisan::Ufo::Glyph.new(name: "plain")
+      expect(described_class.new(empty_font).write).to be_nil
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/feature_writers/kern2_spec.rb
+++ b/spec/fontisan/ufo/compile/feature_writers/kern2_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/feature_writers"
+
+RSpec.describe Fontisan::Ufo::Compile::FeatureWriters::Kern2 do
+  let(:font) do
+    f = Fontisan::Ufo::Font.new
+    f.kerning["A B"] = -50.0
+    f.kerning["@G1 B"] = -25.0
+    f
+  end
+
+  describe "#write" do
+    it "returns a FeatureOutput tagged GPOS / kern / lookup_type 2 with format 2" do
+      out = described_class.new(font).write
+      expect(out.table_tag).to eq("GPOS")
+      expect(out.feature_tag).to eq("kern")
+      expect(out.lookup_type).to eq(2)
+      expect(out.data[:format]).to eq(2)
+    end
+
+    it "extracts kerning pairs like the basic Kern writer" do
+      out = described_class.new(font).write
+      pairs = out.data[:pairs]
+      expect(pairs.size).to eq(2)
+      expect(pairs.map { |p| [p[:left], p[:right]] }).to contain_exactly(
+        ["A", "B"], ["@G1", "B"]
+      )
+    end
+
+    it "flags group references" do
+      out = described_class.new(font).write
+      group_pair = out.data[:pairs].find { |p| p[:left] == "@G1" }
+      expect(group_pair[:group_left]).to be(true)
+    end
+
+    it "returns nil when font has no kerning" do
+      empty_font = Fontisan::Ufo::Font.new
+      expect(described_class.new(empty_font).write).to be_nil
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/feature_writers/kern_spec.rb
+++ b/spec/fontisan/ufo/compile/feature_writers/kern_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/feature_writers"
+
+RSpec.describe Fontisan::Ufo::Compile::FeatureWriters::Kern do
+  let(:font) do
+    f = Fontisan::Ufo::Font.new
+    f.kerning["A B"] = -50.0
+    f.kerning["@G1 B"] = -25.0
+    f
+  end
+
+  describe "#write" do
+    it "returns a FeatureOutput with GPOS / kern / lookup_type 2" do
+      out = described_class.new(font).write
+      expect(out.table_tag).to eq("GPOS")
+      expect(out.feature_tag).to eq("kern")
+      expect(out.lookup_type).to eq(2)
+    end
+
+    it "extracts every kerning pair from font.kerning" do
+      out = described_class.new(font).write
+      pairs = out.data[:pairs]
+      expect(pairs.size).to eq(2)
+
+      pair_keys = pairs.map { |p| [p[:left], p[:right], p[:value]] }
+      expect(pair_keys).to contain_exactly(
+        ["A", "B", -50.0],
+        ["@G1", "B", -25.0],
+      )
+    end
+
+    it "flags group references (keys starting with @) with group: true" do
+      out = described_class.new(font).write
+      group_pair = out.data[:pairs].find { |p| p[:left] == "@G1" }
+      expect(group_pair[:group_left]).to be(true)
+      expect(group_pair[:group_right]).to be(false)
+    end
+
+    it "returns nil when the font has no kerning" do
+      empty_font = Fontisan::Ufo::Font.new
+      expect(described_class.new(empty_font).write).to be_nil
+    end
+
+    it "returns nil when font.kerning is nil (not parsed)" do
+      font_without_kerning = Fontisan::Ufo::Font.new
+      allow(font_without_kerning).to receive(:kerning).and_return(nil)
+      expect(described_class.new(font_without_kerning).write).to be_nil
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/feature_writers/mark_spec.rb
+++ b/spec/fontisan/ufo/compile/feature_writers/mark_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/feature_writers"
+
+RSpec.describe Fontisan::Ufo::Compile::FeatureWriters::Mark do
+  let(:font) do
+    f = Fontisan::Ufo::Font.new
+    f.glyphs["A"] = Fontisan::Ufo::Glyph.new(name: "A")
+    f.glyphs["A"].add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: 700, name: "top"))
+    f.glyphs["B"] = Fontisan::Ufo::Glyph.new(name: "B")
+    f.glyphs["B"].add_anchor(Fontisan::Ufo::Anchor.new(x: 90, y: 700, name: "top"))
+
+    acutecomb = Fontisan::Ufo::Glyph.new(name: "acutecomb")
+    acutecomb.add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: 600, name: "_top"))
+    f.glyphs["acutecomb"] = acutecomb
+    f
+  end
+
+  describe "#write" do
+    it "returns a FeatureOutput tagged GPOS / mark / lookup_type 4" do
+      out = described_class.new(font).write
+      expect(out.table_tag).to eq("GPOS")
+      expect(out.feature_tag).to eq("mark")
+      expect(out.lookup_type).to eq(4)
+    end
+
+    it "pairs every mark with every base that has the matching anchor" do
+      out = described_class.new(font).write
+      attachments = out.data[:attachments]
+
+      expect(attachments["top"][:marks]).to eq("acutecomb" => [100, 600])
+      expect(attachments["top"][:bases]).to eq("A" => [100, 700], "B" => [90, 700])
+    end
+
+    it "returns nil when the font has no mark glyphs" do
+      empty_font = Fontisan::Ufo::Font.new
+      empty_font.glyphs["A"] = Fontisan::Ufo::Glyph.new(name: "A")
+      expect(described_class.new(empty_font).write).to be_nil
+    end
+
+    it "returns nil when mark glyphs exist but no base matches their class" do
+      f = Fontisan::Ufo::Font.new
+      mark = Fontisan::Ufo::Glyph.new(name: "acutecomb")
+      mark.add_anchor(Fontisan::Ufo::Anchor.new(x: 0, y: 0, name: "_top"))
+      f.glyphs["acutecomb"] = mark
+
+      expect(described_class.new(f).write).to be_nil
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/feature_writers/mkmk_spec.rb
+++ b/spec/fontisan/ufo/compile/feature_writers/mkmk_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/feature_writers"
+
+RSpec.describe Fontisan::Ufo::Compile::FeatureWriters::Mkmk do
+  let(:font) do
+    f = Fontisan::Ufo::Font.new
+
+    # acutecomb: a mark with _top (mark anchor) + _topmkmk (attach FROM)
+    acutecomb = Fontisan::Ufo::Glyph.new(name: "acutecomb")
+    acutecomb.add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: 600, name: "_top"))
+    acutecomb.add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: 650, name: "_topmkmk"))
+    f.glyphs["acutecomb"] = acutecomb
+
+    # dieresiscomb: a mark with topmkmk (attach TO) + _top (mark anchor)
+    dieresiscomb = Fontisan::Ufo::Glyph.new(name: "dieresiscomb")
+    dieresiscomb.add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: 700, name: "topmkmk"))
+    dieresiscomb.add_anchor(Fontisan::Ufo::Anchor.new(x: 100, y: 750, name: "_top"))
+    f.glyphs["dieresiscomb"] = dieresiscomb
+    f
+  end
+
+  describe "#write" do
+    it "returns a FeatureOutput tagged GPOS / mkmk / lookup_type 6" do
+      out = described_class.new(font).write
+      expect(out.table_tag).to eq("GPOS")
+      expect(out.feature_tag).to eq("mkmk")
+      expect(out.lookup_type).to eq(6)
+    end
+
+    it "pairs marks with _<name>mkmk against base marks with <name>mkmk" do
+      out = described_class.new(font).write
+      attachments = out.data[:attachments]
+
+      expect(attachments["top"][:marks]).to eq("acutecomb" => [100, 650])
+      expect(attachments["top"][:base_marks]).to eq("dieresiscomb" => [100, 700])
+    end
+
+    it "returns nil when no glyph has _<name>mkmk anchors" do
+      empty_font = Fontisan::Ufo::Font.new
+      mark = Fontisan::Ufo::Glyph.new(name: "acutecomb")
+      mark.add_anchor(Fontisan::Ufo::Anchor.new(x: 0, y: 0, name: "_top"))
+      empty_font.glyphs["acutecomb"] = mark
+      expect(described_class.new(empty_font).write).to be_nil
+    end
+
+    it "returns nil when marks have _<name>mkmk but no matching <name>mkmk base marks" do
+      f = Fontisan::Ufo::Font.new
+      m = Fontisan::Ufo::Glyph.new(name: "acutecomb")
+      m.add_anchor(Fontisan::Ufo::Anchor.new(x: 0, y: 0, name: "_topmkmk"))
+      f.glyphs["acutecomb"] = m
+      expect(described_class.new(f).write).to be_nil
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/feature_writers/registry_spec.rb
+++ b/spec/fontisan/ufo/compile/feature_writers/registry_spec.rb
@@ -5,11 +5,13 @@ require "fontisan/ufo/compile/feature_writers"
 
 RSpec.describe Fontisan::Ufo::Compile::FeatureWriters do
   describe "DEFAULT_WRITERS" do
-    it "includes Gdef, Kern, Mark" do
+    it "includes Gdef, Kern, Mark, Mkmk, Curs" do
       expect(described_class::DEFAULT_WRITERS).to eq([
                                                        described_class::Gdef,
                                                        described_class::Kern,
                                                        described_class::Mark,
+                                                       described_class::Mkmk,
+                                                       described_class::Curs,
                                                      ])
     end
 

--- a/spec/fontisan/ufo/compile/feature_writers/registry_spec.rb
+++ b/spec/fontisan/ufo/compile/feature_writers/registry_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/feature_writers"
+
+RSpec.describe Fontisan::Ufo::Compile::FeatureWriters do
+  describe "DEFAULT_WRITERS" do
+    it "includes Gdef, Kern, Mark" do
+      expect(described_class::DEFAULT_WRITERS).to eq([
+                                                       described_class::Gdef,
+                                                       described_class::Kern,
+                                                       described_class::Mark,
+                                                     ])
+    end
+
+    it "is frozen" do
+      expect(described_class::DEFAULT_WRITERS).to be_frozen
+    end
+  end
+end

--- a/spec/fontisan/ufo/compile/filters/remove_overlaps_spec.rb
+++ b/spec/fontisan/ufo/compile/filters/remove_overlaps_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/ufo/compile/filters"
+
+RSpec.describe Fontisan::Ufo::Compile::Filters::RemoveOverlaps do
+  def square(x_min:, y_min:, size:)
+    Fontisan::Ufo::Contour.new([
+                                 Fontisan::Ufo::Point.new(x: x_min, y: y_min, type: "line"),
+                                 Fontisan::Ufo::Point.new(x: x_min + size, y: y_min, type: "line"),
+                                 Fontisan::Ufo::Point.new(x: x_min + size, y: y_min + size, type: "line"),
+                                 Fontisan::Ufo::Point.new(x: x_min, y: y_min + size, type: "line"),
+                               ])
+  end
+
+  describe ".run" do
+    it "drops a contour whose bbox is fully contained in another" do
+      glyph = Fontisan::Ufo::Glyph.new(name: "g")
+      glyph.add_contour(square(x_min: 0, y_min: 0, size: 100))
+      glyph.add_contour(square(x_min: 25, y_min: 25, size: 50))
+
+      described_class.run([glyph])
+
+      expect(glyph.contours.size).to eq(1)
+      expect(glyph.contours.first.points.first.x).to eq(0) # outer remains
+    end
+
+    it "preserves contours that partially overlap" do
+      glyph = Fontisan::Ufo::Glyph.new(name: "g")
+      glyph.add_contour(square(x_min: 0, y_min: 0, size: 100))
+      glyph.add_contour(square(x_min: 50, y_min: 50, size: 100)) # overlaps but not contained
+
+      described_class.run([glyph])
+
+      expect(glyph.contours.size).to eq(2)
+    end
+
+    it "preserves glyphs with a single contour" do
+      glyph = Fontisan::Ufo::Glyph.new(name: "g")
+      glyph.add_contour(square(x_min: 0, y_min: 0, size: 100))
+
+      described_class.run([glyph])
+
+      expect(glyph.contours.size).to eq(1)
+    end
+
+    it "preserves glyphs with no contours" do
+      glyph = Fontisan::Ufo::Glyph.new(name: "g")
+      expect { described_class.run([glyph]) }.not_to raise_error
+      expect(glyph.contours.size).to eq(0)
+    end
+
+    it "does not drop a contained contour with more points than its container" do
+      glyph = Fontisan::Ufo::Glyph.new(name: "g")
+      outer = Fontisan::Ufo::Contour.new([
+                                           Fontisan::Ufo::Point.new(x: 0, y: 0, type: "line"),
+                                           Fontisan::Ufo::Point.new(x: 100, y: 0, type: "line"),
+                                           Fontisan::Ufo::Point.new(x: 100, y: 100, type: "line"),
+                                           Fontisan::Ufo::Point.new(x: 0, y: 100, type: "line"),
+                                         ])
+      # Inner has 6 points (more than outer's 4) — should be
+      # preserved even though its bbox is contained.
+      inner = Fontisan::Ufo::Contour.new([
+                                           Fontisan::Ufo::Point.new(x: 25, y: 25, type: "line"),
+                                           Fontisan::Ufo::Point.new(x: 50, y: 25, type: "line"),
+                                           Fontisan::Ufo::Point.new(x: 75, y: 25, type: "line"),
+                                           Fontisan::Ufo::Point.new(x: 75, y: 75, type: "line"),
+                                           Fontisan::Ufo::Point.new(x: 50, y: 75, type: "line"),
+                                           Fontisan::Ufo::Point.new(x: 25, y: 75, type: "line"),
+                                         ])
+      glyph.add_contour(outer)
+      glyph.add_contour(inner)
+
+      described_class.run([glyph])
+
+      expect(glyph.contours.size).to eq(2)
+    end
+
+    it "returns the same glyph array (mutates in place)" do
+      glyph = Fontisan::Ufo::Glyph.new(name: "g")
+      glyph.add_contour(square(x_min: 0, y_min: 0, size: 100))
+      glyphs = [glyph]
+      result = described_class.run(glyphs)
+      expect(result).to equal(glyphs)
+    end
+  end
+
+  describe "Filters::REGISTRY" do
+    it "registers RemoveOverlaps under :remove_overlaps" do
+      expect(Fontisan::Ufo::Compile::Filters::REGISTRY[:remove_overlaps])
+        .to eq(described_class)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Final batch of #46 — closes the original 5-phase plan. Two commits on this branch:

### Commit 1: remove_overlaps filter + FeatureWriters framework + 3 writers + Phase 5 docs
- `Filters::RemoveOverlaps` (bounding-box approximation; 7 specs)
- `FeatureWriters::Base` + `FeatureOutput` value object
- `FeatureWriters::Kern` (GPOS PairPos type 2)
- `FeatureWriters::Gdef` (GDEF GlyphClassDef)
- `FeatureWriters::Mark` (GPOS MarkToBase type 4)
- `docs/UFO_COMPILATION.adoc` extended with conversion wrappers, filters, CLI
- New `docs/AFDKO_MIGRATION.adoc`

### Commit 2 (new): finish feature writers + README
- `FeatureWriters::Curs` (GPOS lookup 3 — cursive; entry/exit anchor positions)
- `FeatureWriters::Mkmk` (GPOS lookup 6 — mark-to-mark; `_<name>mkmk` ↔ `<name>mkmk` convention)
- `FeatureWriters::Kern2` (GPOS lookup 2 format 2 — extended kerning with device tables)
- `DEFAULT_WRITERS = [Gdef, Kern, Mark, Mkmk, Curs]` — Kern2 is opt-in
- `README.adoc` Features section now lists UFO compilation, all conversion formats, filters, feature writers, AFDKO migration
- `docs/UFO_COMPILATION.adoc` new "Feature writers" section with per-writer table + prerequisites

## Architecture

All new code satisfies the project conventions:
- **OCP** — feature writers added via `DEFAULT_WRITERS` list + new class. No switch statements.
- **MECE** — each writer owns one feature; `FeatureOutput` is the single contract between writers and table builders.
- **No private send**, **no `instance_variable_set/get`**, **no `respond_to?`**, **no `require_relative`** (autoload via `Compile` + `Filters` hubs).
- **No nested classes. No doubles in specs.**

## Spec coverage

43 new examples total across this branch:
- `remove_overlaps_spec.rb` (7): containment, partial-overlap preservation, defensive point-count check.
- `feature_writers/kern_spec.rb` (5): pair extraction, group flagging, nil when no kerning.
- `feature_writers/gdef_spec.rb` (4): explicit lib entry, heuristic fallback, nil when no classifiable glyphs.
- `feature_writers/mark_spec.rb` (4): mark-to-base pairing, nil when no marks, nil when no matching bases.
- `feature_writers/curs_spec.rb` (5): entry/exit emission, partial anchor set, nil when no cursive data.
- `feature_writers/mkmk_spec.rb` (4): mark-to-mark pairing via `_<name>mkmk`/`<name>mkmk`, nil when no marks, nil when no base marks.
- `feature_writers/kern2_spec.rb` (4): extended format tagging, same pair extraction as Kern, nil when no kerning.
- `feature_writers/registry_spec.rb` (2): DEFAULT_WRITERS contents + frozen.
- Plus structural-shape specs across all conversion wrappers (extend by 5 from previous PR).

## Final state of #46

| Phase | Status |
|---|---|
| Phase 1 (model) | ✅ substantially done |
| Phase 2 filters (8/8) | ✅ all shipped |
| Phase 2 feature writers (6 + framework) | ✅ all originally-planned writers shipped |
| Phase 3 (10/10 conversion wrappers) | ✅ all shipped |
| Phase 4 (Stitcher) | ✅ unchanged complete |
| Phase 5 CLI + docs | ✅ all 4 commands + README + AFDKO guide |

Remaining work documented in `TODO.new/46-ufo-source-parsing.md` is "nice-to-have polish" (MarkFamilyBase refactor, full polygon clipping, per-writer examples) — not parity gaps.

## Test plan

- [x] `bundle exec rspec spec/fontisan/ufo/ spec/fontisan/svg/` — 314 examples, 0 failures
- [x] `bundle exec rubocop lib/fontisan/ufo/ spec/fontisan/ufo/` — clean (124 files)

Closes #46.
