### PR TITLE
woff2: pad reconstructed glyphs to loca alignment boundary

### DIFF
--- a/lib/fontisan/woff2/glyf_loca_reconstruct.rb
+++ b/lib/fontisan/woff2/glyf_loca_reconstruct.rb
@@ -48,6 +48,14 @@ module Fontisan
 
       # Reconstruct glyf and loca tables.
       #
+      # Per OpenType glyf table spec, loca offsets must be even (short
+      # format) or multiples of 4 (long format). Each reconstructed glyph
+      # is padded to the loca-format alignment boundary so the next
+      # glyph starts at a valid offset. Without this padding, Chrome's
+      # OTS rejects the font with "Failed to convert WOFF 2.0 font to
+      # SFNT" because glyf.origLength understates the padded size every
+      # conformant decoder produces.
+      #
       # @return [Hash{Symbol => String}] `{ glyf:, loca: }`
       def reconstruct
         header = parse_header
@@ -55,10 +63,14 @@ module Fontisan
 
         glyf = String.new(encoding: Encoding::BINARY)
         offsets = [0]
+        align = @index_format.zero? ? 2 : 4
 
         num_glyphs.times do |glyph_id|
           glyph = decode_glyph(glyph_id, streams)
           glyf << glyph
+          # Pad to alignment boundary so next glyph starts at a valid loca offset
+          remainder = glyf.bytesize % align
+          glyf << ("\x00" * (align - remainder)) if remainder.positive?
           offsets << glyf.bytesize
         end
 


### PR DESCRIPTION
## Summary

Fixes the last Chrome OTS rejection: `GlyfLocaReconstruct` was appending reconstructed glyphs back-to-back without padding, producing a glyf table smaller than what every conformant decoder (fontTools, Chrome OTS) expects.

## The bug

Per OpenType glyf table spec, loca offsets must be:
- Even (2-byte aligned) for short loca (indexFormat=0)
- Multiples of 4 for long loca (indexFormat=1)

Each reconstructed glyph must be padded to the alignment boundary so the next glyph starts at a valid offset. fontTools' decoder does this; ours didn't.

The padding gap caused `glyf.origLength` (computed via round-trip through the decoder) to understate the padded size that Chrome's OTS expects. Result: "Failed to convert WOFF 2.0 font to SFNT" on **all** WOFF2 files.

## The fix

`GlyfLocaReconstruct#reconstruct` now pads each glyph to the loca-format alignment boundary after appending:

```ruby
align = @index_format.zero? ? 2 : 4
remainder = glyf.bytesize % align
glyf << ("\x00" * (align - remainder)) if remainder.positive?
```

## Verification

| Font | indexFormat | glyf.origLength | decoded glyf | loca aligned |
|------|-------------|-----------------|--------------|-------------|
| TestTTF | 0 (short) | 104 | 104 | all even |
| LibertinusKeyboard | 1 (long) | 191,724 | 191,724 | all mod 4 |

## Test plan

- [x] `bundle exec rspec` — 5980 examples, 0 failures
- [x] `bundle exec rubocop` — clean
- [x] glyf.origLength matches decoded glyf bytesize exactly
- [x] All loca offsets satisfy alignment constraint
- [ ] CI green
- [ ] Chrome document.fonts loads without OTS rejection
