### PR TITLE
woff1: fix WOFF 1.0 spec violations in WoffWriter

### DIFF
--- a/lib/fontisan/converters/woff_writer.rb
+++ b/lib/fontisan/converters/woff_writer.rb
@@ -12,7 +12,8 @@ module Fontisan
     #
     # - `zlib_level` (0–9) — zlib compression level
     # - `uncompressed` (bool) — store tables uncompressed (legal per WOFF 1.0
-    #   §5.1; `compLength == origLength`)
+    #   §5.1; `compLength == origLength`). Metadata is still compressed per
+    #   spec §7 ("it is never stored in uncompressed form").
     # - `compression_threshold` (bytes) — skip compression for tables smaller
     #   than N bytes (rarely needed; keeps tiny tables uncompressed)
     # - `metadata_xml` (string) — optional metadata block
@@ -119,24 +120,35 @@ module Fontisan
 
       # Write font to WOFF binary.
       #
+      # Layout per WOFF 1.0 spec:
+      #   [header (44)] [table directory (20 × N)] [font tables, 4-byte aligned]
+      #   [optional metadata, 4-byte aligned] [optional private data, 4-byte aligned]
+      #
+      # Each font table is padded with 0-3 null bytes to a 4-byte boundary
+      # (spec §5/§6: "Font data tables in the WOFF file have the same
+      # requirement: they MUST begin on 4-byte boundaries and be zero-padded
+      # to the next 4-byte boundary"). Padding aligns the next block.
+      #
       # @param font [TrueTypeFont, OpenTypeFont] Source font
       # @param zlib_level [Integer] 0–9
-      # @param uncompressed [Boolean] skip zlib; store as-is
+      # @param uncompressed [Boolean] skip zlib; store tables as-is
       # @param compression_threshold [Integer] skip compression below N bytes
-      # @param metadata [String, nil] optional metadata XML
+      # @param metadata [String, nil] optional metadata XML (always compressed
+      #   per spec §7 — "it is never stored in uncompressed form")
       # @param private_data [String, nil] optional private data
       # @return [Hash{Symbol => String}] `{ woff_binary: <bytes> }`
       def write_font(font, zlib_level:, uncompressed:, compression_threshold:,
                      metadata: nil, private_data: nil)
-        tables_data = collect_tables_data(font)
+        tables = collect_tables_data(font)
         compressed_tables = compress_tables(
-          tables_data,
+          tables,
           zlib_level: uncompressed ? 0 : zlib_level,
           skip_compression: uncompressed,
           compression_threshold: compression_threshold,
         )
-        compressed_metadata = compress_metadata(metadata, zlib_level: zlib_level,
-                                                          skip_compression: uncompressed)
+        # Per spec §7, metadata MUST always be zlib-compressed regardless of
+        # the per-table `uncompressed` flag.
+        compressed_metadata = compress_metadata(metadata, zlib_level:)
         binary = build_woff_file(compressed_tables, font, compressed_metadata,
                                  private_data)
         { woff_binary: binary }
@@ -152,14 +164,16 @@ module Fontisan
         options.select { |k, _| names.include?(k.to_sym) }
       end
 
-      # Collect all table data from font.
+      # Collect all table data from font in input-font order (spec §6: tables
+      # MUST be stored in the same order as the well-formed input font).
       #
       # @param font [TrueTypeFont, OpenTypeFont]
       # @return [Hash<String, String>]
       def collect_tables_data(font)
-        font.table_names.to_h do |tag|
-          [tag, font.table_data[tag]]
-        end.compact
+        font.table_names.each_with_object({}) do |tag, h|
+          data = font.table_data[tag]
+          h[tag] = data if data
+        end
       end
 
       # Compress tables with zlib (or skip compression entirely).
@@ -197,71 +211,92 @@ module Fontisan
         end
       end
 
-      # Compress metadata with zlib.
+      # Compress metadata with zlib. Per spec §7, metadata MUST always be
+      # zlib-compressed — `skip_compression` is intentionally not exposed
+      # here. The zlib output is used even when it is larger than the input
+      # (e.g. tiny XML payloads where zlib header+checksum overhead exceeds
+      # any compression gain); the spec mandates compression, not optimality.
+      # Returns nil if no metadata was supplied.
       #
       # @param metadata [String, nil]
       # @param zlib_level [Integer]
-      # @param skip_compression [Boolean]
       # @return [Hash, nil]
