### PR TITLE
woff2: fix 255UInt16 encoding — single source of truth (UInt255 module)

### DIFF
--- a/lib/fontisan/converters/woff2_encoder.rb
+++ b/lib/fontisan/converters/woff2_encoder.rb
@@ -227,6 +227,12 @@ module Fontisan
       # are kept in `table_data` so its `origLength` is preserved; the
       # transformed bytes are passed to the entries builder separately.
       #
+      # glyf.origLength is computed by round-tripping the transformed glyf
+      # through the decoder — this guarantees the directory matches what
+      # any compliant decoder will produce, including padding and minor
+      # re-encoding differences (OFF section 5.3.3 allows multiple valid
+      # reconstructions of the same glyph data).
+      #
       # @return [Hash{Symbol => Object}, nil]
       def apply_glyf_loca_transform!(table_data, font)
         return nil unless font.respond_to?(:has_table?)
@@ -240,22 +246,32 @@ module Fontisan
         head = font.table("head")
         return nil unless maxp && head
 
+        index_format = head.index_to_loc_format
+
         transformed = Woff2::GlyfLocaTransform.new(
           glyf_data:,
           loca_data:,
           num_glyphs: maxp.num_glyphs,
-          index_format: head.index_to_loc_format,
+          index_format:,
         ).transform
 
-        # The glyf transform always emits indexFormat=0 (Chrome OTS
-        # requirement), so the decoder reconstructs a short loca
-        # (2 bytes per offset). The directory's origLength must match
-        # the reconstructed size, not the source's bytesize — otherwise
-        # fontTools and Chrome's OTS reject the file for the size mismatch.
-        loca_orig_length = (maxp.num_glyphs + 1) * 2
+        # Round-trip through the decoder to get the exact reconstructed
+        # sizes the directory must advertise. fontTools re-compiles glyf
+        # during encoding, producing sizes that differ from the source by
+        # small amounts (encoding variations per OFF section 5.3.3). Using
+        # the source bytesize causes fontTools' decoder to reject the
+        # WOFF2 with "not enough 'glyf' table data".
+        reconstructed = Woff2::GlyfLocaReconstruct.new(
+          transformed_glyf: transformed,
+          num_glyphs: maxp.num_glyphs,
+          index_format:,
+        ).reconstruct
+
+        glyf_orig_length = reconstructed[:glyf].bytesize
+        loca_orig_length = reconstructed[:loca].bytesize
         table_data.delete("loca")
 
-        { transformed_glyf: transformed, loca_orig_length: }
+        { transformed_glyf: transformed, glyf_orig_length:, loca_orig_length: }
       end
 
       def get_table_data(font, tag)
@@ -282,7 +298,7 @@ module Fontisan
 
         table_data.keys.sort.each do |tag|
           if tag == "glyf" && glyf_transform
-            entries << build_glyf_entry(table_data["glyf"],
+            entries << build_glyf_entry(glyf_transform[:glyf_orig_length],
                                         glyf_transform[:transformed_glyf])
             entries << build_loca_entry(glyf_transform[:loca_orig_length])
             transformed_data["glyf"] = glyf_transform[:transformed_glyf]
@@ -319,13 +335,13 @@ module Fontisan
         entry
       end
 
-      # Build the glyf directory entry. origLength is the original (input)
-      # glyf size; transformLength is the size of the WOFF2-transformed
-      # glyf stream per spec section 5.1.
-      def build_glyf_entry(orig_data, transformed_data)
+      # Build the glyf directory entry. origLength is the reconstructed
+      # glyf size (what a decoder will produce); transformLength is the
+      # size of the WOFF2-transformed glyf stream per spec section 5.1.
+      def build_glyf_entry(glyf_orig_length, transformed_data)
         entry = Woff2::Directory::Entry.new
         entry.tag = "glyf"
-        entry.orig_length = orig_data.bytesize
+        entry.orig_length = glyf_orig_length
         entry.transform_length = transformed_data.bytesize
         entry.flags = entry.calculate_flags
         entry

--- a/lib/fontisan/converters/woff2_encoder.rb
+++ b/lib/fontisan/converters/woff2_encoder.rb
@@ -247,7 +247,12 @@ module Fontisan
           index_format: head.index_to_loc_format,
         ).transform
 
-        loca_orig_length = loca_data.bytesize
+        # The glyf transform always emits indexFormat=0 (Chrome OTS
+        # requirement), so the decoder reconstructs a short loca
+        # (2 bytes per offset). The directory's origLength must match
+        # the reconstructed size, not the source's bytesize — otherwise
+        # fontTools and Chrome's OTS reject the file for the size mismatch.
+        loca_orig_length = (maxp.num_glyphs + 1) * 2
         table_data.delete("loca")
 
         { transformed_glyf: transformed, loca_orig_length: }

--- a/lib/fontisan/woff2.rb
+++ b/lib/fontisan/woff2.rb
@@ -13,6 +13,7 @@ module Fontisan
     autoload :HmtxTransformer, "fontisan/woff2/hmtx_transformer"
     autoload :TableTransformer, "fontisan/woff2/table_transformer"
     autoload :TripletCodec, "fontisan/woff2/triplet_codec"
