### PR TITLE
woff2: complete collection support — decoder, domain object, pipeline integration

### DIFF
--- a/lib/fontisan.rb
+++ b/lib/fontisan.rb
@@ -116,6 +116,7 @@ module Fontisan
   autoload :OutlineExtractor, "fontisan/outline_extractor"
   autoload :SfntFont, "fontisan/sfnt_font"
   autoload :SfntTable, "fontisan/sfnt_table"
+  autoload :SfntBuilder, "fontisan/sfnt_builder"
   autoload :Stitcher, "fontisan/stitcher"
   autoload :StitcherCli, "fontisan/stitcher_cli"
   autoload :Tasks, "fontisan/tasks"
@@ -123,6 +124,7 @@ module Fontisan
   autoload :TrueTypeFont, "fontisan/true_type_font"
   autoload :TrueTypeFontExtensions, "fontisan/true_type_font_extensions"
   autoload :Type1Font, "fontisan/type1_font"
+  autoload :Woff2Collection, "fontisan/woff2_collection"
   autoload :Woff2Font, "fontisan/woff2_font"
   autoload :WoffFont, "fontisan/woff_font"
 

--- a/lib/fontisan/commands/convert_command.rb
+++ b/lib/fontisan/commands/convert_command.rb
@@ -299,7 +299,7 @@ module Fontisan
       # Determine collection type from format
       #
       # @param format [Symbol] Target format
-      # @return [Symbol, nil] Collection type (:ttc, :otc, :dfont) or nil
+      # @return [Symbol, nil] Collection type (:ttc, :otc, :dfont, :woff2_collection) or nil
       def collection_type_from_format(format)
         case format
         when :ttc
@@ -308,6 +308,8 @@ module Fontisan
           :otc
         when :dfont
           :dfont
+        when :woff2
+          :woff2_collection
         else
           # Check output extension
           ext = File.extname(@output_path).downcase
@@ -318,6 +320,8 @@ module Fontisan
             :otc
           when ".dfont"
             :dfont
+          when ".woff2"
+            :woff2_collection
           end
         end
       end

--- a/lib/fontisan/config/conversion_matrix.yml
+++ b/lib/fontisan/config/conversion_matrix.yml
@@ -377,6 +377,42 @@ conversions:
       Unpacks dfont suitcase and repacks as OTC. If dfont contains TrueType
       fonts, they are converted to OpenType/CFF format.
 
+  # WOFF2 collection conversions (spec section 4.2)
+  - from: ttc
+    to: woff2_collection
+    strategy: collection_converter
+    description: "Convert TrueType Collection to WOFF2 collection"
+    status: implemented
+    notes: >
+      Unpacks TTC, encodes each font per WOFF2 spec, packs as a single
+      WOFF2 collection file (flavor='ttcf'). Tables shared across fonts
+      are deduplicated.
+
+  - from: otc
+    to: woff2_collection
+    strategy: collection_converter
+    description: "Convert OpenType Collection to WOFF2 collection"
+    status: implemented
+    notes: >
+      Unpacks OTC, encodes each font per WOFF2 spec, packs as a single
+      WOFF2 collection file (flavor='ttcf').
+
+  - from: woff2_collection
+    to: ttc
+    strategy: collection_converter
+    description: "Convert WOFF2 collection to TrueType Collection"
+    status: implemented
+    notes: >
+      Decodes WOFF2 collection, extracts each font, repacks as TTC.
+
+  - from: woff2_collection
+    to: otc
+    strategy: collection_converter
+    description: "Convert WOFF2 collection to OpenType Collection"
+    status: implemented
+    notes: >
+      Decodes WOFF2 collection, extracts each font, repacks as OTC.
+
 # Conversion compatibility matrix
 #
 # This section documents which source features are preserved in conversions.

--- a/lib/fontisan/converters/collection_converter.rb
+++ b/lib/fontisan/converters/collection_converter.rb
@@ -121,9 +121,10 @@ module Fontisan
           raise ArgumentError, "Collection file not found: #{collection_path}"
         end
 
-        unless %i[ttc otc dfont].include?(target_type)
+        unless %i[ttc otc dfont woff2_collection].include?(target_type)
           raise ArgumentError,
-                "Invalid target type: #{target_type}. Must be :ttc, :otc, or :dfont"
+                "Invalid target type: #{target_type}. Must be :ttc, :otc, " \
+                ":dfont, or :woff2_collection"
         end
 
         unless options[:output]
@@ -145,6 +146,8 @@ module Fontisan
                   unpack_ttc_otc(collection_path)
                 when :dfont
                   unpack_dfont(collection_path)
+                when :woff2_collection
+                  unpack_woff2_collection(collection_path)
                 else
                   raise Error, "Unknown collection type: #{source_type}"
                 end
@@ -155,7 +158,7 @@ module Fontisan
       # Detect collection type from file
       #
       # @param path [String] Collection path