-      def compress_metadata(metadata, zlib_level:, skip_compression:)
+      def compress_metadata(metadata, zlib_level:)
         return nil unless metadata
 
         original_length = metadata.bytesize
-        if skip_compression
-          return {
-            original_data: metadata,
-            compressed_data: metadata,
-            original_length: original_length,
-            compressed_length: original_length,
-          }
-        end
-
         compressed = Zlib::Deflate.deflate(metadata, zlib_level)
-        use_compressed = compressed.bytesize < original_length
         {
           original_data: metadata,
-          compressed_data: use_compressed ? compressed : metadata,
+          compressed_data: compressed,
           original_length: original_length,
-          compressed_length: use_compressed ? compressed.bytesize : original_length,
+          compressed_length: compressed.bytesize,
         }
+      end
+
+      # Padding bytes needed to bring `length` up to a 4-byte boundary.
+      def padding_to_4(length)
+        (4 - (length % 4)) % 4
       end
 
       # Assemble complete WOFF binary.
       #
-      # @param compressed_tables [Hash]
+      # Computes the full layout (offsets + padding) up front so the header
+      # fields (metaOffset, privOffset) point to the correct locations, then
+      # emits header → directory → tables → optional metadata → optional
+      # private data.
+      #
+      # @param compressed_tables [Hash<String, Hash>] in input-font order
       # @param font [TrueTypeFont, OpenTypeFont]
       # @param compressed_metadata [Hash, nil]
       # @param private_data [String, nil]
       # @return [String]
       def build_woff_file(compressed_tables, font, compressed_metadata,
                           private_data)
-        io = StringIO.new
-        io.set_encoding(Encoding::BINARY)
-
         header_size = 44
         num_tables = compressed_tables.length
-        table_dir_size = num_tables * 20
-        data_offset = header_size + table_dir_size
-        metadata_offset = data_offset
-        metadata_size = compressed_metadata ? compressed_metadata[:compressed_length] : 0
-        total_compressed_size = compressed_tables.values.sum do |t|
-          t[:compressed_length]
-        end
-        private_offset = data_offset + total_compressed_size + metadata_size
-        private_size = private_data ? private_data.bytesize : 0
-        total_size = private_offset + private_size
-        total_sfnt_size = compressed_tables.values.sum do |t|
-          t[:original_length]
-        end +
-          header_size + table_dir_size
+        data_start = header_size + (num_tables * 20)
 
+        # Lay out tables in input-font order with 4-byte alignment padding.
+        # Each entry: { tag:, info:, offset:, pad_bytes: }
+        entries = []
+        cursor = data_start
+        compressed_tables.each do |tag, info|
+          pad = padding_to_4(info[:compressed_length])
+          entries << { tag:, info:, offset: cursor, pad_bytes: "\x00" * pad }
+          cursor += info[:compressed_length] + pad
+        end
+        tables_end = cursor
+
+        metadata_size = compressed_metadata ? compressed_metadata[:compressed_length] : 0
+        # metaOffset/privOffset are 0 when their block is absent (spec §4:
+        # offsets to optional blocks; convention is 0 for "not present").
+        metadata_offset = compressed_metadata ? tables_end : 0
+        metadata_end = tables_end + metadata_size
+
+        private_size = private_data ? private_data.bytesize : 0
+        private_offset = private_data ? metadata_end : 0
+        total_size = metadata_end + private_size
+
+        # totalSfntSize: reconstructed SFNT size with per-table 4-byte padding.
+        # spec §4: "Total size needed for the uncompressed font data, including
+        # the sfnt header, directory, and font tables (including padding)."
+        sfnt_header_size = 12
+        sfnt_dir_size = num_tables * 16
+        sfnt_tables_size = compressed_tables.values.sum do |t|
+          t[:original_length] + padding_to_4(t[:original_length])
+        end
+        total_sfnt_size = sfnt_header_size + sfnt_dir_size + sfnt_tables_size
+
+        io = StringIO.new
+        io.set_encoding(Encoding::BINARY)
         write_woff_header(
           io, font, total_size, total_sfnt_size, num_tables,
           compressed_metadata, metadata_offset, metadata_size,
           private_offset, private_size
         )
-        write_table_directory(io, compressed_tables, data_offset)
-        write_compressed_table_data(io, compressed_tables)
+        write_table_directory(io, entries)
+        write_compressed_table_data(io, entries)
         write_metadata(io, compressed_metadata) if compressed_metadata
         write_private_data(io, private_data) if private_data
 