+    autoload :UInt255, "fontisan/woff2/uint255"
     autoload :Woff2Header, "fontisan/woff2/header"
   end
 end

--- a/lib/fontisan/woff2/collection_decoder.rb
+++ b/lib/fontisan/woff2/collection_decoder.rb
@@ -133,14 +133,14 @@ module Fontisan
         pos += 4
         raise InvalidFontError, "Unsupported CollectionHeader version 0x#{version.to_s(16)}" unless version == 0x00010000
 
-        num_fonts, pos = read_255_uint16(pos)
+        num_fonts, pos = UInt255.decode_at(@data, pos)
         font_entries = Array.new(num_fonts) do
-          num_tables_f, pos2 = read_255_uint16(pos)
+          num_tables_f, pos2 = UInt255.decode_at(@data, pos)
           pos = pos2
           flavor = @data[pos, 4].unpack1("N")
           pos += 4
           indices = Array.new(num_tables_f) do
-            idx, pos2 = read_255_uint16(pos)
+            idx, pos2 = UInt255.decode_at(@data, pos)
             pos = pos2
             idx
           end
@@ -200,26 +200,6 @@ module Fontisan
           value = (value << 7) | (byte & 0x7F)
         end
         raise InvalidFontError, "UIntBase128 sequence exceeds 5 bytes"
-      end
-
-      def read_255_uint16(pos)
-        code = @data.getbyte(pos)
-        pos += 1
-        case code
-        when 0..252 then [code, pos]
-        when 253
-          v = @data.getbyte(pos)
-          pos += 1
-          [253 + v, pos]
-        when 254
-          v = @data[pos, 2].unpack1("n")
-          pos += 2
-          [v, pos]
-        when 255
-          v = @data[pos, 2].unpack1("n")
-          pos += 2
-          [v + 506, pos]
-        end
       end
     end
   end

--- a/lib/fontisan/woff2/collection_encoder.rb
+++ b/lib/fontisan/woff2/collection_encoder.rb
@@ -238,7 +238,7 @@ module Fontisan
       def write_collection_directory(io, fonts, font_to_ckeys, ckey_to_index)
         # CollectionHeader
         io.write([0x00010000].pack("N")) # version 1.0
-        io.write(encode_255_uint16(fonts.size))
+        io.write(UInt255.encode(fonts.size))
 
         # One CollectionFontEntry per font
         fonts.each_with_index do |font, fi|
@@ -254,12 +254,12 @@ module Fontisan
           ordered << "loca" if has_placeholder
           ordered = ordered.sort
 
-          io.write(encode_255_uint16(ordered.size))
+          io.write(UInt255.encode(ordered.size))
           io.write([font_flavor(font)].pack("N"))
           ordered.each do |tag|
             ckey = font_keys[tag] || placeholder_key
             index = ckey_to_index.fetch(ckey)
-            io.write(encode_255_uint16(index))
+            io.write(UInt255.encode(index))
           end
         end
       end
@@ -269,18 +269,6 @@ module Fontisan
           Constants::SFNT_VERSION_OTTO
         else
           Constants::SFNT_VERSION_TRUETYPE
-        end
-      end
-
-      def encode_255_uint16(value)
-        if value < 253
-          [value].pack("C")
-        elsif value < 506
-          [253, value - 253].pack("CC")
-        elsif value < 65_536
-          [254].pack("C") + [value].pack("n")
-        else
-          [255].pack("C") + [value - 506].pack("n")
         end
       end
     end

--- a/lib/fontisan/woff2/directory.rb
+++ b/lib/fontisan/woff2/directory.rb
@@ -235,48 +235,20 @@ module Fontisan
         raise Fontisan::Error, "Invalid UIntBase128 encoding"
       end
 
-      # Encode 255UInt16 value
-      #
-      # Used in transformed glyf table:
-      # - 0-252: value itself (1 byte)
-      # - 253: next byte + 253 (2 bytes)
-      # - 254: next 2 bytes as big-endian (3 bytes)
-      # - 255: next 2 bytes + 506 (3 bytes)
+      # Encode 255UInt16. Delegates to {UInt255} (single source of truth).
       #
       # @param value [Integer] Value to encode (0-65535)
       # @return [String] Binary encoded data
       def self.encode_255_uint16(value)
-        if value < 253
-          [value].pack("C")
-        elsif value < 506
-          [253, value - 253].pack("C*")
-        elsif value < 65536
-          [254].pack("C") + [value].pack("n")
-        else
-          [255].pack("C") + [value - 506].pack("n")
-        end
+        UInt255.encode(value)
       end
 
-      # Decode 255UInt16 from IO
+      # Decode 255UInt16 from IO. Delegates to {UInt255}.
       #
       # @param io [IO] Input stream
       # @return [Integer] Decoded value
       def self.decode_255_uint16(io)
-        first = io.read(1)&.unpack1("C")
-        return nil unless first
-
-        case first
-        when 0..252
-          first
-        when 253
-          second = io.read(1)&.unpack1("C")
-          253 + second
-        when 254
-          io.read(2)&.unpack1("n")
-        when 255
-          value = io.read(2)&.unpack1("n")
-          value + 506
-        end
+        UInt255.decode(io)
       end
     end
   end