-      # @return [Symbol] Collection type (:ttc, :otc, or :dfont)
+      # @return [Symbol] Collection type (:ttc, :otc, :dfont, or :woff2_collection)
       def detect_collection_type(path)
         File.open(path, "rb") do |io|
           signature = io.read(4)
@@ -165,6 +168,12 @@ module Fontisan
             # TTC or OTC - check extension
             ext = File.extname(path).downcase
             ext == ".otc" ? :otc : :ttc
+          elsif signature == "wOF2"
+            # WOFF2 collection or single font — distinguish by flavor
+            io.read(8) # signature + flavor
+            io.rewind
+            flavor = File.binread(path, 4, 4)&.unpack1("N")
+            flavor == Woff2::CollectionDecoder::TTC_FLAVOR ? :woff2_collection : (raise Error, "Not a WOFF2 collection: #{path}")
           elsif Parsers::DfontParser.dfont?(io)
             :dfont
           else
@@ -205,6 +214,15 @@ module Fontisan
         end
 
         fonts
+      end
+
+      # Unpack fonts from WOFF2 collection (spec section 4.2).
+      #
+      # @param path [String] WOFF2 collection path
+      # @return [Array<Font>] Unpacked fonts
+      def unpack_woff2_collection(path)
+        collection = FontLoader.load_collection(path)
+        collection.extract_fonts
       end
 
       # Convert fonts if outline format change needed
@@ -380,6 +398,8 @@ conv_options = nil)
           repack_ttc_otc(fonts, target_type, output_path, options)
         when :dfont
           repack_dfont(fonts, output_path, options)
+        when :woff2_collection
+          repack_woff2_collection(fonts, output_path, options)
         else
           raise Error, "Unknown target type: #{target_type}"
         end
@@ -413,6 +433,19 @@ conv_options = nil)
       def repack_dfont(fonts, output_path, _options)
         builder = Collection::DfontBuilder.new(fonts)
         builder.build_to_file(output_path)
+      end
+
+      # Repack fonts into a WOFF2 collection (spec section 4.2).
+      #
+      # @param fonts [Array<Font>] Fonts
+      # @param output_path [String] Output path (.woff2)
+      # @param options [Hash] Options (looks for :brotli_quality)
+      # @return [void]
+      def repack_woff2_collection(fonts, output_path, options)
+        brotli_quality = options.fetch(:brotli_quality, 11)
+        encoder = Woff2::CollectionEncoder.new(brotli_quality:)
+        bytes = encoder.encode_fonts(fonts)
+        File.binwrite(output_path, bytes)
       end
 
       # Build conversion result

--- a/lib/fontisan/font_loader.rb
+++ b/lib/fontisan/font_loader.rb
@@ -45,6 +45,7 @@ module Fontisan
       ttc: TrueTypeCollection,
       otc: OpenTypeCollection,
       dfont: DfontCollection,
+      woff2_collection: Woff2Collection,
     }.freeze
     private_constant :COLLECTION_CLASSES
 
@@ -83,6 +84,8 @@ module Fontisan
                                                  lazy: resolved_lazy)
       when :ttc, :otc then load_from_collection(path, format, font_index,
                                                 mode: resolved_mode)
+      when :woff2_collection then load_from_collection(path, format, font_index,
+                                                       mode: resolved_mode)
       when :dfont then load_dfont(path, font_index: font_index,
                                         mode: resolved_mode)
       when :pfa, :pfb then Type1Font.from_file(path, mode: resolved_mode)
@@ -185,7 +188,7 @@ module Fontisan
                when Constants::SFNT_OTTO_MAGIC then :otf
                when Constants::SFNT_TRUETYPE_MAGIC, Constants::SFNT_TRUE_MAGIC then :ttf
                when Constants::WOFF_MAGIC then :woff
-               when Constants::WOFF2_MAGIC then :woff2
+               when Constants::WOFF2_MAGIC then scan_woff2(io)
                when Constants::DFONT_RESOURCE_HEADER
                  io.rewind
                  Parsers::DfontParser.dfont?(io) ? :dfont : nil
@@ -238,6 +241,18 @@ module Fontisan
       nil
     end
 
+    # Distinguish a WOFF2 collection (flavor='ttcf') from a single-font
+    # WOFF2. The 8-byte probe covers the WOFF2 signature + flavor field;
+    # spec section 3.2 requires flavor='ttcf' (0x74746366) for collections.
+    def self.scan_woff2(io)
+      io.rewind
+      io.read(4) # signature (already matched)
+      flavor = io.read(4)&.unpack1("N")
+      flavor == Woff2::CollectionDecoder::TTC_FLAVOR ? :woff2_collection : :woff2
+    rescue IOError
+      :woff2
+    end
+
     # Mode override from FONTISAN_MODE env var, or nil.
     def self.env_mode
       env_value = ENV["FONTISAN_MODE"]
@@ -287,6 +302,7 @@ module Fontisan
     private_class_method :detect,
                          :type1_format_from_header,
                          :scan_collection,
+                         :scan_woff2,
                          :env_mode,
                          :env_lazy,
                          :load_from_collection,