@@ -293,25 +328,25 @@ module Fontisan
         io.write([private_size].pack("N"))             # privLength
       end
 
-      # Write table directory entries (20 bytes each).
-      def write_table_directory(io, compressed_tables, data_offset)
-        current_offset = data_offset
-        compressed_tables.sort_by { |tag, _| tag }.each do |tag, info|
+      # Write table directory entries (20 bytes each), one per laid-out entry.
+      def write_table_directory(io, entries)
+        entries.each do |e|
           checksum = Utilities::ChecksumCalculator
-            .calculate_table_checksum(info[:original_data])
-          io.write(tag)                                  # tag
-          io.write([current_offset].pack("N"))           # offset
-          io.write([info[:compressed_length]].pack("N")) # compLength
-          io.write([info[:original_length]].pack("N"))   # origLength
-          io.write([checksum].pack("N"))                 # origChecksum
-          current_offset += info[:compressed_length]
+            .calculate_table_checksum(e[:info][:original_data])
+          io.write(e[:tag])                                    # tag
+          io.write([e[:offset]].pack("N"))                     # offset
+          io.write([e[:info][:compressed_length]].pack("N"))   # compLength
+          io.write([e[:info][:original_length]].pack("N"))     # origLength
+          io.write([checksum].pack("N"))                       # origChecksum
         end
       end
 
-      # Write compressed table data, sorted by tag (matches directory order).
-      def write_compressed_table_data(io, compressed_tables)
-        compressed_tables.sort_by { |tag, _| tag }.each do |_, info|
-          io.write(info[:compressed_data])
+      # Write each table's compressed data followed by 4-byte alignment
+      # padding (spec §5/§6: tables MUST be zero-padded to next boundary).
+      def write_compressed_table_data(io, entries)
+        entries.each do |e|
+          io.write(e[:info][:compressed_data])
+          io.write(e[:pad_bytes])
         end
       end
 

--- a/spec/fontisan/converters/woff_writer_spec.rb
+++ b/spec/fontisan/converters/woff_writer_spec.rb
@@ -157,35 +157,192 @@ RSpec.describe Fontisan::Converters::WoffWriter do
     end
   end
 
-  describe "offset calculation bug" do
-    it "correctly sets metadata_offset when no metadata present" do
-      ttf_path = File.join(fixture_path, "NotoSans/NotoSans-Regular.ttf")
-      font = Fontisan::FontLoader.load(ttf_path)
+  describe "spec §4/§5/§6/§7 compliance" do
+    let(:ttf_path) { File.join(fixture_path, "NotoSans/NotoSans-Regular.ttf") }
+    let(:font) { Fontisan::FontLoader.load(ttf_path) }
 
-      woff_data = writer.convert(font)
-
-      # Parse header
-      header_data = woff_data[0..43]
-      meta_offset = header_data[28..31].unpack1("N")
-      meta_length = header_data[32..35].unpack1("N")
-
-      # When no metadata, both should be 0
-      expect(meta_offset).to eq(0)
-      expect(meta_length).to eq(0)
+    # Parse the WOFF header — offsets per WOFF 1.0 spec §4.
+    def parse_header(woff)
+      {
+        signature: woff[0, 4].unpack1("N"),
+        flavor: woff[4, 4].unpack1("N"),
+        length: woff[8, 4].unpack1("N"),
+        num_tables: woff[12, 2].unpack1("n"),
+        reserved: woff[14, 2].unpack1("n"),
+        total_sfnt_size: woff[16, 4].unpack1("N"),
+        major_version: woff[20, 2].unpack1("n"),
+        minor_version: woff[22, 2].unpack1("n"),
+        meta_offset: woff[24, 4].unpack1("N"),
+        meta_length: woff[28, 4].unpack1("N"),
+        meta_orig_length: woff[32, 4].unpack1("N"),
+        priv_offset: woff[36, 4].unpack1("N"),
+        priv_length: woff[40, 4].unpack1("N"),
+      }
     end
 
-    it "correctly sets private_offset when no private data present" do
-      ttf_path = File.join(fixture_path, "NotoSans/NotoSans-Regular.ttf")
-      font = Fontisan::FontLoader.load(ttf_path)
+    def parse_table_entries(woff)
+      h = parse_header(woff)
+      entries = []
+      h[:num_tables].times do |i|
+        pos = 44 + (i * 20)
+        entries << {
+          tag: woff[pos, 4],
+          offset: woff[pos + 4, 4].unpack1("N"),
+          comp_length: woff[pos + 8, 4].unpack1("N"),
+          orig_length: woff[pos + 12, 4].unpack1("N"),
+          orig_checksum: woff[pos + 16, 4].unpack1("N"),
+        }
+      end
+      [h, entries]
+    end
 