--- a/lib/fontisan/woff2/encoder_rules.rb
+++ b/lib/fontisan/woff2/encoder_rules.rb
@@ -52,12 +52,6 @@ module Fontisan
       # the 'flags' field of the head table ... to indicate that a recreated
       # font file was subjected to lossless modifying transform."
       #
-      # Also forces head.indexToLocFormat=0 when the glyf/loca tables are
-      # transformed, because Chrome's OTS only accepts WOFF2 glyf
-      # indexFormat=0 (see GlyfLocaTransform). For the reconstructed font
-      # to be self-consistent, head.indexToLocFormat must match the loca
-      # format that the decoder will produce (always short, format=0).
-      #
       # Uses the model-driven Head BinData record so the bits are set via a
       # named attribute on a typed object, not via raw byte slicing.
       def self.mark_lossless_modifying!(table_data)
@@ -65,7 +59,6 @@ module Fontisan
 
         head = Tables::Head.read(table_data["head"])
         head.flags |= Tables::Head::FLAG_LOSSLESS_MODIFYING
-        head.index_to_loc_format = 0
         table_data["head"] = head.to_binary_s
       end
     end

--- a/lib/fontisan/woff2/glyf_loca_reconstruct.rb
+++ b/lib/fontisan/woff2/glyf_loca_reconstruct.rb
@@ -143,7 +143,7 @@ module Fontisan
         end_pts = []
         cumulative = -1
         num_contours.times do
-          pts_of_contour = read_255_uint16(streams[:n_points])
+          pts_of_contour = UInt255.decode(streams[:n_points])
           cumulative += pts_of_contour
           end_pts << cumulative
         end
@@ -169,7 +169,7 @@ module Fontisan
         end
 
         # Step 4-5: read instructionLength from glyphStream, bytes from instructionStream.
-        inst_len = read_255_uint16(streams[:glyph])
+        inst_len = UInt255.decode(streams[:glyph])
         instructions = streams[:instructions].read(inst_len)
 
         # Bbox: emit explicit bbox if bboxBitmap bit is set for this glyph,
@@ -209,7 +209,7 @@ module Fontisan
 
         instructions = String.new(encoding: Encoding::BINARY)
         if have_instructions
-          inst_len = read_255_uint16(streams[:glyph])
+          inst_len = UInt255.decode(streams[:glyph])
           instructions = streams[:instructions].read(inst_len)
         end
 
@@ -250,26 +250,6 @@ module Fontisan
                   end
         bytes = io.read(n_bytes)
         bytes ? bytes.bytes : Array.new(n_bytes, 0)
-      end
-
-      def read_255_uint16(io)
-        return 0 if io.eof?
-
-        code = io.read(1)&.unpack1("C")
-        return 0 unless code
-
-        case code
-        when 0..252 then code
-        when 253
-          b = io.read(1)&.unpack1("C") || 0
-          253 + b
-        when 254
-          io.read(2)&.unpack1("n") || 0
-
-        when 255
-          v = io.read(2)&.unpack1("n") || 0
-          v + 506
-        end
       end
 
       def read_uint16_io(io)

--- a/lib/fontisan/woff2/glyf_loca_transform.rb
+++ b/lib/fontisan/woff2/glyf_loca_transform.rb
@@ -127,7 +127,7 @@ module Fontisan
         # nPoints stream: per-contour point counts (NOT endPtsOfContours).
         prev_end = -1
         end_pts.each do |ep|
-          s.n_points << encode_255_uint16(ep - prev_end)
+          s.n_points << UInt255.encode(ep - prev_end)
           prev_end = ep
         end
 
@@ -157,7 +157,7 @@ module Fontisan
         end
 
         # glyphStream carries per-glyph instructionLength; bytes go to instructionStream
-        s.glyph << encode_255_uint16(instructions.bytesize)
+        s.glyph << UInt255.encode(instructions.bytesize)
         s.instructions << instructions
 
         # Spec: simple glyphs omit bbox when it matches calculated bounds.
@@ -191,7 +191,7 @@ module Fontisan
         if have_instructions
           inst_len = io.read(2).unpack1("n")
           instructions = io.read(inst_len)
-          s.glyph << encode_255_uint16(instructions.bytesize)
+          s.glyph << UInt255.encode(instructions.bytesize)
           s.instructions << instructions
         end
 
@@ -312,18 +312,6 @@ module Fontisan
         return nil if xs.empty?
 
         [xs.min, ys.min, xs.max, ys.max]
-      end
-
-      def encode_255_uint16(value)
-        if value < 253
-          [value].pack("C")
-        elsif value < 506
-          [253, value - 253].pack("CC")
-        elsif value < 65_536
-          [254].pack("C") + [value].pack("n")
-        else
-          [255].pack("C") + [value - 506].pack("n")
-        end
       end
     end
   end

--- a/lib/fontisan/woff2/glyf_loca_transform.rb
+++ b/lib/fontisan/woff2/glyf_loca_transform.rb
@@ -255,10 +255,11 @@ module Fontisan
         out << [0].pack("S>")                                  # version
         out << [(s.has_overlap? ? 1 : 0)].pack("S>")           # optionFlags
         out << [@num_glyphs].pack("S>")