--- a/lib/fontisan/sfnt_builder.rb
+++ b/lib/fontisan/sfnt_builder.rb
@@ -45,6 +45,8 @@ module Fontisan
       # table data with 4-byte padding. The directory entries' offset
       # fields were precomputed assuming this layout.
       sorted = records.sort_by { |r| r[:tag] }
+      # rubocop:disable Style/CombinableLoops
+      # SFNT requires all directory entries before any table data
       sorted.each do |r|
         out << r[:tag].ljust(4, "\x00")
         out << [r[:checksum]].pack("N")
@@ -56,6 +58,7 @@ module Fontisan
         out << r[:data]
         out << ("\x00" * r[:padding])
       end
+      # rubocop:enable Style/CombinableLoops
 
       out
     end

--- a/lib/fontisan/sfnt_builder.rb
+++ b/lib/fontisan/sfnt_builder.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Fontisan
+  # Builds an SFNT (TrueType/OpenType) binary from a flavor + per-tag table
+  # data. Used whenever WOFF2-derived table data needs to be reassembled
+  # into a parseable SFNT (single-font decoding, WOFF2 collection → font).
+  #
+  # Single source of truth for the SFNT byte layout: 12-byte offset table,
+  # 16-byte table directory entries, padded table data.
+  module SfntBuilder
+    # @param flavor [Integer] SFNT version (Constants::SFNT_VERSION_TRUETYPE
+    #   or Constants::SFNT_VERSION_OTTO)
+    # @param tables [Hash<String => String>] tag → table bytes
+    # @return [String] SFNT binary
+    def self.build(flavor:, tables:)
+      num_tables = tables.length
+      entry_selector = (Math.log(num_tables) / Math.log(2)).floor
+      search_range = (2**entry_selector) * 16
+      range_shift = (num_tables * 16) - search_range
+
+      out = String.new(encoding: Encoding::BINARY)
+      # Offset table (12 bytes)
+      out << [flavor].pack("N")
+      out << [num_tables].pack("n")
+      out << [search_range].pack("n")
+      out << [entry_selector].pack("n")
+      out << [range_shift].pack("n")
+
+      # Compute layout for table directory + table data with 4-byte padding
+      data_start = 12 + (num_tables * 16)
+      cursor = data_start
+      records = tables.map do |tag, data|
+        length = data.bytesize
+        checksum = Utilities::ChecksumCalculator.calculate_table_checksum(data)
+        padding = (4 - (length % 4)) % 4
+        record = { tag:, checksum:, offset: cursor, length:, data:, padding: }
+        cursor += length + padding
+        record
+      end
+
+      # Write all table directory entries first (16 bytes each, sorted
+      # alphabetically per SFNT convention for stable output), then all
+      # table data with 4-byte padding. The directory entries' offset
+      # fields were precomputed assuming this layout.
+      sorted = records.sort_by { |r| r[:tag] }
+      sorted.each do |r|
+        out << r[:tag].ljust(4, "\x00")
+        out << [r[:checksum]].pack("N")
+        out << [r[:offset]].pack("N")
+        out << [r[:length]].pack("N")
+      end
+
+      sorted.each do |r|
+        out << r[:data]
+        out << ("\x00" * r[:padding])
+      end
+
+      out
+    end
+  end
+end

--- a/lib/fontisan/woff2.rb
+++ b/lib/fontisan/woff2.rb
@@ -4,6 +4,7 @@
 
 module Fontisan
   module Woff2
+    autoload :CollectionDecoder, "fontisan/woff2/collection_decoder"
     autoload :CollectionEncoder, "fontisan/woff2/collection_encoder"
     autoload :Directory, "fontisan/woff2/directory"
     autoload :EncoderRules, "fontisan/woff2/encoder_rules"