-      woff_data = writer.convert(font)
+    it "header.signature is 'wOFF' (0x774F4646)" do
+      woff = writer.convert(font)
+      expect(parse_header(woff)[:signature]).to eq(0x774F4646)
+    end
 
-      # Parse header
-      header_data = woff_data[0..43]
-      priv_offset = header_data[40..43].unpack1("N")
+    it "header.reserved is 0 (spec §4: MUST be zero)" do
+      woff = writer.convert(font)
+      expect(parse_header(woff)[:reserved]).to eq(0)
+    end
 
-      # When no private data, offset should be 0
-      expect(priv_offset).to eq(0)
+    it "header.length equals actual file size" do
+      woff = writer.convert(font)
+      expect(parse_header(woff)[:length]).to eq(woff.bytesize)
+    end
+
+    # Regression: metaOffset header field used to point to start of font
+    # tables (data_offset) instead of the actual metadata location after
+    # the tables. Decoders following the header field got table bytes
+    # instead of the metadata XML.
+    it "metaOffset points to actual metadata location (not start of tables)" do
+      woff = writer.convert(font, metadata_xml: "<metadata>x</metadata>")
+      h = parse_header(woff)
+
+      # Metadata must come AFTER all font tables.
+      _, entries = parse_table_entries(woff)
+      last_table_end = entries.max_by { |e| e[:offset] }[:offset]
+      expect(h[:meta_offset]).to be > last_table_end,
+                                 "metaOffset (#{h[:meta_offset]}) must point past the last table (ends at #{last_table_end})"
+
+      # And the bytes at metaOffset must zlib-inflate to the metadata XML.
+      require "zlib"
+      meta_bytes = woff[h[:meta_offset], h[:meta_length]]
+      decompressed = Zlib::Inflate.inflate(meta_bytes)
+      expect(decompressed).to eq("<metadata>x</metadata>")
+    end
+
+    it "metaOffset and metaLength are 0 when no metadata" do
+      woff = writer.convert(font)
+      h = parse_header(woff)
+      expect(h[:meta_offset]).to eq(0)
+      expect(h[:meta_length]).to eq(0)
+      expect(h[:meta_orig_length]).to eq(0)
+    end
+
+    it "privOffset and privLength are 0 when no private data" do
+      woff = writer.convert(font)
+      h = parse_header(woff)
+      expect(h[:priv_offset]).to eq(0)
+      expect(h[:priv_length]).to eq(0)
+    end
+
+    # Regression: tables used to follow each other contiguously without
+    # 4-byte alignment padding. Spec §5/§6: "Font data tables in the WOFF
+    # file have the same requirement: they MUST begin on 4-byte boundaries
+    # and be zero-padded to the next 4-byte boundary".
+    it "every font table starts on a 4-byte boundary" do
+      woff = writer.convert(font)
+      _, entries = parse_table_entries(woff)
+      entries.each do |e|
+        expect(e[:offset] % 4).to eq(0),
+                                  "table #{e[:tag]} starts at offset #{e[:offset]} (not 4-byte aligned)"
+      end
+    end
+
+    it "tables are zero-padded to next 4-byte boundary" do
+      woff = writer.convert(font)
+      _, entries = parse_table_entries(woff)
+      entries.each_cons(2) do |cur, nxt|
+        end_off = cur[:offset] + cur[:comp_length]
+        expected_padding = (4 - (cur[:comp_length] % 4)) % 4
+        actual_padding = nxt[:offset] - end_off
+        expect(actual_padding).to eq(expected_padding),
+                                  "padding after #{cur[:tag]} should be #{expected_padding} bytes, got #{actual_padding}"
+
+        # Padding bytes must all be zero
+        woff[end_off, actual_padding].each_byte do |b|
+          expect(b).to eq(0), "non-zero padding byte after #{cur[:tag]}"
+        end
+      end
+    end
+
+    # Spec §7: "If present, the metadata MUST be compressed; it is never
+    # stored in uncompressed form."
+    it "metadata is zlib-compressed even when uncompressed: true" do
+      woff = writer.convert(font, uncompressed: true,
+                                  metadata_xml: "<metadata>test</metadata>")
+      h = parse_header(woff)
+      require "zlib"
+      meta_bytes = woff[h[:meta_offset], h[:meta_length]]
+      expect { Zlib::Inflate.inflate(meta_bytes) }.not_to raise_error,
+                                                          "metadata must be zlib-compressed even with uncompressed: true"
+    end
+
+    # Spec §4: "totalSfntSize: Total size needed for the uncompressed font
+    # data, including the sfnt header, directory, and font tables (including
+    # padding)."
+    it "totalSfntSize includes per-table 4-byte padding" do
+      woff = writer.convert(font)
+      h, entries = parse_table_entries(woff)
+
+      sfnt_header_size = 12
+      sfnt_dir_size = entries.size * 16
+      sfnt_tables_with_padding = entries.sum do |e|
+        e[:orig_length] + ((4 - (e[:orig_length] % 4)) % 4)
+      end
+      expected = sfnt_header_size + sfnt_dir_size + sfnt_tables_with_padding
+
+      expect(h[:total_sfnt_size]).to eq(expected),
+                                     "totalSfntSize must include per-table 4-byte padding"
+    end
+
+    it "private data is preserved verbatim at privOffset" do
+      private_data = "secret bytes \x00\x01\x02".b
+      woff = writer.convert(font, private_data:)
+      h = parse_header(woff)
+      actual = woff[h[:priv_offset], h[:priv_length]]
+      expect(actual).to eq(private_data)
+    end
+
+    it "preserves input font table order (spec §6)" do
+      woff = writer.convert(font)
+      _, entries = parse_table_entries(woff)
+      actual_order = entries.map { |e| e[:tag].force_encoding("UTF-8") }
+      expected_order = font.table_names
+      expect(actual_order).to eq(expected_order),
+                              "tables must be stored in input font order, not sorted alphabetically"
+    end
+
+    # Cross-validation: fontTools can decode our output.
+    it "fontTools decodes the WOFF and reads all tables", :python do
+      skip "fontTools not available" unless python_fonttools?
+
+      woff = writer.convert(font, metadata_xml: "<metadata>test</metadata>")
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out.woff")
+        File.binwrite(path, woff)
+        script = File.join(dir, "check.py")
+        File.write(script, <<~PY)
+          import sys
+          from fontTools.ttLib import TTFont
+          t = TTFont(sys.argv[1])
+          print("OK", sorted(t.keys()))
+        PY
+        output = `python3 #{script} #{path} 2>&1`
+        expect($?).to be_success, "fontTools failed:\n#{output}"
+        expect(output).to include("OK")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes multiple WOFF 1.0 spec violations in `WoffWriter`. Most critically, the `metaOffset` header field pointed to the wrong location — any WOFF 1 file exported with `metadata_xml:` was unreadable through strict decoders.

