### PR TITLE
woff2: emit loca.origLength matching reconstructed short loca

### DIFF
--- a/lib/fontisan/converters/woff2_encoder.rb
+++ b/lib/fontisan/converters/woff2_encoder.rb
@@ -247,7 +247,12 @@ module Fontisan
           index_format: head.index_to_loc_format,
         ).transform
 
-        loca_orig_length = loca_data.bytesize
+        # The glyf transform always emits indexFormat=0 (Chrome OTS
+        # requirement), so the decoder reconstructs a short loca
+        # (2 bytes per offset). The directory's origLength must match
+        # the reconstructed size, not the source's bytesize — otherwise
+        # fontTools and Chrome's OTS reject the file for the size mismatch.
+        loca_orig_length = (maxp.num_glyphs + 1) * 2
         table_data.delete("loca")
 
         { transformed_glyf: transformed, loca_orig_length: }

--- a/spec/fontisan/converters/woff2_ots_rejection_spec.rb
+++ b/spec/fontisan/converters/woff2_ots_rejection_spec.rb
@@ -128,6 +128,36 @@ RSpec.describe Fontisan::Converters::Woff2Encoder do
       end
     end
 
+    it "emits loca.origLength matching the reconstructed short loca size" do
+      # The glyf transform always emits indexFormat=0, so the decoder
+      # reconstructs a short loca (2 bytes per offset). The directory's
+      # loca.origLength must match that reconstructed size, not the source
+      # font's loca bytesize — otherwise fontTools and Chrome's OTS reject
+      # the file for the loca size mismatch.
+      long_loca_ttf = fixture_path(
+        "fonts/Libertinus/Libertinus-7.051/static/TTF/LibertinusKeyboard-Regular.ttf"
+      )
+      skip "long-loca fixture missing" unless File.exist?(long_loca_ttf)
+
+      source = Fontisan::FontLoader.load(long_loca_ttf)
+      skip "fixture is not long-loca" unless source.table("head").index_to_loc_format == 1
+
+      woff2 = encode_to_woff2(long_loca_ttf)
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out.woff2")
+        File.binwrite(path, woff2)
+
+        loca_entry = Fontisan::Woff2Font.from_file(path).table_entries
+          .find { |e| e.tag == "loca" }
+        num_glyphs = source.table("maxp").num_glyphs
+        expected = (num_glyphs + 1) * 2
+        expect(loca_entry.orig_length).to eq(expected),
+                                          "loca.origLength must match the reconstructed short loca " \
+                                          "(numGlyphs+1)*2=#{expected}, got #{loca_entry.orig_length}; " \
+                                          "Chrome OTS rejects size mismatch"
+      end
+    end
+
     it "places loca immediately after glyf in the table directory" do
       woff2 = encode_to_woff2(input_ttf)
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
## Problem

`Woff2Encoder#apply_glyf_loca_transform!` set the synthetic `loca` directory entry's `origLength` to the source font's loca bytesize. For long-loca sources (`head.indexToLocFormat=1`, e.g. LibertinusKeyboard, NotoSans, the Essenfont TTC) that's twice the size of the short loca the decoder actually reconstructs (the glyf transform always emits `indexFormat=0` per the Chrome OTS requirement in 5f7e32d).

The size mismatch causes fontTools to throw on decode:

```
TTLibError: reconstructed 'loca' table doesn't match original size:
expected 324, found 162
```

Chrome's OTS rejects the file silently.

## Fix

`lib/fontisan/woff2/glyf_loca_transform.rb:243` already passes the source's `index_format` for parsing source loca offsets, and `assemble` hardcodes `indexFormat=0` in the output header. The encoder's `loca_orig_length` now matches that output: `(numGlyphs + 1) * 2`.

## Spec

New example in `spec/fontisan/converters/woff2_ots_rejection_spec.rb` encodes the LibertinusKeyboard fixture (`indexToLocFormat=1`) and asserts `loca.origLength == (numGlyphs + 1) * 2`.

All 11 OTS rejection specs pass.

## Repro (before fix)

```ruby
font = Fontisan::FontLoader.load("spec/fixtures/fonts/Libertinus/Libertinus-7.051/static/TTF/LibertinusKeyboard-Regular.ttf")
woff2 = Fontisan::Converters::Woff2Encoder.new.convert(font, brotli_quality: 11)[:woff2_binary]
File.binwrite("/tmp/out.woff2", woff2)
```

```python
from fontTools.ttLib import TTFont
TTFont("/tmp/out.woff2")
# TTLibError: reconstructed 'loca' table doesn't match original size
```