--- a/lib/fontisan/woff2/collection_decoder.rb
+++ b/lib/fontisan/woff2/collection_decoder.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Fontisan
+  module Woff2
+    # Decodes a WOFF2 font collection per spec section 4.2. This is the
+    # decoder counterpart of {Woff2::CollectionEncoder}.
+    #
+    # Layout parsed:
+    #   [WOFF2Header (48 bytes, flavor = 'ttcf')]
+    #   [TableDirectory]              # one entry per unique table
+    #   [CollectionDirectory]         # CollectionHeader + N CollectionFontEntry
+    #   [CompressedFontData]          # single brotli stream of all tables
+    #
+    # Each CollectionFontEntry references tables in the TableDirectory via
+    # indices. The decoder yields one reconstructed font per entry, with
+    # glyf/loca reconstruction per spec section 5.1/5.3 applied.
+    #
+    # Reference: W3C WOFF2 spec, section 4.2.
+    class CollectionDecoder
+      TTC_FLAVOR = 0x74746366 # 'ttcf'
+
+      # Parsed table directory entry: tag + raw bytes + transform state.
+      TableEntry = Struct.new(:tag, :raw_bytes, :orig_length, :transform_length,
+                              keyword_init: true)
+
+      # Parsed CollectionFontEntry: per-font table indices + flavor.
+      FontEntry = Struct.new(:flavor, :table_indices, keyword_init: true)
+
+      # @param data [String] WOFF2 collection binary
+      def initialize(data)
+        @data = data.dup.force_encoding(Encoding::BINARY)
+      end
+
+      # Decode the WOFF2 collection, returning one Hash per font containing
+      # the reconstructed table data ready to assemble into an SFNT.
+      #
+      # @return [Array<Hash{Symbol => Object}>] per-font:
+      #   {flavor:, tables: {tag ⇒ bytes}}
+      def decode
+        validate_signature!
+        validate_collection_flavor!
+
+        table_entries, post_dir_pos = read_table_directory
+        font_entries, post_coll_pos = read_collection_directory(post_dir_pos)
+        decompressed = decompress_table_data(post_coll_pos)
+
+        # Replace each table entry's raw_bytes by slicing from the
+        # decompressed stream at its cumulative offset.
+        cursor = 0
+        table_entries.each do |e|
+          len = e.transform_length || e.orig_length
+          e.raw_bytes = decompressed[cursor, len]
+          cursor += len
+        end
+
+        # For each font, gather its tables and reconstruct glyf/loca when
+        # the glyf was transformed.
+        font_entries.map do |fe|
+          font_tables = {}
+          fe.table_indices.each do |idx|
+            entry = table_entries.fetch(idx)
+            font_tables[entry.tag] = entry.raw_bytes
+          end
+          reconstruct_glyf_loca!(font_tables) if font_tables.key?("glyf")
+          { flavor: fe.flavor, tables: font_tables }
+        end
+      end
+
+      private
+
+      def validate_signature!
+        sig = @data[0, 4].unpack1("N")
+        return if sig == Woff2Header::SIGNATURE
+
+        raise InvalidFontError,
+              "Invalid WOFF2 signature: 0x#{sig.to_s(16)}"
+      end
+
+      def validate_collection_flavor!
+        flavor = @data[4, 4].unpack1("N")
+        return if flavor == TTC_FLAVOR
+
+        raise InvalidFontError,
+              "WOFF2 file is not a collection (flavor 0x#{flavor.to_s(16)}; " \
+              "expected 0x#{TTC_FLAVOR.to_s(16)} 'ttcf')"
+      end
+
+      def num_tables = @data[12, 2].unpack1("n")
+
+      def total_compressed_size = @data[20, 4].unpack1("N")
+
+      # Walk num_tables entries, returning the array of TableEntry and the
+      # byte position immediately after the table directory.
+      def read_table_directory
+        entries = []
+        pos = 48
+        num_tables.times do
+          entry, pos = read_one_directory_entry(pos)
+          entries << entry
+        end
+        [entries, pos]
+      end
+
+      def read_one_directory_entry(pos)
+        flags = @data.getbyte(pos)
+        pos += 1
+        tag_index = flags & 0x3F
+        transform_version = (flags >> 6) & 0x03
+        tag = if tag_index == 0x3F
+                t = @data[pos, 4]
+                pos += 4
+                t
+              else
+                Directory::KNOWN_TAGS.fetch(tag_index)
+              end
+        orig_length, pos = read_uint_base128(pos)
+        transform_length = nil
+        is_glyf_loca = ["glyf", "loca"].include?(tag)
+        is_transformed_hmtx = tag == "hmtx" && transform_version == 1
+        if (is_glyf_loca && transform_version.zero?) || is_transformed_hmtx
+          transform_length, pos = read_uint_base128(pos)
+        end
+        entry = TableEntry.new(tag:, raw_bytes: nil, orig_length:,
+                               transform_length:)
+        [entry, pos]
+      end
+
+      # Read CollectionHeader + N CollectionFontEntry records.
+      def read_collection_directory(pos)
+        version = @data[pos, 4].unpack1("N")
+        pos += 4
+        raise InvalidFontError, "Unsupported CollectionHeader version 0x#{version.to_s(16)}" unless version == 0x00010000
+
+        num_fonts, pos = read_255_uint16(pos)
+        font_entries = Array.new(num_fonts) do
+          num_tables_f, pos2 = read_255_uint16(pos)
+          pos = pos2
+          flavor = @data[pos, 4].unpack1("N")
+          pos += 4
+          indices = Array.new(num_tables_f) do
+            idx, pos2 = read_255_uint16(pos)
+            pos = pos2
+            idx
+          end
+          FontEntry.new(flavor:, table_indices: indices)
+        end
+        [font_entries, pos]
+      end
+
+      def decompress_table_data(start_pos)
+        compressed = @data[start_pos, total_compressed_size]
+        Utilities::BrotliWrapper.decompress(compressed)
+      end
+
+      # Reconstruct glyf + loca per spec section 5.1/5.3 when glyf is in
+      # transformed format. Replaces font_tables["glyf"] with reconstructed
+      # bytes and adds font_tables["loca"].
+      def reconstruct_glyf_loca!(font_tables)
+        glyf_bytes = font_tables["glyf"]
+        return unless glyf_bytes && glyf_bytes.bytesize >= 36
+
+        num_glyphs = parse_num_glyphs(font_tables)
+        index_format = parse_index_format(font_tables)
+        return unless num_glyphs && index_format
+
+        result = GlyfLocaReconstruct.new(
+          transformed_glyf: glyf_bytes,
+          num_glyphs:,
+          index_format:,
+        ).reconstruct
+        font_tables["glyf"] = result[:glyf]
+        font_tables["loca"] = result[:loca]
+      end
+
+      def parse_num_glyphs(font_tables)
+        maxp = font_tables["maxp"]
+        return nil unless maxp && maxp.bytesize >= 6
+
+        maxp[4, 2].unpack1("n")
+      end
+
+      def parse_index_format(font_tables)
+        head = font_tables["head"]
+        return nil unless head && head.bytesize >= 52
+
+        head[50, 2].unpack1("n")
+      end
+
+      def read_uint_base128(pos)
+        value = 0
+        5.times do
+          byte = @data.getbyte(pos)
+          pos += 1
+          if (byte & 0x80).zero?
+            value = (value << 7) | byte
+            return [value, pos]
+          end
+          value = (value << 7) | (byte & 0x7F)
+        end
+        raise InvalidFontError, "UIntBase128 sequence exceeds 5 bytes"
+      end
+
+      def read_255_uint16(pos)
+        code = @data.getbyte(pos)
+        pos += 1
+        case code
+        when 0..252 then [code, pos]
+        when 253
+          v = @data.getbyte(pos)
+          pos += 1
+          [253 + v, pos]
+        when 254
+          v = @data[pos, 2].unpack1("n")
+          pos += 2
+          [v, pos]
+        when 255
+          v = @data[pos, 2].unpack1("n")
+          pos += 2
+          [v + 506, pos]
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/woff2_collection.rb
+++ b/lib/fontisan/woff2_collection.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Fontisan
+  # WOFF2 font collection (spec section 4.2).
+  #
+  # Wraps a WOFF2 collection file (flavor='ttcf') and exposes the same
+  # interface as `TrueTypeCollection`/`OpenTypeCollection` so collection
+  # consumers don't need to know which container format they're holding.
+  #
+  # Unlike TTC/OTC (which subclass `BaseCollection` for BinData parsing),
+  # WOFF2 collections are decoded eagerly via `Woff2::CollectionDecoder`
+  # because the per-font tables require Brotli decompression +
+  # glyf/loca reconstruction before they can be returned.
+  class Woff2Collection
+    include Collection::SharedLogic
+
+    # @return [String] Source WOFF2 binary
+    attr_reader :data
+
+    # @param data [String] WOFF2 collection binary
+    def initialize(data)
+      @data = data.force_encoding(Encoding::BINARY)
+    end
+
+    # Load a WOFF2 collection from a file path.
+    #
+    # @param path [String]
+    # @return [Woff2Collection]
+    def self.from_file(path)
+      new(File.binread(path))
+    end
+
+    # Number of fonts in the collection.
+    #
+    # @return [Integer]
+    def num_fonts
+      decoded.length
+    end
+    alias font_count num_fonts
+
+    # Per-font synthetic offsets. WOFF2 collections don't have byte offsets
+    # like TTC (each font is reconstructed in memory); the index is the
+    # only identifier. Returned for compatibility with `BaseCollection`'s
+    # interface.
+    #
+    # @return [Array<Integer>] 0..num_fonts-1
+    def font_offsets
+      (0...num_fonts).to_a
+    end
+
+    # Extract every font in the collection.
+    #
+    # @param _io [IO, nil] Ignored — WOFF2 collections decode in memory.
+    # @return [Array<TrueTypeFont, OpenTypeFont>]
+    def extract_fonts(_io = nil)
+      decoded.map { |entry| build_font(entry) }
+    end
+
+    # Get a single font by index.
+    #
+    # @param index [Integer] 0-based font index
+    # @param _io [IO, nil] Ignored.
+    # @param _mode [Symbol] Ignored — full mode only (WOFF2 collections are
+    #   decoded eagerly).
+    # @return [TrueTypeFont, OpenTypeFont, nil] nil if index out of range
+    def font(index, _io = nil, _mode: LoadingModes::FULL)
+      return nil if index >= num_fonts
+
+      build_font(decoded[index])
+    end
+
+    # Whether this object represents a font collection. WOFF2 collections
+    # are always collections.
+    #
+    # @return [Boolean]
+    def collection? = true
+
+    # Collections have no single SFNT table directory.
+    #
+    # @return [Array<String>] empty
+    def table_names = []
+
+    # Validate format correctness.
+    #
+    # @return [Boolean]
+    def valid?
+      flavor = @data[4, 4].unpack1("N")
+      flavor == Woff2::CollectionDecoder::TTC_FLAVOR
+    rescue StandardError
+      false
+    end
+
+    # High-level pipeline format identifier. Owned by the collection class
+    # so the conversion pipeline can dispatch without case statements.
+    #
+    # @return [Symbol] :woff2_collection
+    def format = :woff2_collection
+
+    private
+
+    # Lazily decoded collection entries (one Hash per font).
+    def decoded
+      @decoded ||= Woff2::CollectionDecoder.new(@data).decode
+    end
+
+    # Build a TrueTypeFont or OpenTypeFont from a decoded font entry.
+    # Constructs an in-memory SFNT binary from the per-table data and
+    # loads it through the normal font reader path.
+    def build_font(entry)
+      sfnt = SfntBuilder.build(flavor: entry[:flavor], tables: entry[:tables])
+      sfnt_io = StringIO.new(sfnt)
+      font_class = truetype_flavor?(entry[:flavor]) ? TrueTypeFont : OpenTypeFont
+      font = font_class.read(sfnt_io)
+      font.initialize_storage
+      font.read_table_data(StringIO.new(sfnt))
+      font
+    end
+
+    def truetype_flavor?(flavor)
+      [Constants::SFNT_VERSION_TRUETYPE, 0x00010000].include?(flavor)
+    end
+  end
+end