-        # Always emit indexFormat=0 per Chrome OTS requirement. WOFF2 spec
-        # section 5.1 allows the source's indexToLocFormat, but Chrome's
-        # OTS silently rejects any value other than 0.
-        out << [0].pack("S>")
+        # Emit the source's indexFormat. The earlier "always 0" override
+        # (commit 5f7e32d) was based on a misdiagnosis — Chrome's OTS
+        # accepts both 0 and 1, but short loca (0) can't address glyf
+        # offsets > 0x20000 bytes, so large fonts MUST use 1.
+        out << [@source_index_format].pack("S>")
         out << [s.n_contour.bytesize].pack("L>")
         out << [s.n_points.bytesize].pack("L>")
         out << [s.flags.bytesize].pack("L>")

--- a/lib/fontisan/woff2/hmtx_transformer.rb
+++ b/lib/fontisan/woff2/hmtx_transformer.rb
@@ -46,7 +46,7 @@ glyf_lsbs = nil)
         if (flags & HMTX_FLAG_EXPLICIT_ADVANCE_WIDTHS).zero?
           # Proportional encoding - read deltas
           # First advance width is explicit
-          first_advance = read_255_uint16(io)
+          first_advance = UInt255.decode(io)
           advance_widths << first_advance
 
           # Remaining are deltas from previous
@@ -57,7 +57,7 @@ glyf_lsbs = nil)
         else
           # Explicit advance widths in transformed format
           num_h_metrics.times do
-            advance_widths << read_255_uint16(io)
+            advance_widths << UInt255.decode(io)
           end
         end
 
@@ -86,31 +86,6 @@ glyf_lsbs = nil)
 
         # Build standard hmtx table
         build_hmtx_table(advance_widths, lsbs, num_h_metrics, num_glyphs)
-      end
-
-      # Read variable-length 255UInt16 integer
-      #
-      # Format from WOFF2 spec:
-      # - value < 253: one byte
-      # - value == 253: 253 + next uint16
-      # - value == 254: 253 * 2 + next uint16
-      # - value == 255: 253 * 3 + next uint16
-      #
-      # @param io [StringIO] Input stream
-      # @return [Integer] Decoded value
-      def self.read_255_uint16(io)
-        code = read_uint8(io)
-
-        case code
-        when 255
-          759 + read_uint16(io)  # 253 * 3 + value
-        when 254
-          506 + read_uint16(io)  # 253 * 2 + value
-        when 253
-          253 + read_uint16(io)
-        else
-          code
-        end
       end
 
       # Build standard hmtx table format

--- a/lib/fontisan/woff2/table_transformer.rb
+++ b/lib/fontisan/woff2/table_transformer.rb
@@ -401,7 +401,7 @@ num_glyphs)
 
         # Write advance widths using proportional encoding
         # First advance width is explicit
-        data << encode_255_uint16(advance_widths[0])
+        data << UInt255.encode(advance_widths[0])
 
         # Remaining advance widths as deltas
         (1...num_h_metrics).each do |i|
@@ -473,7 +473,7 @@ num_glyphs)
             prev_pt = -1
             glyph[:end_pts].each do |pt|
               delta = pt - prev_pt - 1
-              n_points_stream << encode_255_uint16(delta)
+              n_points_stream << UInt255.encode(delta)
               prev_pt = pt
             end
 
@@ -488,7 +488,7 @@ num_glyphs)
             glyph[:bbox].each { |v| bbox_stream << [v].pack("n") }
 
             # Write instructions
-            instruction_stream << encode_255_uint16(glyph[:instructions].bytesize)
+            instruction_stream << UInt255.encode(glyph[:instructions].bytesize)
             instruction_stream << glyph[:instructions] if glyph[:instructions].bytesize.positive?
 
           when :composite
@@ -566,22 +566,6 @@ num_glyphs)
                     end
 
           prev = coord
-        end
-      end
-
-      # Encode 255UInt16 value
-      #
-      # @param value [Integer] Value to encode
-      # @return [String] Encoded bytes
-      def encode_255_uint16(value)
-        if value < 253
-          [value].pack("C")
-        elsif value < 506
-          [253, value - 253].pack("CC")
-        elsif value < 65536
-          [254].pack("C") + [value].pack("n")
-        else
-          [255].pack("C") + [value - 506].pack("n")
         end
       end
 

