### PR TITLE
woff2: correct glyph padding — short loca only, matching fontTools

### DIFF
--- a/lib/fontisan/woff2/glyf_loca_reconstruct.rb
+++ b/lib/fontisan/woff2/glyf_loca_reconstruct.rb
@@ -63,14 +63,20 @@ module Fontisan
 
         glyf = String.new(encoding: Encoding::BINARY)
         offsets = [0]
-        align = @index_format.zero? ? 2 : 4
+        # Short loca (indexFormat=0) stores offset/2 as uint16, so glyph
+        # offsets must be even — pad to 2-byte boundary. Long loca
+        # (indexFormat=1) has no alignment requirement (fontTools does
+        # not pad). Matching fontTools exactly is required: Chrome OTS
+        # rejects when glyf.origLength doesn't equal the decoder's output.
+        align = @index_format.zero? ? 2 : 1
 
         num_glyphs.times do |glyph_id|
           glyph = decode_glyph(glyph_id, streams)
           glyf << glyph
-          # Pad to alignment boundary so next glyph starts at a valid loca offset
-          remainder = glyf.bytesize % align
-          glyf << ("\x00" * (align - remainder)) if remainder.positive?
+          if align > 1
+            remainder = glyf.bytesize % align
+            glyf << ("\x00" * (align - remainder)) if remainder.positive?
+          end
           offsets << glyf.bytesize
         end
 


### PR DESCRIPTION
## Summary

Fixes incorrect glyph padding from PR #99 (commit 9b534a6). That commit applied 4-byte alignment for long loca (indexFormat=1), but fontTools does NOT pad glyphs for long loca — only short loca (indexFormat=0) needs 2-byte padding because loca stores offset/2 as uint16.

## Fix

`align = @index_format.zero? ? 2 : 1` — long loca gets no padding, matching fontTools exactly.

## Test plan

- [x] `bundle exec rspec` — 266 WOFF2 specs pass locally
- [x] `bundle exec rubocop` — clean
- [x] Long-loca font (LibertinusKeyboard): glyf.origLength matches decoded bytesize
- [x] Short-loca font (TestTTF): glyf.origLength matches decoded bytesize
- [ ] CI green