--- a/spec/fontisan/sfnt_builder_spec.rb
+++ b/spec/fontisan/sfnt_builder_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe Fontisan::SfntBuilder do
+  describe ".build" do
+    let(:flavor) { Fontisan::Constants::SFNT_VERSION_TRUETYPE }
+
+    it "returns a binary string" do
+      bytes = described_class.build(flavor:, tables: { "head" => "\x00" * 54 })
+      expect(bytes).to be_a(String)
+      expect(bytes.encoding).to eq(Encoding::BINARY)
+    end
+
+    it "starts with the SFNT flavor" do
+      bytes = described_class.build(flavor:, tables: { "head" => "\x00" * 54 })
+      expect(bytes[0, 4].unpack1("N")).to eq(flavor)
+    end
+
+    it "writes a 12-byte offset table + 16-byte directory per table + padded data" do
+      tables = { "head" => "\x00" * 54, "maxp" => "\x00" * 32 }
+      bytes = described_class.build(flavor:, tables:)
+
+      # numTables field
+      num_tables = bytes[4, 2].unpack1("n")
+      expect(num_tables).to eq(2)
+
+      # First table directory entry at offset 12 (alphabetical: head before maxp)
+      # SFNT TableDirectoryEntry: tag(4) checksum(4) offset(4) length(4) = 16 bytes
+      tag = bytes[12, 4]
+      checksum = bytes[16, 4].unpack1("N")
+      offset = bytes[20, 4].unpack1("N")
+      length = bytes[24, 4].unpack1("N")
+      expect(tag).to eq("head")
+      expect(length).to eq(54)
+      expect(checksum).to be_an(Integer)
+      expect(offset).to eq(12 + (2 * 16)) # after offset table + directory
+    end
+
+    it "pads table data to 4-byte boundary" do
+      # head table is 54 bytes (not 4-aligned). Padding = 2 bytes.
+      bytes = described_class.build(flavor:, tables: { "head" => "\x00" * 54 })
+      # Head entry is first (alphabetically). Find its data start (12 + 16 = 28).
+      # Then 54 bytes + 2 padding = 56 bytes total before EOF.
+      expect(bytes.bytesize).to eq(12 + 16 + 54 + 2) # offset + dir + data + padding
+    end
+  end
+end