--- a/lib/fontisan/woff2/uint255.rb
+++ b/lib/fontisan/woff2/uint255.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Fontisan
+  module Woff2
+    # 255UInt16 variable-length encoding per WOFF2 spec section 3.1.
+    #
+    # Single source of truth for encoding and decoding this data type. All
+    # other WOFF2 code MUST delegate to this module — the previous inline
+    # copies had the code-byte mapping inverted for values ≥ 253.
+    #
+    # Encoding table (per W3C spec pseudocode):
+    #
+    #   value range     | encoding              | bytes
+    #   ----------------|-----------------------|------
+    #   0 .. 252        | literal              | 1
+    #   253 .. 505      | code 255 + (v - 253) | 2
+    #   506 .. 761      | code 254 + (v - 506) | 2
+    #   762 .. 65535    | code 253 + uint16    | 3
+    #
+    # Decoding (inverse):
+    #
+    #   code byte | meaning
+    #   ----------|--------------------------------
+    #   0 .. 252  | literal value
+    #   253       | read uint16 → value
+    #   254       | read 1 byte → value + 506
+    #   255       | read 1 byte → value + 253
+    module UInt255
+      WORD_CODE = 253
+      ONE_MORE_BYTE_CODE1 = 255 # adds 253
+      ONE_MORE_BYTE_CODE2 = 254 # adds 506
+
+      MAX_VALUE = 65_535
+
+      # Encode a value (0..65535) into a 1-3 byte binary string.
+      #
+      # @param value [Integer]
+      # @return [String] binary-encoded bytes
+      # @raise [ArgumentError] if value is out of range
+      def self.encode(value)
+        case value
+        when 0..252
+          [value].pack("C")
+        when 253..505
+          [ONE_MORE_BYTE_CODE1, value - 253].pack("C*")
+        when 506..761
+          [ONE_MORE_BYTE_CODE2, value - 506].pack("C*")
+        when 762..MAX_VALUE
+          [WORD_CODE].pack("C") + [value].pack("n")
+        else
+          raise ArgumentError,
+                "255UInt16 requires 0 <= value <= #{MAX_VALUE}, got #{value}"
+        end
+      end
+
+      # Decode a 255UInt16 value from an IO stream. Reads 1-3 bytes.
+      #
+      # @param io [IO, StringIO] input stream positioned at the code byte
+      # @return [Integer, nil] decoded value, or nil if the stream is empty
+      def self.decode(io)
+        code = io.read(1)&.unpack1("C")
+        return nil unless code
+
+        case code
+        when 0..252
+          code
+        when WORD_CODE
+          io.read(2)&.unpack1("n")
+        when ONE_MORE_BYTE_CODE2
+          506 + (io.read(1)&.unpack1("C") || 0)
+        when ONE_MORE_BYTE_CODE1
+          253 + (io.read(1)&.unpack1("C") || 0)
+        end
+      end
+
+      # Decode from a binary String at a given position. Returns the value
+      # and the new cursor position. Used by callers that index into a
+      # flat String rather than wrapping it in a StringIO.
+      #
+      # @param data [String] binary data
+      # @param pos [Integer] byte offset of the code byte
+      # @return [Array(Integer, Integer)] [value, new_pos]
+      def self.decode_at(data, pos)
+        code = data.getbyte(pos)
+        pos += 1
+        case code
+        when 0..252
+          [code, pos]
+        when WORD_CODE
+          [data[pos, 2].unpack1("n"), pos + 2]
+        when ONE_MORE_BYTE_CODE2
+          [506 + data.getbyte(pos), pos + 1]
+        when ONE_MORE_BYTE_CODE1
+          [253 + data.getbyte(pos), pos + 1]
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/woff2_font.rb
+++ b/lib/fontisan/woff2_font.rb
@@ -732,22 +732,6 @@ module Fontisan
       self.class.read_uint_base128_from_io(io)
     end
 
-    # Read 255UInt16 variable-length integer
-    def read_255_uint16(io)
-      code = io.read(1).unpack1("C")
-
-      case code
-      when 0..252
-        code
-      when 253
-        253 + io.read(1).unpack1("C")
-      when 254
-        io.read(2).unpack1("n")
-      when 255
-        io.read(2).unpack1("n") + 506
-      end
-    end
-
     # Calculate offset table fields
     def calculate_offset_table_fields(num_tables)
       entry_selector = (Math.log(num_tables) / Math.log(2)).floor

--- a/spec/fontisan/converters/woff2_ots_rejection_spec.rb
+++ b/spec/fontisan/converters/woff2_ots_rejection_spec.rb
@@ -128,6 +128,36 @@ RSpec.describe Fontisan::Converters::Woff2Encoder do
       end
     end
 
+    it "emits loca.origLength matching the reconstructed short loca size" do
+      # The glyf transform always emits indexFormat=0, so the decoder
+      # reconstructs a short loca (2 bytes per offset). The directory's
+      # loca.origLength must match that reconstructed size, not the source
+      # font's loca bytesize — otherwise fontTools and Chrome's OTS reject
+      # the file for the loca size mismatch.
+      long_loca_ttf = fixture_path(
+        "fonts/Libertinus/Libertinus-7.051/static/TTF/LibertinusKeyboard-Regular.ttf"
+      )
+      skip "long-loca fixture missing" unless File.exist?(long_loca_ttf)
+
+      source = Fontisan::FontLoader.load(long_loca_ttf)
+      skip "fixture is not long-loca" unless source.table("head").index_to_loc_format == 1
+
+      woff2 = encode_to_woff2(long_loca_ttf)
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out.woff2")
+        File.binwrite(path, woff2)
+
+        loca_entry = Fontisan::Woff2Font.from_file(path).table_entries
+          .find { |e| e.tag == "loca" }
+        num_glyphs = source.table("maxp").num_glyphs
+        expected = (num_glyphs + 1) * 2
+        expect(loca_entry.orig_length).to eq(expected),
+                                          "loca.origLength must match the reconstructed short loca " \
+                                          "(numGlyphs+1)*2=#{expected}, got #{loca_entry.orig_length}; " \
+                                          "Chrome OTS rejects size mismatch"
+      end
+    end
+
     it "places loca immediately after glyf in the table directory" do
       woff2 = encode_to_woff2(input_ttf)
       Dir.mktmpdir do |dir|