## Bugs fixed

| # | Bug | Spec ref | Impact |
|---|---|---|---|
| 1 | `metaOffset` pointed to start of font tables instead of metadata location | §4, §7 | Any font with metadata is corrupted |
| 2 | Tables emitted without 4-byte alignment or inter-table padding | §5, §6 | Strict decoders reject |
| 3 | Metadata could be uncompressed when `uncompressed: true` | §7 | Spec violation ("it is never stored in uncompressed form") |
| 4 | `totalSfntSize` omitted per-table padding | §4 | Size mismatch |
| 5 | `privOffset` set to file-end even when `privLength == 0` | §4 | Convention violation |
| 6 | Tables sorted alphabetically, not in input order | §6 | "MUST be stored in the same order as the well-formed input font" |

## Architecture

- Layout (offsets + padding) computed up front in `build_woff_file` so header fields point to correct locations. No offset mutation during writes.
- `compress_metadata` no longer takes `skip_compression:` — spec §7 overrides any per-table setting.
- `collect_tables_data` returns hash in font order (`each_with_object` preserves iteration order through Ruby's ordered Hash).

## Test plan

- [x] `bundle exec rspec` — 5939 examples, 0 failures (3 pre-existing pending)
- [x] 12 new spec examples covering each fix
- [x] `bundle exec rubocop` on touched files — clean
- [x] fontTools round-trip succeeds (decodes all tables + numGlyphs)
- [ ] CI green on Ruby 3.3/3.4/4.0 × mac/linux/windows

## References

- WOFF 1.0 spec: https://www.w3.org/TR/WOFF/
- Audit findings in PR #92 discussion