--- a/spec/fontisan/woff2/collection_decoder_spec.rb
+++ b/spec/fontisan/woff2/collection_decoder_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe Fontisan::Woff2::CollectionDecoder do
+  let(:ttc_path) { fixture_path("fonts/DinaRemasterII/DinaRemasterII.ttc") }
+  let(:fonts) do
+    File.open(ttc_path, "rb") do |io|
+      Fontisan::FontLoader.load_collection(ttc_path).extract_fonts(io)
+    end
+  end
+  let(:woff2_bytes) do
+    Fontisan::Woff2::CollectionEncoder.new(brotli_quality: 11).encode_fonts(fonts)
+  end
+
+  let(:decoder) { described_class.new(woff2_bytes) }
+
+  describe "#decode" do
+    subject(:result) { decoder.decode }
+
+    it "returns one entry per source font" do
+      expect(result.length).to eq(fonts.length)
+    end
+
+    it "each entry has :flavor and :tables keys" do
+      expect(result).to all(include(:flavor, :tables))
+    end
+
+    it "flavor matches the source fonts" do
+      result.each_with_index do |entry, _i|
+        expect(entry[:flavor]).to eq(Fontisan::Constants::SFNT_VERSION_TRUETYPE)
+      end
+    end
+
+    it "tables hash contains glyf and loca per font" do
+      result.each do |entry|
+        expect(entry[:tables]).to include("glyf", "loca")
+      end
+    end
+
+    it "reconstructs glyf to a non-empty binary string" do
+      result.each do |entry|
+        glyf = entry[:tables]["glyf"]
+        expect(glyf).to be_a(String)
+        expect(glyf.bytesize).to be > 0
+      end
+    end
+
+    it "raises InvalidFontError for non-WOFF2 input" do
+      expect { described_class.new("not a woff2").decode }
+        .to raise_error(Fontisan::InvalidFontError, /Invalid WOFF2 signature/)
+    end
+
+    it "raises InvalidFontError for a single-font WOFF2 (flavor not 'ttcf')" do
+      skip "needs a single-font WOFF2 fixture" unless File.exist?(fixture_path("fonttools/TestWOFF2.woff2"))
+
+      single_bytes = File.binread(fixture_path("fonttools/TestWOFF2.woff2"))
+      expect { described_class.new(single_bytes).decode }
+        .to raise_error(Fontisan::InvalidFontError, /not a collection/)
+    end
+  end
+end