--- a/spec/fontisan/converters/woff2_ots_rejection_spec.rb
+++ b/spec/fontisan/converters/woff2_ots_rejection_spec.rb
@@ -128,14 +128,14 @@ RSpec.describe Fontisan::Converters::Woff2Encoder do
       end
     end
 
-    it "emits loca.origLength matching the reconstructed short loca size" do
-      # The glyf transform always emits indexFormat=0, so the decoder
-      # reconstructs a short loca (2 bytes per offset). The directory's
-      # loca.origLength must match that reconstructed size, not the source
-      # font's loca bytesize — otherwise fontTools and Chrome's OTS reject
-      # the file for the loca size mismatch.
+    it "emits loca.origLength matching the reconstructed loca size" do
+      # The glyf transform preserves the source's indexFormat, so the
+      # decoder reconstructs loca in that format. The directory's
+      # loca.origLength must match the reconstructed size — otherwise
+      # fontTools and Chrome's OTS reject the file for the loca size
+      # mismatch.
       long_loca_ttf = fixture_path(
-        "fonts/Libertinus/Libertinus-7.051/static/TTF/LibertinusKeyboard-Regular.ttf"
+        "fonts/Libertinus/Libertinus-7.051/static/TTF/LibertinusKeyboard-Regular.ttf",
       )
       skip "long-loca fixture missing" unless File.exist?(long_loca_ttf)
 
@@ -150,11 +150,12 @@ RSpec.describe Fontisan::Converters::Woff2Encoder do
         loca_entry = Fontisan::Woff2Font.from_file(path).table_entries
           .find { |e| e.tag == "loca" }
         num_glyphs = source.table("maxp").num_glyphs
-        expected = (num_glyphs + 1) * 2
+        index_format = source.table("head").index_to_loc_format
+        bytes_per_entry = index_format.zero? ? 2 : 4
+        expected = (num_glyphs + 1) * bytes_per_entry
         expect(loca_entry.orig_length).to eq(expected),
-                                          "loca.origLength must match the reconstructed short loca " \
-                                          "(numGlyphs+1)*2=#{expected}, got #{loca_entry.orig_length}; " \
-                                          "Chrome OTS rejects size mismatch"
+                                          "loca.origLength must match the reconstructed loca " \
+                                          "(numGlyphs+1)*#{bytes_per_entry}=#{expected}, got #{loca_entry.orig_length}"
       end
     end
 

--- a/spec/fontisan/woff2/directory_spec.rb
+++ b/spec/fontisan/woff2/directory_spec.rb
@@ -108,10 +108,10 @@ RSpec.describe Fontisan::Woff2::Directory do
       expect(encoded.bytesize).to eq(1)
     end
 
-    it "encodes 253 in 2 bytes" do
+    it "encodes 253 in 2 bytes (code 255 + 0)" do
       encoded = described_class.encode_255_uint16(253)
       expect(encoded.bytesize).to eq(2)
-      expect(encoded.unpack("C*")).to eq([253, 0])
+      expect(encoded.unpack("C*")).to eq([255, 0])
     end
 
     it "encodes values 253-505 in 2 bytes" do

--- a/spec/fontisan/woff2/glyf_loca_transform_spec.rb
+++ b/spec/fontisan/woff2/glyf_loca_transform_spec.rb
@@ -30,14 +30,13 @@ RSpec.describe Fontisan::Woff2::GlyfLocaTransform do
       version, option_flags, num_glyphs, index_format = result[0, 8].unpack("S>S>S>S>")
       expect(version).to eq(0)
       expect(num_glyphs).to eq(6)
-      # Encoder always emits indexFormat=0 per Chrome OTS requirement
-      # (WOFF2 spec section 5.1 allows the source's indexToLocFormat, but
-      # Chrome silently rejects any value other than 0).
-      expect(index_format).to eq(0)
+      # indexFormat matches the source head.indexToLocFormat per WOFF2
+      # spec section 5.1. Chrome OTS accepts both 0 and 1.
+      expect(index_format).to eq(font.table("head").index_to_loc_format)
       expect(option_flags).to eq(0) # TestTTF has no OVERLAP_SIMPLE glyphs
     end
 
-    it "emits indexFormat=0 even when source head.indexToLocFormat=1 (Chrome OTS requirement)" do
+    it "preserves source head.indexToLocFormat in the glyf transform header" do
       long_loca_path = fixture_path("fonts/Libertinus/Libertinus-7.051/static/TTF/LibertinusKeyboard-Regular.ttf")
       long_loca_font = Fontisan::FontLoader.load(long_loca_path)
       skip "long-loca fixture missing" unless long_loca_font.table("head").index_to_loc_format == 1
@@ -50,8 +49,8 @@ RSpec.describe Fontisan::Woff2::GlyfLocaTransform do
       ).transform
 
       _, _, _, index_format = transformed[0, 8].unpack("S>S>S>S>")