--- a/spec/fontisan/woff2_collection_spec.rb
+++ b/spec/fontisan/woff2_collection_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe Fontisan::Woff2Collection do
+  let(:ttc_path) { fixture_path("fonts/DinaRemasterII/DinaRemasterII.ttc") }
+
+  # Build a WOFF2 collection from the TTC source, yield its path.
+  def with_woff2_collection
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "out.woff2")
+      fonts = File.open(ttc_path, "rb") do |io|
+        Fontisan::FontLoader.load_collection(ttc_path).extract_fonts(io)
+      end
+      bytes = Fontisan::Woff2::CollectionEncoder.new(brotli_quality: 11).encode_fonts(fonts)
+      File.binwrite(path, bytes)
+      yield path
+    end
+  end
+
+  describe ".from_file" do
+    it "loads a WOFF2 collection and exposes num_fonts" do
+      with_woff2_collection do |path|
+        collection = described_class.from_file(path)
+        expect(collection.num_fonts).to eq(2)
+      end
+    end
+  end
+
+  describe "#valid?" do
+    it "returns true for a real WOFF2 collection" do
+      with_woff2_collection do |path|
+        expect(described_class.from_file(path)).to be_valid
+      end
+    end
+  end
+
+  describe "#collection?" do
+    it "returns true (always)" do
+      with_woff2_collection do |path|
+        expect(described_class.from_file(path).collection?).to be true
+      end
+    end
+  end
+
+  describe "#font_offsets" do
+    it "returns 0..num_fonts-1 (synthetic indices for compat with BaseCollection)" do
+      with_woff2_collection do |path|
+        expect(described_class.from_file(path).font_offsets).to eq([0, 1])
+      end
+    end
+  end
+
+  describe "#extract_fonts" do
+    it "returns the same number of fonts as the source" do
+      with_woff2_collection do |path|
+        fonts = described_class.from_file(path).extract_fonts
+        expect(fonts.length).to eq(2)
+      end
+    end
+
+    it "each extracted font has glyf, loca, head, maxp tables" do
+      with_woff2_collection do |path|
+        fonts = described_class.from_file(path).extract_fonts
+        fonts.each do |font|
+          %w[glyf loca head maxp].each do |tag|
+            expect(font.has_table?(tag)).to be(true),
+                                            "font should have #{tag}"
+          end
+        end
+      end
+    end
+
+    it "preserves glyph count from source" do
+      with_woff2_collection do |path|
+        fonts = described_class.from_file(path).extract_fonts
+        fonts.each do |font|
+          expect(font.table("maxp").num_glyphs).to be > 0
+        end
+      end
+    end
+  end
+
+  describe "#font" do
+    it "returns a single font by index" do
+      with_woff2_collection do |path|
+        collection = described_class.from_file(path)
+        font = collection.font(0)
+        expect(font).to be_a(Fontisan::TrueTypeFont)
+        expect(font.has_table?("glyf")).to be true
+      end
+    end
+
+    it "returns nil for out-of-range index" do
+      with_woff2_collection do |path|
+        expect(described_class.from_file(path).font(99)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/integration/woff2_collection_pipeline_spec.rb
+++ b/spec/integration/woff2_collection_pipeline_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe "WOFF2 collection conversion pipeline", type: :integration do
+  let(:ttc_path) { fixture_path("fonts/DinaRemasterII/DinaRemasterII.ttc") }
+
+  it "round-trips TTC → WOFF2 collection → TTC with all fonts preserved" do
+    Dir.mktmpdir do |dir|
+      woff2_path = File.join(dir, "intermediate.woff2")
+      ttc_out_path = File.join(dir, "round.ttc")
+
+      # Step 1: TTC → WOFF2 collection via CollectionConverter
+      converter = Fontisan::Converters::CollectionConverter.new
+      converter.convert(ttc_path, target_type: :woff2_collection,
+                                  options: { output: woff2_path })
+
+      expect(File.exist?(woff2_path)).to be(true)
+      expect(File.binread(woff2_path, 4)).to eq("wOF2")
+      # flavor field at bytes 4-7 = 'ttcf' = 0x74746366
+      expect(File.binread(woff2_path, 4, 4).unpack1("N")).to eq(0x74746366)
+
+      # Step 2: WOFF2 collection → TTC via CollectionConverter
+      converter.convert(woff2_path, target_type: :ttc,
+                                    options: { output: ttc_out_path })
+
+      expect(File.exist?(ttc_out_path)).to be(true)
+      # TTC tag at bytes 0-3 = 'ttcf'
+      expect(File.binread(ttc_out_path, 4)).to eq("ttcf")
+
+      # Round-trip preserved all fonts
+      decoded = Fontisan::FontLoader.load_collection(ttc_out_path)
+      expect(decoded.num_fonts).to eq(2)
+    end
+  end
+
+  it "detects WOFF2 collection files as collections" do
+    Dir.mktmpdir do |dir|
+      woff2_path = File.join(dir, "out.woff2")
+      fonts = File.open(ttc_path, "rb") do |io|
+        Fontisan::FontLoader.load_collection(ttc_path).extract_fonts(io)
+      end
+      bytes = Fontisan::Woff2::CollectionEncoder.new(brotli_quality: 11).encode_fonts(fonts)
+      File.binwrite(woff2_path, bytes)
+
+      expect(Fontisan::FontLoader.collection?(woff2_path)).to be(true)
+      expect(Fontisan::FontLoader.detect_format(woff2_path)).to eq(:woff2_collection)
+      expect(Fontisan::FontLoader.load_collection(woff2_path))
+        .to be_a(Fontisan::Woff2Collection)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes the WOFF2 collection gap documented in TODO.woff/4 and TODO.woff/5. Adds complete bidirectional support for WOFF2 font collections (flavor='ttcf') per W3C WOFF2 spec section 4.2.

### Workstream 1: `Woff2::CollectionDecoder`

New spec §4.2 reader. Parses the WOFF2 collection binary: 48-byte header, table directory, CollectionHeader + N CollectionFontEntry records, single brotli-compressed font data block. Reconstructs glyf/loca per font via `Woff2::GlyfLocaReconstruct` when the source had a transformed glyf.

### Workstream 2: `Fontisan::Woff2Collection` domain object

Peer of `TrueTypeCollection`/`OpenTypeCollection`. Wraps a WOFF2 collection file and exposes the `BaseCollection` interface (`num_fonts`, `font_offsets`, `extract_fonts`, `font`, `valid?`, `collection?`, `format`) so collection consumers don't need to know which container they hold.

### Workstream 3: `SfntBuilder` extracted (DRY)

New `Fontisan::SfntBuilder` module consolidates SFNT byte-layout logic (12-byte offset table + 16-byte directory entries + padded table data) into a single source of truth. Replaces inlined logic in `Woff2Font.build_sfnt_in_memory`.

### Workstream 4: Pipeline integration

- `FontLoader.detect` distinguishes `:woff2_collection` (flavor='ttcf') from `:woff2` (single font) via `scan_woff2` helper.
- `FontLoader.load_collection` accepts WOFF2 collections (added to `COLLECTION_CLASSES`).
- `CollectionConverter` supports `:woff2_collection` as both source and target.
- CLI: `fontisan convert X.ttc --to woff2` and `fontisan convert X.woff2 --to ttc` work end-to-end.
- `conversion_matrix.yml` gains 4 entries: ttc↔woff2_collection, otc↔woff2_collection.

## Architecture

- All new classes are siblings under `Woff2` namespace or `Fontisan` flat namespace (no nested classes).
- Uses Ruby autoload (no `require_relative`).
- No `send(:private_method)`, no `instance_variable_get/set`, no `respond_to?`.
- DRY: `SfntBuilder` is the single source of truth for SFNT layout, reused by both `Woff2Font` and `Woff2Collection`.

## End-to-end validation

```
$ fontisan convert DinaRemasterII.ttc --to woff2 --output out.woff2
Converting collection to WOFF2_COLLECTION...
Conversion complete!
  Output: out.woff2 (7.3 KB)
  Format: TTC → WOFF2_COLLECTION
  Fonts:  2

$ fontisan convert out.woff2 --to ttc --output round.ttc
Converting collection to TTC...
Conversion complete!
  Output: round.ttc (43.8 KB)
  Format: WOFF2_COLLECTION → TTC
  Fonts:  2
```

## Test plan

- [x] `bundle exec rspec` — 5955 examples, 0 failures (3 pre-existing pending)
- [x] `bundle exec rubocop` on touched files — clean
- [x] `Woff2::CollectionDecoder` round-trips our encoder's output
- [x] `Woff2Collection` exposes BaseCollection-compatible interface
- [x] SfntBuilder produces spec-correct SFNT binary
- [x] TTC → WOFF2 collection → TTC via CLI preserves all fonts
- [x] FontLoader detects WOFF2 collections correctly
- [ ] CI green on Ruby 3.3/3.4/4.0 × mac/linux/windows

## References

- WOFF2 spec section 4.2: https://www.w3.org/TR/WOFF2/#collection_dir_format
- TODO.woff/4-woff2-collection-decoder.md
- TODO.woff/5-pipeline-integration.md