-      expect(index_format).to eq(0),
-                              "WOFF2 glyf transform header indexFormat must always be 0 (Chrome OTS rejects others)"
+      expect(index_format).to eq(1),
+                              "glyf transform header should preserve source indexToLocFormat (1 for long loca)"
     end
 
     it "writes 7 stream size prefixes after the header" do

--- a/spec/fontisan/woff2/hmtx_transformer_spec.rb
+++ b/spec/fontisan/woff2/hmtx_transformer_spec.rb
@@ -3,33 +3,6 @@
 require "spec_helper"
 
 RSpec.describe Fontisan::Woff2::HmtxTransformer do
-  describe ".read_255_uint16" do
-    it "reads single-byte values (< 253)" do
-      io = StringIO.new([100].pack("C"))
-      expect(described_class.send(:read_255_uint16, io)).to eq(100)
-    end
-
-    it "reads code 253 format (253 + uint16)" do
-      io = StringIO.new([253, 100].pack("Cn"))
-      expect(described_class.send(:read_255_uint16, io)).to eq(353)  # 253 + 100
-    end
-
-    it "reads code 254 format (506 + uint16)" do
-      io = StringIO.new([254, 100].pack("Cn"))
-      expect(described_class.send(:read_255_uint16, io)).to eq(606)  # 253*2 + 100
-    end
-
-    it "reads code 255 format (759 + uint16)" do
-      io = StringIO.new([255, 100].pack("Cn"))
-      expect(described_class.send(:read_255_uint16, io)).to eq(859)  # 253*3 + 100
-    end
-
-    it "handles maximum single-byte value (252)" do
-      io = StringIO.new([252].pack("C"))
-      expect(described_class.send(:read_255_uint16, io)).to eq(252)
-    end
-  end
-
   describe ".build_hmtx_table" do
     it "builds standard hmtx table with full metrics" do
       advance_widths = [500, 600, 700]

--- a/spec/fontisan/woff2/uint255_spec.rb
+++ b/spec/fontisan/woff2/uint255_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "stringio"
+
+RSpec.describe Fontisan::Woff2::UInt255 do
+  describe ".encode / .decode round-trip" do
+    boundary_values = [0, 1, 100, 252, 253, 254, 300, 505, 506, 507, 600,
+                       761, 762, 763, 1000, 5000, 65_535]
+
+    boundary_values.each do |v|
+      it "round-trips #{v}" do
+        encoded = described_class.encode(v)
+        decoded = described_class.decode(StringIO.new(encoded))
+        expect(decoded).to eq(v)
+      end
+    end
+
+    it "round-trips every value 250..260 (boundary between literal and multi-byte)" do
+      (250..260).each do |v|
+        encoded = described_class.encode(v)
+        decoded = described_class.decode(StringIO.new(encoded))
+        expect(decoded).to eq(v), "value #{v} encoded as #{encoded.unpack1('H*')} decoded as #{decoded}"
+      end
+    end
+
+    it "round-trips every value 503..510 (boundary between code 255 and 254)" do
+      (503..510).each do |v|
+        encoded = described_class.encode(v)
+        decoded = described_class.decode(StringIO.new(encoded))
+        expect(decoded).to eq(v), "value #{v} failed"
+      end
+    end
+
+    it "round-trips every value 759..765 (boundary between code 254 and 253)" do
+      (759..765).each do |v|
+        encoded = described_class.encode(v)
+        decoded = described_class.decode(StringIO.new(encoded))
+        expect(decoded).to eq(v), "value #{v} failed"
+      end
+    end
+  end
+
+  describe ".encode — matches fontTools byte-for-byte" do
+    # fontTools pack255UShort docstring examples
+    it "encodes 252 as single byte 0xFC" do
+      expect(described_class.encode(252).unpack1("H*")).to eq("fc")
+    end
+
+    it "encodes 506 as code 254 + byte 0 (2 bytes)" do
+      expect(described_class.encode(506).unpack1("H*")).to eq("fe00")
+    end
+
+    it "encodes 762 as code 253 + uint16 (3 bytes)" do
+      expect(described_class.encode(762).unpack1("H*")).to eq("fd02fa")
+    end
+
+    # Specific variant ranges per spec
+    it "uses code 255 (1 byte + 253) for values 253..505" do
+      expect(described_class.encode(253).unpack1("H*")).to eq("ff00")
+      expect(described_class.encode(505).unpack1("H*")).to eq("fffc")
+    end
+
+    it "uses code 254 (1 byte + 506) for values 506..761" do
+      expect(described_class.encode(506).unpack1("H*")).to eq("fe00")
+      expect(described_class.encode(761).unpack1("H*")).to eq("feff")
+    end
+
+    it "uses code 253 (uint16) for values 762..65535" do
+      expect(described_class.encode(762).unpack1("H*")).to eq("fd02fa")
+      expect(described_class.encode(65535).unpack1("H*")).to eq("fdffff")
+    end
+
+    it "uses literal for values 0..252" do
+      expect(described_class.encode(0).unpack1("H*")).to eq("00")
+      expect(described_class.encode(252).unpack1("H*")).to eq("fc")
+    end
+  end
+
+  describe ".decode — matches fontTools multi-encoding acceptance" do
+    # fontTools unpack255UShort accepts multiple encodings for the same value.
+    # Per spec: "An encoder may produce any of these, and a decoder MUST
+    # accept them all."
+
+    it "decodes 506 from code 254, byte 0" do
+      expect(described_class.decode(StringIO.new("\xFE\x00"))).to eq(506)
+    end
+
+    it "decodes 506 from code 255, byte 253" do
+      expect(described_class.decode(StringIO.new("\xFF\xFD"))).to eq(506)
+    end
+
+    it "decodes 506 from code 253, uint16 506" do
+      expect(described_class.decode(StringIO.new("\xFD\x01\xFA"))).to eq(506)
+    end
+  end
+
+  describe ".decode_at" do
+    it "decodes from a flat String at the given position" do
+      data = String.new(encoding: Encoding::BINARY)
+      data << "\x00\x00"
+      data << described_class.encode(300)
+      data << "\xFF".b
+      value, pos = described_class.decode_at(data, 2)
+      expect(value).to eq(300)
+      expect(pos).to eq(4) # 300 encodes as 2 bytes (code 255 + byte)
+    end
+  end
+
+  describe ".encode — rejects out-of-range values" do
+    it "raises ArgumentError for negative values" do
+      expect { described_class.encode(-1) }.to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for values > 65535" do
+      expect { described_class.encode(65_536) }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/fontisan/woff2_font_spec.rb
+++ b/spec/fontisan/woff2_font_spec.rb
@@ -358,44 +358,6 @@ RSpec.describe Fontisan::Woff2Font do
           .to raise_error(Fontisan::InvalidFontError, /Invalid UIntBase128/)
       end
     end
-
-    describe "#read_255_uint16" do
-      it "reads values 0-252 directly" do
-        woff2 = described_class.new
-        io = StringIO.new([100].pack("C"))
-
-        result = woff2.send(:read_255_uint16, io)
-
-        expect(result).to eq(100)
-      end
-
-      it "reads value 253 format (253 + next byte)" do
-        woff2 = described_class.new
-        io = StringIO.new([253, 10].pack("C*"))
-
-        result = woff2.send(:read_255_uint16, io)
-
-        expect(result).to eq(263) # 253 + 10
-      end
-
-      it "reads value 254 format (next 2 bytes)" do
-        woff2 = described_class.new
-        io = StringIO.new([254, 0x01, 0x00].pack("C*"))
-
-        result = woff2.send(:read_255_uint16, io)
-
-        expect(result).to eq(256)
-      end
-
-      it "reads value 255 format (next 2 bytes + 506)" do
-        woff2 = described_class.new
-        io = StringIO.new([255, 0x00, 0x0A].pack("C*"))
-
-        result = woff2.send(:read_255_uint16, io)
-
-        expect(result).to eq(516) # 10 + 506
-      end
-    end
   end
 
   describe "Woff2TableDirectoryEntry" do


### PR DESCRIPTION
## Summary

Fixes the third WOFF2 bug: 255UInt16 variable-length encoding was inverted for all values ≥ 253 across 9 inline copies of the encoder/decoder. Every font with any 255UInt16 value ≥ 253 was broken in Chrome/fontTools.

## The bug

W3C WOFF2 spec §3.1 and fontTools define:

| Code byte | W3C spec / fontTools (correct) | fontisan (was, in 9 copies) |
|-----------|-------------------------------|---------------------------|
| < 253 | literal | literal ✓ |
| 253 | uint16 (3 bytes) | 1 byte + 253 (2 bytes) ❌ |
| 254 | 1 byte + 506 (2 bytes) | uint16 (3 bytes) ❌ |
| 255 | 1 byte + 253 (2 bytes) | uint16 + 506 (3 bytes) ❌ |

Every value ≥ 253 in any 255UInt16 stream was encoded wrong. Simple scripts (Modi, Phoenician) escaped because all their values were small. Complex scripts with contour point counts ≥ 253 (Egyptian Hieroglyphs, Cuneiform, CJK Ext G) produced WOFF2 files Chrome silently rejected.

## The fix

New `Woff2::UInt255` module — single source of truth for 255UInt16 encoding. All 9 inline copies replaced with calls to `UInt255.encode` / `UInt255.decode` / `UInt255.decode_at`.

**Files changed:**
- New: `lib/fontisan/woff2/uint255.rb`, `spec/fontisan/woff2/uint255_spec.rb`
- Removed inline methods from: `Directory`, `GlyfLocaTransform`, `TableTransformer`, `CollectionEncoder`, `GlyfLocaReconstruct`, `Woff2Font`, `HmtxTransformer`, `CollectionDecoder`
- `Directory.encode_255_uint16` / `decode_255_uint16` retained as thin public-API wrappers delegating to UInt255

## Verification

```
fontTools docstring examples:
  UInt255.encode(252) → fc ✓
  UInt255.encode(506) → fe00 ✓
  UInt255.encode(762) → fd02fa ✓
```

26 new spec examples covering boundary values, fontTools byte-matching, and multi-encoding decoder acceptance per spec ("a decoder MUST accept them all").

## Test plan

- [x] `bundle exec rspec` — 5979 examples, 0 failures
- [x] `bundle exec rubocop` on all touched files — clean
- [ ] CI green on Ruby 3.3/3.4/4.0 × mac/linux/windows
