### PR TITLE
subset: preserve CBDT/CBLC color bitmaps through web-profile subsetting

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -88,6 +88,11 @@ Lint/UnusedMethodArgument:
     - 'lib/fontisan/tables/cff2/private_dict_blend_handler.rb'
     - 'lib/fontisan/variation/table_accessor.rb'
     - 'lib/fontisan/woff_font.rb'
+    # Subset strategies share a uniform (context:, tag:, table:) interface
+    # so the dispatcher can call every registered class the same way. Not
+    # every strategy reads every arg; the interface contract justifies the
+    # unused warnings here.
+    - 'lib/fontisan/subset/table_strategy/**/*'
 
 # Offense count: 5
 Lint/UselessConstantScoping:

--- a/lib/fontisan/config/subset_profiles.yml
+++ b/lib/fontisan/config/subset_profiles.yml
@@ -55,6 +55,8 @@ web:
     - glyf
     - GSUB
     - GPOS
+    - CBDT
+    - CBLC
 
 # Minimal Profile: Absolute minimum tables for font rendering
 minimal:

--- a/lib/fontisan/subset.rb
+++ b/lib/fontisan/subset.rb
@@ -8,6 +8,9 @@ module Fontisan
     autoload :GlyphMapping, "fontisan/subset/glyph_mapping"
     autoload :Options, "fontisan/subset/options"
     autoload :Profile, "fontisan/subset/profile"
+    autoload :SharedState, "fontisan/subset/shared_state"
+    autoload :SubsetContext, "fontisan/subset/subset_context"
+    autoload :TableStrategy, "fontisan/subset/table_strategy"
     autoload :TableSubsetter, "fontisan/subset/table_subsetter"
   end
 end

--- a/lib/fontisan/subset/shared_state.rb
+++ b/lib/fontisan/subset/shared_state.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    # Per-subsetting shared state.
+    #
+    # Several subset strategies depend on values computed by earlier
+    # strategies during the same subsetting run:
+    #
+    #   - `subset_max_advance` is computed by the Hmtx strategy and read
+    #     by Hhea (because hhea is processed alphabetically before hmtx).
+    #   - `glyf_data`, `loca_offsets`, and `subset_bbox` are computed by
+    #     the Glyf strategy and consumed by Loca and Head.
+    #
+    # Rather than giving each TableStrategy access to the entire
+    # TableSubsetter (which would couple them to internals), the
+    # cross-strategy state lives here. Each strategy receives a Context
+    # exposing [font], [mapping], [options], and this [SharedState].
+    class SharedState
+      # @return [String, nil] binary glyf data built by the Glyf strategy
+      attr_accessor :glyf_data
+
+      # @return [Array<Integer>, nil] loca offsets produced by the Glyf strategy
+      attr_accessor :loca_offsets
+
+      # @return [Array(Integer, Integer, Integer, Integer), nil] union
+      #   xMin/yMin/xMax/yMax over the subset's glyphs
+      attr_accessor :subset_bbox
+
+      # @return [Integer] largest advanceWidth seen while subsetting hmtx
+      attr_accessor :subset_max_advance
+
+      # @return [TableStrategy::ColorBitmapSubsetter, nil] cached paired
+      #   CBDT+CBLC subsetter so both strategies reuse the same pass
+      attr_accessor :color_bitmap_subsetter
+
+      def initialize
+        @subset_max_advance = 0
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/subset_context.rb
+++ b/lib/fontisan/subset/subset_context.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    # Value object handed to every TableStrategy. Encapsulates the inputs
+    # (font, mapping, options) plus the cross-strategy [SharedState] so
+    # strategies don't need a back-reference to the TableSubsetter.
+    #
+    # @!attribute font
+    #   @return [SfntFont]
+    # @!attribute mapping
+    #   @return [GlyphMapping]
+    # @!attribute options
+    #   @return [Options]
+    # @!attribute state
+    #   @return [SharedState]
+    SubsetContext = Struct.new(:font, :mapping, :options, :state,
+                               keyword_init: true)
+  end
+end

--- a/lib/fontisan/subset/table_strategy.rb
+++ b/lib/fontisan/subset/table_strategy.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Autoload hub for the Fontisan::Subset::TableStrategy namespace.
+#
+# Each table tag handled by the subsetter has a corresponding strategy
+# class (e.g. `TableStrategy::Maxp` for the "maxp" tag). Strategies are
+# stateless — they receive a [SubsetContext] + tag + table and return
+# the subset table's binary bytes. Unknown tags fall back to
+# [TableStrategy::PassThrough], which preserves the source bytes.
+#
+# Registering a new tag is a one-line change: add the autoload here and
+# an entry in REGISTRY. No edits to TableSubsetter required (Open/Closed).
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      autoload :Cblc, "fontisan/subset/table_strategy/cblc"
+      autoload :Cbdt, "fontisan/subset/table_strategy/cbdt"
+      autoload :Cmap, "fontisan/subset/table_strategy/cmap"
+      autoload :ColorBitmapPlacement,
+               "fontisan/subset/table_strategy/color_bitmap_placement"
+      autoload :ColorBitmapStrikePlan,
+               "fontisan/subset/table_strategy/color_bitmap_strike_plan"
+      autoload :ColorBitmapSubsetPlan,
+               "fontisan/subset/table_strategy/color_bitmap_subset_plan"
+      autoload :ColorBitmapSubsetter,
+               "fontisan/subset/table_strategy/color_bitmap_subsetter"
+      autoload :ColorBitmapSubtablePlan,
+               "fontisan/subset/table_strategy/color_bitmap_subtable_plan"
+      autoload :Glyf, "fontisan/subset/table_strategy/glyf"
+      autoload :GlyfLocaBuilder,
+               "fontisan/subset/table_strategy/glyf_loca_builder"
+      autoload :Head, "fontisan/subset/table_strategy/head"
+      autoload :Hhea, "fontisan/subset/table_strategy/hhea"
+      autoload :Hmtx, "fontisan/subset/table_strategy/hmtx"
+      autoload :Loca, "fontisan/subset/table_strategy/loca"
+      autoload :Maxp, "fontisan/subset/table_strategy/maxp"
+      autoload :Name, "fontisan/subset/table_strategy/name"
+      autoload :Os2, "fontisan/subset/table_strategy/os2"
+      autoload :PassThrough, "fontisan/subset/table_strategy/pass_through"
+      autoload :Post, "fontisan/subset/table_strategy/post"
+
+      # Tag → strategy class name (resolved lazily via const_get to keep
+      # this file loadable in any order). Add new subsetting logic by
+      # adding one autoload + one entry here, plus a strategy file under
+      # `lib/fontisan/subset/table_strategy/`.
+      REGISTRY = {
+        "maxp" => :Maxp,
+        "hhea" => :Hhea,
+        "hmtx" => :Hmtx,
+        "loca" => :Loca,
+        "glyf" => :Glyf,
+        "cmap" => :Cmap,
+        "post" => :Post,
+        "name" => :Name,
+        "head" => :Head,
+        "OS/2" => :Os2,
+        "CBDT" => :Cbdt,
+        "CBLC" => :Cblc,
+      }.freeze
+
+      # Resolve a table tag to its strategy class. Returns PassThrough
+      # for any tag without an explicit registration.
+      #
+      # @param tag [String] OpenType table tag (e.g. "maxp", "CBDT")
+      # @return [Class] a strategy class responding to `.call`
+      def self.for(tag)
+        const_name = REGISTRY[tag]
+        return PassThrough unless const_name
+
+        const_get(const_name)
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/cbdt.rb
+++ b/lib/fontisan/subset/table_strategy/cbdt.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # CBDT strategy: delegate to [ColorBitmapSubsetter], which produces
+      # both CBDT and CBLC bytes in a single pass. The Cblc strategy
+      # reads from the same collaborator so the two tables stay
+      # consistent.
+      class Cbdt
+        # @param context [SubsetContext]
+        # @param tag [String] "CBDT"
+        # @param table [Cbdt] parsed CBDT table (unused)
+        # @return [String] subset CBDT bytes
+        def self.call(context:, tag:, table:)
+          color_bitmap_subsetter(context).cbdt_bytes
+        end
+
+        # @param context [SubsetContext]
+        # @return [ColorBitmapSubsetter] cached on the shared state so the
+        #   Cblc strategy reuses the same pass
+        def self.color_bitmap_subsetter(context)
+          context.state.color_bitmap_subsetter ||= ColorBitmapSubsetter.new(font: context.font,
+                                                                            mapping: context.mapping).build
+        end
+        private_class_method :color_bitmap_subsetter
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/cblc.rb
+++ b/lib/fontisan/subset/table_strategy/cblc.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # CBLC strategy: delegate to [ColorBitmapSubsetter] (the same
+      # collaborator used by the Cbdt strategy) so both tables stay
+      # consistent. The subsetter is built lazily on first access and
+      # cached on [SharedState].
+      class Cblc
+        # @param context [SubsetContext]
+        # @param tag [String] "CBLC"
+        # @param table [Cblc] parsed CBLC table (unused)
+        # @return [String] subset CBLC bytes
+        def self.call(context:, tag:, table:)
+          color_bitmap_subsetter(context).cblc_bytes
+        end
+
+        def self.color_bitmap_subsetter(context)
+          context.state.color_bitmap_subsetter ||= ColorBitmapSubsetter.new(font: context.font,
+                                                                            mapping: context.mapping).build
+        end
+        private_class_method :color_bitmap_subsetter
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/cmap.rb
+++ b/lib/fontisan/subset/table_strategy/cmap.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Cmap strategy: rebuild cmap containing only the (codepoint →
+      # new GID) mappings for codepoints whose original GID is retained.
+      # Emits a format-4 subtable for BMP codepoints and a format-12
+      # subtable for supplementary-plane codepoints.
+      class Cmap
+        # @param context [SubsetContext]
+        # @param tag [String] "cmap"
+        # @param table [Cmap] parsed cmap table
+        # @return [String] binary cmap bytes for the subset
+        def self.call(context:, tag:, table:)
+          new_mappings = {}
+          table.unicode_mappings.each do |char_code, old_gid|
+            new_gid = context.mapping.new_id(old_gid)
+            new_mappings[char_code] = new_gid if new_gid
+          end
+          Builder.new(new_mappings).build
+        end
+
+        # Builds a minimal valid cmap table from a {codepoint => gid} map.
+        # Extracted as a sibling class so [Cmap] stays focused on
+        # subsetting dispatch while the binary arithmetic lives
+        # separately.
+        class Builder
+          def initialize(mappings)
+            @mappings = mappings
+          end
+
+          def build
+            @mappings = { 0 => 0 } if @mappings.empty?
+
+            bmp = @mappings.select { |cp, _| cp <= 0xFFFF }
+            supp = @mappings.select { |cp, _| cp > 0xFFFF }
+
+            subtables = []
+            records = []
+
+            unless bmp.empty?
+              subtables << build_format_4(bmp)
+              idx = subtables.size - 1
+              records << [3, 1, idx] # Windows BMP
+              records << [0, 3, idx] # Unicode BMP
+            end
+
+            unless supp.empty?
+              subtables << build_format_12(@mappings)
+              idx = subtables.size - 1
+              records << [3, 10, idx] # Windows UCS-4
+              records << [0, 4, idx]  # Unicode full
+            end
+
+            assemble(records, subtables)
+          end
+
+          private
+
+          def assemble(records, subtables)
+            num_tables = records.size
+            header = [0, num_tables].pack("nn")
+            subtable_base = 4 + (8 * num_tables)
+
+            offsets = []
+            running = subtable_base
+            subtables.each do |st|
+              offsets << running
+              running += st.bytesize
+            end
+
+            record_bytes = +""
+            records.each do |pid, eid, idx|
+              record_bytes << [pid, eid, offsets[idx]].pack("nnN")
+            end
+
+            header + record_bytes + subtables.join
+          end
+
+          def build_format_4(bmp_mappings)
+            segments = coalesce_segments(bmp_mappings)
+            segments << { start_cp: 0xFFFF, end_cp: 0xFFFF, start_gid: 0 }
+
+            seg_count = segments.size
+            seg_count_x2 = seg_count * 2
+            search_range = 2**Math.log2(seg_count).floor * 2
+            search_range = 2 if search_range < 2
+            entry_selector = Math.log2(search_range / 2).to_i
+            range_shift = seg_count_x2 - search_range
+
+            end_codes = segments.map { |s| s[:end_cp] }
+            start_codes = segments.map { |s| s[:start_cp] }
+            id_deltas = segments.map do |s|
+              (s[:start_gid] - s[:start_cp]) & 0xFFFF
+            end
+            id_range_offsets = [0] * seg_count
+
+            subtable = +""
+            subtable << [4, 0, 0, seg_count_x2,
+                         search_range, entry_selector, range_shift].pack("n*")
+            subtable << end_codes.pack("n*")
+            subtable << [0].pack("n") # reservedPad
+            subtable << start_codes.pack("n*")
+            subtable << id_deltas.pack("n*")
+            subtable << id_range_offsets.pack("n*")
+
+            subtable[2, 2] = [subtable.bytesize].pack("n")
+            subtable
+          end
+
+          def build_format_12(all_mappings)
+            groups = coalesce_segments(all_mappings)
+            num_groups = groups.size
+
+            subtable = +""
+            subtable << [12, 0, 0, 0, num_groups].pack("nnNNN")
+            groups.each do |g|
+              subtable << [g[:start_cp], g[:end_cp], g[:start_gid]].pack("NNN")
+            end
+
+            subtable[4, 4] = [subtable.bytesize].pack("N")
+            subtable
+          end
+
+          def coalesce_segments(mappings)
+            sorted = mappings.sort_by { |cp, _| cp }
+            segments = []
+            current = nil
+            sorted.each do |cp, gid|
+              if current && cp == current[:end_cp] + 1 &&
+                  gid == current[:start_gid] + (cp - current[:start_cp])
+                current[:end_cp] = cp
+              else
+                segments << current if current
+                current = { start_cp: cp, end_cp: cp, start_gid: gid }
+              end
+            end
+            segments << current if current
+            segments
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/color_bitmap_placement.rb
+++ b/lib/fontisan/subset/table_strategy/color_bitmap_placement.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Per-survivor placement: where the source bitmap lives and where it
+# ends up in the subset CBDT.
+module Fontisan
+  module Subset
+    module TableStrategy
+      ColorBitmapPlacement = Struct.new(:source_gid, :new_gid,
+                                        :source_offset, :byte_length,
+                                        :image_format, :strike_ppem,
+                                        :new_offset,
+                                        keyword_init: true) do
+        def initialize(*)
+          super
+          self.new_offset ||= 0
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/color_bitmap_strike_plan.rb
+++ b/lib/fontisan/subset/table_strategy/color_bitmap_strike_plan.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Plan for one strike emitted by [ColorBitmapSubsetter]: the source
+      # BitmapSize plus the list of contiguous new-gid runs (each run
+      # becomes one IndexSubTable in the output CBLC).
+      class ColorBitmapStrikePlan
+        attr_reader :source_strike, :subtable_plans
+
+        def initialize(source_strike)
+          @source_strike = source_strike
+          @subtable_plans = []
+        end
+
+        # Add a placement, grouping into contiguous new-gid runs. A new
+        # run starts when the new gid skips, the ppem changes, or the
+        # image format changes.
+        def add(placement)
+          current = @subtable_plans.last
+
+          if current && placement.new_gid == current.last_new_gid + 1
+            current.add(placement)
+          else
+            sub = ColorBitmapSubtablePlan.new(
+              strike_ppem: placement.strike_ppem,
+              image_format: placement.image_format,
+            )
+            sub.add(placement)
+            @subtable_plans << sub
+          end
+        end
+
+        def empty?
+          @subtable_plans.empty?
+        end
+
+        def subtable_count
+          @subtable_plans.size
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/color_bitmap_subset_plan.rb
+++ b/lib/fontisan/subset/table_strategy/color_bitmap_subset_plan.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Plan for the subset of color bitmaps: which source strikes have
+      # any surviving glyph, and the per-strike runs of surviving new
+      # GIDs. Built once by [ColorBitmapSubsetter] from a CBLC + a
+      # GlyphMapping, then used to drive both CBDT and CBLC emission.
+      class ColorBitmapSubsetPlan
+        attr_reader :strikes, :strike_plans, :placements
+
+        def initialize(mapping)
+          @mapping = mapping
+          @strikes = []
+          @strike_plans = []
+          @placements = []
+        end
+
+        # Walk every (gid, strike) location in CBLC and capture the
+        # ones whose source gid is in the subset. Remaps the gid via
+        # the supplied mapping.
+        def collect!(cblc)
+          cblc.bitmap_sizes.each do |strike|
+            strike_plan = ColorBitmapStrikePlan.new(strike)
+
+            cblc.sub_tables_for(strike).each do |sub|
+              sub.locations.each do |loc|
+                new_gid = @mapping.new_id(loc.glyph_id)
+                next unless new_gid
+
+                placement = ColorBitmapPlacement.new(
+                  source_gid: loc.glyph_id,
+                  new_gid: new_gid,
+                  source_offset: loc.cbdt_offset,
+                  byte_length: loc.byte_length,
+                  image_format: loc.image_format,
+                  strike_ppem: strike.ppem,
+                )
+                @placements << placement
+                strike_plan.add(placement)
+              end
+            end
+
+            next if strike_plan.empty?
+
+            @strikes << strike
+            @strike_plans << strike_plan
+          end
+        end
+
+        def each_placement(&)
+          @placements.each(&)
+        end
+
+        def each_strike_plan(&)
+          @strike_plans.each(&)
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/color_bitmap_subsetter.rb
+++ b/lib/fontisan/subset/table_strategy/color_bitmap_subsetter.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Paired CBDT + CBLC subsetter.
+      #
+      # CBDT (Color Bitmap Data) and CBLC (Color Bitmap Location) are
+      # tightly coupled: CBLC indexes glyph IDs to CBDT byte offsets,
+      # and CBDT is just a blob of bitmap blocks. Subsetting requires
+      # walking both at once — filtering to subset GIDs, copying the
+      # retained bitmap blocks into a fresh CBDT, and rewriting CBLC's
+      # IndexSubTable offsets to match.
+      #
+      # Both the Cbdt and Cblc strategies call into this collaborator,
+      # which performs the work once and caches both byte strings. This
+      # keeps the strategies themselves trivial and avoids forcing the
+      # TableSubsetter to know about CBDT/CBLC ordering.
+      #
+      # The output CBLC keeps the source BitmapSize records verbatim
+      # (ppem, metrics, glyph_range) and rewrites each IndexSubTable's
+      # `imageDataOffset` and offset array to point into the new CBDT.
+      # Glyph IDs are remapped via the supplied [GlyphMapping] so the
+      # subset's CBLC references subset GIDs, not source GIDs.
+      #
+      # Output IndexSubTables always use format 1 (uint32 offsets) —
+      # it has no alignment requirement, so arbitrary bitmap block
+      # sizes from the source work without padding.
+      #
+      # Reference: OpenType CBDT/CBLC specifications.
+      class ColorBitmapSubsetter
+        # @return [String] new CBDT bytes (header + retained blocks)
+        attr_reader :cbdt_bytes
+
+        # @return [String] new CBLC bytes (header + BitmapSize + ISTA + IST)
+        attr_reader :cblc_bytes
+
+        # @param font [SfntFont]
+        # @param mapping [GlyphMapping] old↔new GID map for the subset
+        def initialize(font:, mapping:)
+          @font = font
+          @mapping = mapping
+          @cbdt_bytes = +""
+          @cblc_bytes = +""
+        end
+
+        # Build the subset CBDT + CBLC bytes. Idempotent.
+        #
+        # @return [self]
+        def build
+          return self if @built
+
+          source_cblc = @font.table_data["CBLC"]
+          source_cbdt = @font.table_data["CBDT"]
+
+          if source_cblc.nil? || source_cbdt.nil?
+            @built = true
+            return self
+          end
+
+          cblc = Tables::Cblc.read(source_cblc)
+          cbdt = Tables::Cbdt.read(source_cbdt)
+
+          plan = ColorBitmapSubsetPlan.new(@mapping)
+          plan.collect!(cblc)
+
+          emit_cbdt(cbdt, plan)
+          emit_cblc(cblc, plan)
+
+          @built = true
+          self
+        end
+
+        private
+
+        # Emit CBDT: preserve the source 4-byte header, then concatenate
+        # every retained bitmap block in (strike, gid) order. The
+        # placement's new_offset is recorded so CBLC emission can
+        # reference it.
+        def emit_cbdt(cbdt, plan)
+          @cbdt_bytes = String.new(encoding: Encoding::BINARY)
+          @cbdt_bytes << cbdt.raw_data[0, 4] # majorVersion + minorVersion
+
+          plan.each_placement do |placement|
+            block = cbdt.bitmap_data_at(placement.source_offset,
+                                        placement.byte_length)
+            next unless block
+
+            placement.new_offset = @cbdt_bytes.bytesize
+            @cbdt_bytes << block
+          end
+        end
+
+        # Emit CBLC: header + BitmapSize section + IndexSubTableArray
+        # section + IndexSubTable records. The IndexSubTableArray entries
+        # are grouped per strike; IndexSubTable records are appended
+        # after all ISTA entries. Each IndexSubTable is format 1.
+        def emit_cblc(cblc, plan)
+          output = String.new(encoding: Encoding::BINARY)
+          output << [Integer(cblc.version), plan.strikes.size].pack("NN")
+
+          bitmap_size_section_end = output.bytesize + (plan.strikes.size * 48)
+          ista_offsets = build_ista_offsets(plan, bitmap_size_section_end)
+          ista_section_end = ista_offsets.last.to_i +
+            (plan.strike_plans.sum(&:subtable_count) * 8)
+
+          # BitmapSize records (patched array_offset + number_of_subtables).
+          plan.strike_plans.each_with_index do |strike_plan, idx|
+            output << patch_bitmap_size(strike_plan.source_strike,
+                                        ista_offsets[idx],
+                                        strike_plan.subtable_count)
+          end
+
+          # IndexSubTableArray entries (one per subtable plan).
+          ist_cursor = ista_section_end
+          plan.strike_plans.each_with_index do |strike_plan, idx|
+            strike_ista_offset = ista_offsets[idx]
+            strike_plan.subtable_plans.each do |sub|
+              additional = ist_cursor - strike_ista_offset
+              output << [sub.first_new_gid, sub.last_new_gid,
+                         additional].pack("nnN")
+              ist_cursor += sub.byte_length
+            end
+          end
+
+          # IndexSubTable records (format 1).
+          plan.each_strike_plan do |strike_plan|
+            strike_plan.subtable_plans.each do |sub|
+              output << build_index_sub_table(sub)
+            end
+          end
+
+          @cblc_bytes = output
+        end
+
+        # Absolute CBLC offset of each survivor strike's IndexSubTableArray.
+        # Each strike's ISTA is laid out right after the BitmapSize section
+        # and the previous strikes' ISTA entries (8 bytes × subtable count).
+        def build_ista_offsets(plan, bitmap_size_section_end)
+          offsets = []
+          cursor = bitmap_size_section_end
+          plan.strike_plans.each do |sp|
+            offsets << cursor
+            cursor += sp.subtable_count * 8
+          end
+          offsets
+        end
+
+        # Clone a BitmapSize with patched `index_subtable_array_offset`
+        # and `number_of_index_subtables`; everything else preserved
+        # from the source.
+        def patch_bitmap_size(source_strike, new_ista_offset, subtable_count)
+          clone = Tables::CblcBitmapSize.new
+          clone.index_subtable_array_offset = new_ista_offset
+          clone.index_tables_size = source_strike.index_tables_size
+          clone.number_of_index_subtables = subtable_count
+          clone.color_ref = source_strike.color_ref
+          clone.hori = source_strike.hori
+          clone.vert = source_strike.vert
+          clone.start_glyph_index = source_strike.start_glyph_index
+          clone.end_glyph_index = source_strike.end_glyph_index
+          clone.ppem_x = source_strike.ppem_x
+          clone.ppem_y = source_strike.ppem_y
+          clone.bit_depth = source_strike.bit_depth
+          clone.flags = source_strike.flags
+          clone.to_binary_s
+        end
+
+        # Format 1 IndexSubTable: 8-byte header + uint32 offsetArray[count+1].
+        # imageDataOffset = absolute new CBDT offset of the first glyph's
+        # bitmap. offsets[i] = relative offset from imageDataOffset for
+        # glyph i.
+        def build_index_sub_table(sub)
+          bytes = String.new(encoding: Encoding::BINARY)
+          bytes << [1, sub.image_format, sub.first_new_offset].pack("nnN")
+          bytes << sub.offset_array.pack("N*")
+          bytes
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/color_bitmap_subtable_plan.rb
+++ b/lib/fontisan/subset/table_strategy/color_bitmap_subtable_plan.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Plan for one IndexSubTable emitted by [ColorBitmapSubsetter]:
+      # a contiguous run of new GIDs at a single strike, with the
+      # CBDT offsets and lengths needed to emit a format 1 IndexSubTable.
+      class ColorBitmapSubtablePlan
+        attr_reader :placements, :strike_ppem, :image_format
+
+        def initialize(strike_ppem:, image_format:)
+          @strike_ppem = strike_ppem
+          @image_format = image_format
+          @placements = []
+        end
+
+        def add(placement)
+          @placements << placement
+        end
+
+        def first_new_gid
+          @placements.first.new_gid
+        end
+
+        def last_new_gid
+          @placements.last.new_gid
+        end
+
+        # Absolute CBDT offset where this subtable's first glyph's
+        # bitmap begins. Assigned during CBDT emission.
+        #
+        # @return [Integer]
+        def first_new_offset
+          @placements.first.new_offset
+        end
+
+        # IndexSubTable format 1 offset array (relative to
+        # imageDataOffset). offsets[0] is 0 (first glyph starts at
+        # imageDataOffset); offsets[i+1] = offsets[i] + byte_length.
+        #
+        # @return [Array<Integer>]
+        def offset_array
+          arr = [0]
+          @placements.each do |p|
+            arr << (arr.last + p.byte_length)
+          end
+          arr
+        end
+
+        # Byte length of this IndexSubTable in the output CBLC:
+        # 8-byte header + (count + 1) × 4-byte offsets.
+        def byte_length
+          8 + (@placements.size + 1) * 4
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/glyf.rb
+++ b/lib/fontisan/subset/table_strategy/glyf.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Glyf strategy: extract each subset glyph's bytes from the source
+      # glyf table (remapping composite component glyph IDs), build the
+      # corresponding loca offsets, and stash both into [SharedState] so
+      # the Loca strategy can read them. Also records the union bbox
+      # for the Head strategy.
+      class Glyf
+        # @param context [SubsetContext]
+        # @param tag [String] "glyf"
+        # @param table [Glyf] parsed glyf table (unused; builder reads
+        #   the table from `context.font` directly so it sees the same
+        #   instance)
+        # @return [String] binary glyf bytes for the subset
+        def self.call(context:, tag:, table:)
+          builder = GlyfLocaBuilder.new(font: context.font,
+                                        mapping: context.mapping).build
+          context.state.glyf_data = builder.glyf_data
+          context.state.loca_offsets = builder.loca_offsets
+          context.state.subset_bbox = builder.bbox
+          builder.glyf_data
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/glyf_loca_builder.rb
+++ b/lib/fontisan/subset/table_strategy/glyf_loca_builder.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Glyf + Loca are emitted together because loca is just an offset
+      # index into glyf. This builder walks the subset's glyph mapping,
+      # extracts each glyph's bytes (remapping composite component refs),
+      # and produces the new glyf bytes, the new loca offsets, and the
+      # union bounding box over the subset's glyphs.
+      #
+      # Extracted as a collaborator so both the Glyf and Loca strategies
+      # can share a single build pass without coupling to each other or
+      # to TableSubsetter internals.
+      class GlyfLocaBuilder
+        # @param font [SfntFont]
+        # @param mapping [GlyphMapping]
+        def initialize(font:, mapping:)
+          @font = font
+          @mapping = mapping
+        end
+
+        # @return [String] new glyf bytes
+        attr_reader :glyf_data
+
+        # @return [Array<Integer>] loca offsets (one per glyph + 1)
+        attr_reader :loca_offsets
+
+        # @return [Array(Integer, Integer, Integer, Integer), nil] union
+        #   bbox as [x_min, y_min, x_max, y_max], or nil if all glyphs empty
+        attr_reader :bbox
+
+        # Build glyf + loca + bbox. Idempotent — re-calling is a no-op.
+        #
+        # @return [self]
+        def build
+          return self if @glyf_data
+
+          glyf = @font.table("glyf")
+          loca = @font.table("loca")
+          head = @font.table("head")
+
+          ensure_loca_parsed!(loca, head)
+
+          @glyf_data = String.new(encoding: Encoding::BINARY)
+          @loca_offsets = []
+          current_offset = 0
+
+          bbox_x_min = 1 << 30
+          bbox_y_min = 1 << 30
+          bbox_x_max = -(1 << 30)
+          bbox_y_max = -(1 << 30)
+
+          @mapping.old_ids.each do |old_id|
+            @loca_offsets << current_offset
+
+            offset = loca.offset_for(old_id)
+            size = loca.size_of(old_id)
+            next if size.nil? || size.zero?
+
+            glyph_data = glyf.raw_data[offset, size]
+
+            if glyph_data.bytesize >= 10
+              _n, gx_min, gy_min, gx_max, gy_max = glyph_data[0, 10].unpack("n5")
+              gx_min = to_signed_16(gx_min)
+              gy_min = to_signed_16(gy_min)
+              gx_max = to_signed_16(gx_max)
+              gy_max = to_signed_16(gy_max)
+              bbox_x_min = gx_min if gx_min < bbox_x_min
+              bbox_y_min = gy_min if gy_min < bbox_y_min
+              bbox_x_max = gx_max if gx_max > bbox_x_max
+              bbox_y_max = gy_max if gy_max > bbox_y_max
+            end
+
+            glyph_data = remap_compound!(glyph_data) if compound?(glyph_data)
+
+            @glyf_data << glyph_data
+            current_offset += glyph_data.bytesize
+          end
+
+          @loca_offsets << current_offset
+
+          return if bbox_x_min > bbox_x_max
+
+          @bbox = [bbox_x_min, bbox_y_min, bbox_x_max, bbox_y_max]
+          self
+        end
+
+        private
+
+        def ensure_loca_parsed!(loca, head)
+          return if loca.parsed?
+
+          maxp = @font.table("maxp")
+          loca.parse_with_context(head.index_to_loc_format, maxp.num_glyphs)
+        end
+
+        def compound?(data)
+          return false if data.length < 2
+
+          num_contours = to_signed_16(data[0, 2].unpack1("n"))
+          num_contours == -1
+        end
+
+        def remap_compound!(data)
+          new_data = data.dup
+          offset = 10 # skip 10-byte header
+
+          loop do
+            break if offset >= new_data.length - 4
+
+            flags = new_data[offset, 2].unpack1("n")
+            old_glyph_index = new_data[offset + 2, 2].unpack1("n")
+
+            new_glyph_index = @mapping.new_id(old_glyph_index)
+            unless new_glyph_index
+              raise Fontisan::SubsettingError,
+                    "Component glyph #{old_glyph_index} not in subset"
+            end
+
+            new_data[offset + 2, 2] = [new_glyph_index].pack("n")
+            offset += 4 # flags + glyph_index
+            offset += (flags & 0x0001).zero? ? 2 : 4 # args
+
+            if (flags & 0x0080) != 0
+              offset += 8 # 2x2 matrix
+            elsif (flags & 0x0040) != 0
+              offset += 4 # X and Y scale
+            elsif (flags & 0x0008) != 0
+              offset += 2 # uniform scale
+            end
+
+            break unless (flags & 0x0020) != 0 # MORE_COMPONENTS
+          end
+
+          new_data
+        end
+
+        def to_signed_16(value)
+          value > 0x7FFF ? value - 0x10000 : value
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/head.rb
+++ b/lib/fontisan/subset/table_strategy/head.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Head strategy: recompute xMin/yMin/xMax/yMax (offsets 36–43) from
+      # the subset's actual glyphs. The source TTC's bbox covers every
+      # donor font in the collection and is far larger than any per-block
+      # subset needs; an inflated bbox makes browsers render glyphs at
+      # the wrong visual size. The remaining head fields pass through
+      # unchanged — checksumAdjustment is rewritten by FontWriter.
+      class Head
+        # @param context [SubsetContext]
+        # @param tag [String] "head"
+        # @param table [Head] parsed head table (unused)
+        # @return [String] binary head bytes for the subset
+        def self.call(context:, tag:, table:)
+          ensure_glyf_built!(context)
+
+          data = context.font.table_data["head"].dup
+          bbox = context.state.subset_bbox
+          return data unless bbox
+
+          x_min, y_min, x_max, y_max = bbox
+          data[36, 8] = [x_min, y_min, x_max, y_max].pack("n4")
+          data
+        end
+
+        def self.ensure_glyf_built!(context)
+          return if context.state.glyf_data
+
+          builder = GlyfLocaBuilder.new(font: context.font,
+                                        mapping: context.mapping).build
+          context.state.glyf_data = builder.glyf_data
+          context.state.loca_offsets = builder.loca_offsets
+          context.state.subset_bbox = builder.bbox
+        end
+        private_class_method :ensure_glyf_built!
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/hhea.rb
+++ b/lib/fontisan/subset/table_strategy/hhea.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Hhea strategy: rewrite numberOfHMetrics (offset 34, uint16) and
+      # advanceWidthMax (offset 10, uint16). The source TTC's
+      # advanceWidthMax covers every donor font and can be far larger
+      # than any per-block subset needs; recomputing from the subset's
+      # actual hmtx keeps the value honest.
+      #
+      # Hhea runs alphabetically before Hmtx, so the Hmtx strategy's
+      # SharedState cache hasn't been populated yet — we walk the source
+      # hmtx directly to find the max.
+      class Hhea
+        # @param context [SubsetContext]
+        # @param tag [String] "hhea"
+        # @param table [Hhea] parsed hhea table
+        # @return [String] binary hhea bytes for the subset
+        def self.call(context:, tag:, table:)
+          data = table.to_binary_s.dup
+
+          new_num_h_metrics = calculate_number_of_h_metrics(context, table)
+          data[34, 2] = [new_num_h_metrics].pack("n")
+
+          new_max = compute_subset_max_advance(context)
+          data[10, 2] = [new_max].pack("n") if new_max.positive?
+
+          data
+        end
+
+        def self.calculate_number_of_h_metrics(context, _table)
+          hmtx = context.font.table("hmtx")
+          if hmtx&.parsed? && hmtx.h_metrics
+            hmtx.h_metrics.size
+          else
+            context.mapping.size
+          end
+        end
+
+        def self.compute_subset_max_advance(context)
+          hmtx = context.font.table("hmtx")
+          return 0 unless hmtx
+
+          unless hmtx.parsed?
+            hhea = context.font.table("hhea")
+            maxp = context.font.table("maxp")
+            hmtx.parse_with_context(hhea.number_of_h_metrics,
+                                    maxp.num_glyphs)
+          end
+
+          max_advance = 0
+          context.mapping.old_ids.each do |old_id|
+            metric = hmtx.metric_for(old_id)
+            next unless metric
+
+            advance = metric[:advance_width]
+            max_advance = advance if advance && advance > max_advance
+          end
+          max_advance
+        end
+        private_class_method :calculate_number_of_h_metrics,
+                             :compute_subset_max_advance
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/hmtx.rb
+++ b/lib/fontisan/subset/table_strategy/hmtx.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Hmtx strategy: emit one LongHorMetric per glyph in the subset's
+      # glyph mapping, in the same order as the mapping. Also records
+      # the maximum advanceWidth into [SharedState] so Hhea (which is
+      # processed alphabetically before Hmtx) can read it.
+      #
+      # Tables are processed in profile order — Hhea comes before Hmtx
+      # alphabetically — so Hhea reads its max advance via a private
+      # helper that walks the source hmtx directly. Hmtx then stashes
+      # the value into SharedState for any later consumer.
+      class Hmtx
+        # @param context [SubsetContext]
+        # @param tag [String] "hmtx"
+        # @param table [Hmtx] parsed hmtx table
+        # @return [String] binary hmtx bytes for the subset
+        def self.call(context:, tag:, table:)
+          ensure_parsed!(context, table)
+
+          data = String.new(encoding: Encoding::BINARY)
+          max_advance = 0
+
+          context.mapping.old_ids.each do |old_id|
+            metric = table.metric_for(old_id)
+            next unless metric
+
+            advance = metric[:advance_width]
+            max_advance = advance if advance && advance > max_advance
+            data << [advance].pack("n")
+            data << [metric[:lsb]].pack("n")
+          end
+
+          context.state.subset_max_advance = max_advance
+          data
+        end
+
+        def self.ensure_parsed!(context, table)
+          return if table.parsed?
+
+          hhea = context.font.table("hhea")
+          maxp = context.font.table("maxp")
+          table.parse_with_context(hhea.number_of_h_metrics,
+                                   maxp.num_glyphs)
+        end
+        private_class_method :ensure_parsed!
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/loca.rb
+++ b/lib/fontisan/subset/table_strategy/loca.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Loca strategy: emit one entry per subset glyph + a final offset,
+      # using short or long format based on the source head.index_to_loc_format.
+      # Glyph offsets come from [SharedState], populated earlier by the
+      # Glyf strategy. If Glyf hasn't run yet (e.g. direct invocation
+      # from a spec), this strategy triggers the build lazily.
+      class Loca
+        # @param context [SubsetContext]
+        # @param tag [String] "loca"
+        # @param table [Loca] parsed loca table (unused)
+        # @return [String] binary loca bytes for the subset
+        def self.call(context:, tag:, table:)
+          offsets = context.state.loca_offsets
+          if offsets.nil?
+            builder = GlyfLocaBuilder.new(font: context.font,
+                                          mapping: context.mapping).build
+            context.state.glyf_data = builder.glyf_data
+            context.state.loca_offsets = builder.loca_offsets
+            context.state.subset_bbox = builder.bbox
+            offsets = builder.loca_offsets
+          end
+
+          head = context.font.table("head")
+          data = String.new(encoding: Encoding::BINARY)
+
+          if head.index_to_loc_format.zero?
+            offsets.each { |o| data << [o / 2].pack("n") }
+          else
+            offsets.each { |o| data << [o].pack("N") }
+          end
+
+          data
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/maxp.rb
+++ b/lib/fontisan/subset/table_strategy/maxp.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Maxp strategy: rewrite numGlyphs (offset 4, uint16) to the
+      # subset's glyph count. The remaining maxp fields describe worst-
+      # case outline/instruction complexity and can be left as-is —
+      # a smaller subset cannot exceed the source's maxima.
+      class Maxp
+        # @param context [SubsetContext]
+        # @param tag [String] "maxp"
+        # @param table [Maxp] parsed maxp table
+        # @return [String] binary maxp bytes for the subset
+        def self.call(context:, tag:, table:)
+          data = table.to_binary_s.dup
+          data[4, 2] = [context.mapping.size].pack("n")
+          data
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/name.rb
+++ b/lib/fontisan/subset/table_strategy/name.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Name strategy: name records don't reference glyph IDs, so the
+      # full source table is preserved.
+      class Name
+        # @param context [SubsetContext]
+        # @param tag [String] "name"
+        # @param table [Name] parsed name table (unused)
+        # @return [String] source name bytes verbatim
+        def self.call(context:, tag:, table:)
+          context.font.table_data[tag]
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/os2.rb
+++ b/lib/fontisan/subset/table_strategy/os2.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # OS/2 strategy: OS/2 currently passes through unchanged. Unicode
+      # range pruning is left as future work — the source OS/2 ranges
+      # remain valid (they describe the source character coverage, which
+      # is a superset of the subset's).
+      class Os2
+        # @param context [SubsetContext]
+        # @param tag [String] "OS/2"
+        # @param table [Os2] parsed OS/2 table (unused)
+        # @return [String] source OS/2 bytes verbatim
+        def self.call(context:, tag:, table:)
+          context.font.table_data[tag]
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/pass_through.rb
+++ b/lib/fontisan/subset/table_strategy/pass_through.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Default fallback for tags that have no dedicated strategy.
+      # Returns the source table bytes verbatim — used for tables that
+      # don't need any glyph-aware subsetting (e.g. name, OS/2).
+      class PassThrough
+        # @param context [SubsetContext]
+        # @param tag [String] table tag
+        # @param table [Object, nil] parsed table (unused)
+        # @return [String, nil] source binary bytes for `tag`, or nil
+        def self.call(context:, tag:, table:)
+          context.font.table_data[tag]
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/post.rb
+++ b/lib/fontisan/subset/table_strategy/post.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # Post strategy: if the `drop_names` option is set, rewrite as a
+      # version 3.0 post table (no glyph names). Otherwise pass through
+      # the source post bytes.
+      class Post
+        # @param context [SubsetContext]
+        # @param tag [String] "post"
+        # @param table [Post] parsed post table
+        # @return [String] binary post bytes for the subset
+        def self.call(context:, tag:, table:)
+          return build_v3(context) if context.options.drop_names
+
+          context.font.table_data["post"]
+        end
+
+        def self.build_v3(context)
+          data = String.new(encoding: Encoding::BINARY)
+          data << [0x00030000].pack("N") # version 3.0
+
+          original = context.font.table_data["post"]
+          data << if original&.length && original.length >= 32
+                    original[4, 28]
+                  else
+                    [0, 0, 0, 0, 0, 0, 0].pack("N7")
+                  end
+
+          data
+        end
+        private_class_method :build_v3
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_subsetter.rb
+++ b/lib/fontisan/subset/table_subsetter.rb
@@ -2,675 +2,108 @@
 
 module Fontisan
   module Subset
-    # Table-specific subsetting strategies
+    # Table-specific subsetting dispatcher.
     #
-    # This class provides methods for subsetting individual font tables according
-    # to the glyph mapping. Each table type has different subsetting requirements:
+    # Per-table subsetting logic lives in [TableStrategy] classes (one
+    # per OpenType tag). This class:
     #
-    # - maxp: Update glyph count
-    # - hhea: Update horizontal metrics count
-    # - hmtx: Subset horizontal metrics
-    # - glyf: Subset glyph data and remap component references
-    # - loca: Rebuild glyph location index
-    # - cmap: Remap character to glyph mappings
-    # - post: Optionally drop glyph names
-    # - name: Pass through (no subsetting needed)
-    # - head: Update checksum adjustment (handled by FontWriter)
-    # - OS/2: Optionally prune Unicode ranges
+    #   1. Holds the inputs to a subsetting run (font, mapping, options)
+    #      plus the cross-strategy [SharedState] (glyf/loca data, bbox,
+    #      max advance, color bitmap subsetter cache).
+    #   2. Dispatches `subset_table(tag, table)` to the right strategy
+    #      via [TableStrategy.for(tag)].
+    #   3. Keeps `subset_<tag>` wrappers for backward compatibility with
+    #      specs that exercise a single strategy in isolation.
     #
-    # The subsetting process preserves font validity by updating all references
-    # and recalculating offsets and checksums.
+    # Adding a new subsetting strategy does NOT require editing this
+    # file — register it in `lib/fontisan/subset/table_strategy.rb`.
     #
     # @example Subset a single table
     #   subsetter = TableSubsetter.new(font, mapping, options)
-    #   maxp_data = subsetter.subset_maxp(maxp_table)
-    #
-    # @example Subset all tables
-    #   subsetter = TableSubsetter.new(font, mapping, options)
-    #   subset_tables = {}
-    #   profile_tables.each do |tag|
-    #     table = font.table(tag)
-    #     subset_tables[tag] = subsetter.subset_table(tag, table) if table
-    #   end
+    #   maxp_data = subsetter.subset_table("maxp", font.table("maxp"))
     class TableSubsetter
-      # Font instance being subset
-      # @return [TrueTypeFont, OpenTypeFont]
+      # @return [SfntFont]
       attr_reader :font
 
-      # Glyph ID mapping (old GID → new GID)
       # @return [GlyphMapping]
       attr_reader :mapping
 
-      # Subsetting options
       # @return [Options]
       attr_reader :options
 
-      # Initialize table subsetter
-      #
-      # @param font [TrueTypeFont, OpenTypeFont] Font to subset
-      # @param mapping [GlyphMapping] Glyph ID mapping
-      # @param options [Options] Subsetting options
+      # @return [SharedState]
+      attr_reader :state
+
       def initialize(font, mapping, options)
         @font = font
         @mapping = mapping
         @options = options
-        @glyf_data = nil
-        @loca_offsets = nil
-        @subset_bbox = nil      # [xMin, yMin, xMax, yMax] over actual subset glyphs
-        @subset_max_advance = 0 # largest advanceWidth in subset hmtx
+        @state = SharedState.new
       end
 
-      # Subset a table by tag
+      # Subset one table by dispatching to its strategy. Unknown tables
+      # fall through to [TableStrategy::PassThrough] which preserves the
+      # source bytes verbatim.
       #
-      # Delegates to table-specific subsetting methods. Unknown tables
-      # are passed through unchanged.
-      #
-      # @param tag [String] Table tag (e.g., "glyf", "hmtx")
-      # @param table [Object] Parsed table object
-      # @return [String] Binary data of subset table
+      # @param tag [String] OpenType table tag (e.g. "glyf", "CBDT")
+      # @param table [Object] parsed table object
+      # @return [String] subset table binary bytes
       def subset_table(tag, table)
-        case tag
-        when "maxp"
-          subset_maxp(table)
-        when "hhea"
-          subset_hhea(table)
-        when "hmtx"
-          subset_hmtx(table)
-        when "loca"
-          subset_loca(table)
-        when "glyf"
-          subset_glyf(table)
-        when "cmap"
-          subset_cmap(table)
-        when "post"
-          subset_post(table)
-        when "name"
-          subset_name(table)
-        when "head"
-          subset_head(table)
-        when "OS/2"
-          subset_os2(table)
-        else
-          # Unknown tables pass through unchanged
-          font.table_data[tag]
-        end
+        TableStrategy.for(tag).call(
+          context: subset_context, tag: tag, table: table,
+        )
       end
 
-      # Subset maxp table (update numGlyphs)
-      #
-      # Updates the numGlyphs field to reflect the number of glyphs in
-      # the subset font.
-      #
-      # @param table [Maxp] Parsed maxp table
-      # @return [String] Binary data of subset maxp table
+      # --- Backward-compat wrappers --------------------------------------
+      # Specs and external callers may invoke `subset_<tag>(table)`
+      # directly. Each wrapper delegates to the corresponding strategy.
+
       def subset_maxp(table)
-        data = table.to_binary_s.dup
-
-        # Update numGlyphs field (at offset 4, uint16)
-        data[4, 2] = [mapping.size].pack("n")
-
-        data
+        subset_table("maxp", table)
       end
 
-      # Subset hhea table (update numberOfHMetrics + advanceWidthMax)
-      #
-      # Updates numberOfHMetrics to reflect the subset's glyph count and
-      # recomputes advanceWidthMax from the subset's actual hmtx. The
-      # source TTC's advanceWidthMax covers every donor font and is far
-      # larger than any per-block subset needs.
-      #
-      # @param table [Hhea] Parsed hhea table
-      # @param hmtx [Hmtx, nil] Optional parsed hmtx table (for calculating metrics)
-      # @return [String] Binary data of subset hhea table
       def subset_hhea(table, hmtx = nil)
-        data = table.to_binary_s.dup
-
-        # Calculate new numberOfHMetrics
-        new_num_h_metrics = if hmtx&.h_metrics
-                              hmtx.h_metrics.size
-                            else
-                              calculate_number_of_h_metrics
-                            end
-
-        # numberOfHMetrics at offset 34 (uint16)
-        data[34, 2] = [new_num_h_metrics].pack("n")
-
-        # advanceWidthMax at offset 10 (uint16). Recompute from subset
-        # hmtx so a per-block subset doesn't keep the source TTC's
-        # max (which can be 4x larger than any glyph in the subset).
-        # Tables are processed alphabetically (hhea before hmtx), so
-        # we read hmtx directly here rather than relying on a cached
-        # value from subset_hmtx.
-        new_max = compute_subset_max_advance
-        data[10, 2] = [new_max].pack("n") if new_max.positive?
-
-        data
+        _ = hmtx # ignored; the strategy recomputes from source hmtx
+        subset_table("hhea", table)
       end
 
-      # Subset hmtx table (subset horizontal metrics)
-      #
-      # Builds new hmtx table with metrics for subset glyphs only,
-      # preserving the order of the glyph mapping.
-      #
-      # @param table [Hmtx] Parsed hmtx table
-      # @return [String] Binary data of subset hmtx table
       def subset_hmtx(table)
-        # Ensure hmtx is parsed
-        unless table.parsed?
-          hhea = font.table("hhea")
-          maxp = font.table("maxp")
-          table.parse_with_context(hhea.number_of_h_metrics, maxp.num_glyphs)
-        end
-
-        # Build new hmtx data
-        data = String.new(encoding: Encoding::BINARY)
-
-        max_advance = 0
-        mapping.old_ids.each do |old_id|
-          metric = table.metric_for(old_id)
-          next unless metric
-
-          advance = metric[:advance_width]
-          max_advance = advance if advance && advance > max_advance
-          data << [advance].pack("n")
-          data << [metric[:lsb]].pack("n")
-        end
-
-        @subset_max_advance = max_advance
-        data
+        subset_table("hmtx", table)
       end
 
-      # Subset glyf table (subset glyph data)
-      #
-      # Extracts glyph data for subset glyphs and remaps component
-      # references in compound glyphs. Also builds loca offsets.
-      #
-      # @param table [Glyf] Parsed glyf table
-      # @return [String] Binary data of subset glyf table
       def subset_glyf(table)
-        # Build glyf and loca together
-        build_glyf_and_loca(table)
-        @glyf_data
+        subset_table("glyf", table)
       end
 
-      # Subset loca table (rebuild glyph location index)
-      #
-      # Builds new loca table based on subset glyph offsets. Must be
-      # called after subset_glyf.
-      #
-      # @param table [Loca] Parsed loca table
-      # @return [String] Binary data of subset loca table
-      def subset_loca(_table)
-        # Build glyf and loca together if not already done
-        glyf = font.table("glyf")
-        build_glyf_and_loca(glyf) unless @loca_offsets
-
-        head = font.table("head")
-        format = head.index_to_loc_format
-
-        data = String.new(encoding: Encoding::BINARY)
-
-        if format.zero?
-          # Short format: offsets / 2 as uint16
-          @loca_offsets.each do |offset|
-            data << [offset / 2].pack("n")
-          end
-        else
-          # Long format: offsets as uint32
-          @loca_offsets.each do |offset|
-            data << [offset].pack("N")
-          end
-        end
-
-        data
+      def subset_loca(table)
+        subset_table("loca", table)
       end
 
-      # Subset cmap table (remap character to glyph mappings)
-      #
-      # Builds new cmap table with only mappings for glyphs in the subset.
-      # Updates glyph IDs to new values from the mapping.
-      #
-      # @param table [Cmap] Parsed cmap table
-      # @return [String] Binary data of subset cmap table
       def subset_cmap(table)
-        # Get old mappings
-        old_mappings = table.unicode_mappings
-        new_mappings = {}
-
-        # Remap to new glyph IDs
-        old_mappings.each do |char_code, old_gid|
-          new_gid = mapping.new_id(old_gid)
-          new_mappings[char_code] = new_gid if new_gid
-        end
-
-        # Build cmap binary with new mappings
-        build_cmap_binary(new_mappings)
+        subset_table("cmap", table)
       end
 
-      # Subset post table (optionally drop glyph names)
-      #
-      # If drop_names option is set, converts to post version 3.0
-      # (no glyph names). Otherwise passes through unchanged.
-      #
-      # @param table [Post] Parsed post table
-      # @return [String] Binary data of subset post table
       def subset_post(table)
-        if options.drop_names
-          # Build post table version 3.0 (no glyph names)
-          build_post_v3(table)
-        else
-          # Keep as-is
-          font.table_data["post"]
-        end
+        subset_table("post", table)
       end
 
-      # Subset name table (pass through)
-      #
-      # Name table doesn't require subsetting, pass through unchanged.
-      #
-      # @param table [Name] Parsed name table
-      # @return [String] Binary data of subset name table
-      def subset_name(_table)
-        font.table_data["name"]
+      def subset_name(table)
+        subset_table("name", table)
       end
 
-      # Subset head table (pass through)
-      #
-      # head table will have checksum updated by FontWriter,
-      # no subsetting needed.
-      #
-      # @param table [Head] Parsed head table
-      # @return [String] Binary data of subset head table
-      # Subset head table (recompute bbox from actual subset glyphs)
-      #
-      # The source TTC's head.xMin/yMin/xMax/yMax covers every donor
-      # font in the collection — far larger than any per-block subset.
-      # Browsers and layout engines use head bbox (plus hhea + OS/2)
-      # to compute line height and clip text; a too-large bbox makes
-      # glyphs render at the wrong visual size.
-      #
-      # @param _table [Head] Parsed head table (unused; we re-serialize
-      #   directly from font.table_data so we don't lose other fields)
-      # @return [String] Binary data of subset head table
-      def subset_head(_table)
-        # Trigger glyf build (which populates @subset_bbox) if not done.
-        glyf = font.table("glyf")
-        build_glyf_and_loca(glyf) unless @glyf_data
-
-        data = font.table_data["head"].dup
-
-        if @subset_bbox
-          x_min, y_min, x_max, y_max = @subset_bbox
-          # head layout: xMin at offset 36, yMin 38, xMax 40, yMax 42
-          # (each int16, big-endian, signed)
-          data[36, 8] = [x_min, y_min, x_max, y_max].pack("n4")
-        end
-
-        data
+      def subset_head(table)
+        subset_table("head", table)
       end
 
-      # Subset OS/2 table (optionally prune Unicode ranges)
-      #
-      # If unicode_ranges option is set, updates Unicode range bits
-      # to reflect only the characters in the subset.
-      #
-      # @param table [Os2] Parsed OS/2 table
-      # @return [String] Binary data of subset OS/2 table
-      def subset_os2(_table)
-        if options.unicode_ranges
-          # TODO: Implement Unicode range pruning
-          # For now, pass through
-        end
-        font.table_data["OS/2"]
+      def subset_os2(table)
+        subset_table("OS/2", table)
       end
 
       private
 
-      # Calculate numberOfHMetrics for subset
-      #
-      # For now, use the size of the mapping. In the future, this could
-      # be optimized by finding the last unique advance width.
-      #
-      # @return [Integer] Number of unique advance widths
-      def calculate_number_of_h_metrics
-        mapping.size
-      end
-
-      # Compute the largest advanceWidth across all subset glyphs by
-      # reading the source hmtx directly. Called from subset_hhea
-      # because hhea is processed before hmtx (alphabetical order).
-      #
-      # @return [Integer] max advanceWidth, or 0 if no metrics found
-      def compute_subset_max_advance
-        hmtx = font.table("hmtx")
-        return 0 unless hmtx
-
-        unless hmtx.parsed?
-          hhea = font.table("hhea")
-          maxp = font.table("maxp")
-          hmtx.parse_with_context(hhea.number_of_h_metrics, maxp.num_glyphs)
-        end
-
-        max_advance = 0
-        mapping.old_ids.each do |old_id|
-          metric = hmtx.metric_for(old_id)
-          next unless metric
-
-          advance = metric[:advance_width]
-          max_advance = advance if advance && advance > max_advance
-        end
-        max_advance
-      end
-
-      # Build glyf and loca tables together
-      #
-      # This method extracts glyph data for all glyphs in the mapping,
-      # remaps component references in compound glyphs, and builds the
-      # loca offset array.
-      #
-      # @param glyf_table [Glyf] Parsed glyf table
-      def build_glyf_and_loca(glyf_table)
-        return if @glyf_data && @loca_offsets
-
-        loca = font.table("loca")
-        head = font.table("head")
-
-        # Ensure loca is parsed
-        unless loca.parsed?
-          maxp = font.table("maxp")
-          loca.parse_with_context(head.index_to_loc_format, maxp.num_glyphs)
-        end
-
-        @glyf_data = String.new(encoding: Encoding::BINARY)
-        @loca_offsets = []
-        current_offset = 0
-
-        # Track union bbox across all subset glyphs. Glyph binary layout:
-        #   int16 numberOfContours (offset 0)
-        #   int16 xMin (offset 2)
-        #   int16 yMin (offset 4)
-        #   int16 xMax (offset 6)
-        #   int16 yMax (offset 8)
-        bbox_x_min = 1 << 30
-        bbox_y_min = 1 << 30
-        bbox_x_max = -(1 << 30)
-        bbox_y_max = -(1 << 30)
-
-        # Process glyphs in mapping order
-        mapping.old_ids.each do |old_id|
-          @loca_offsets << current_offset
-
-          # Get offset and size from original loca
-          offset = loca.offset_for(old_id)
-          size = loca.size_of(old_id)
-
-          # Empty glyph
-          if size.nil? || size.zero?
-            next
-          end
-
-          # Extract glyph data
-          glyph_data = glyf_table.raw_data[offset, size]
-
-          # Update bbox union. Each glyph has at least 10 bytes of
-          # header (numberOfContours + 4 int16 bbox fields).
-          if glyph_data.bytesize >= 10
-            _n, gx_min, gy_min, gx_max, gy_max = glyph_data[0, 10].unpack("n5")
-            # Treat as signed int16
-            gx_min = (gx_min ^ 0x8000) - 0x8000
-            gy_min = (gy_min ^ 0x8000) - 0x8000
-            gx_max = (gx_max ^ 0x8000) - 0x8000
-            gy_max = (gy_max ^ 0x8000) - 0x8000
-            bbox_x_min = gx_min if gx_min < bbox_x_min
-            bbox_y_min = gy_min if gy_min < bbox_y_min
-            bbox_x_max = gx_max if gx_max > bbox_x_max
-            bbox_y_max = gy_max if gy_max > bbox_y_max
-          end
-
-          # Check if compound glyph and remap components
-          if compound_glyph?(glyph_data)
-            glyph_data = remap_compound_glyph(glyph_data)
-          end
-
-          # Add to new glyf data
-          @glyf_data << glyph_data
-          current_offset += glyph_data.bytesize
-        end
-
-        # Add final offset
-        @loca_offsets << current_offset
-
-        # Stash union bbox if we saw at least one non-empty glyph.
-        return if bbox_x_min > bbox_x_max
-
-        @subset_bbox = [bbox_x_min, bbox_y_min, bbox_x_max, bbox_y_max]
-      end
-
-      # Check if glyph data represents a compound glyph
-      #
-      # @param data [String] Glyph binary data
-      # @return [Boolean] True if compound glyph
-      def compound_glyph?(data)
-        return false if data.length < 2
-
-        num_contours_raw = data[0, 2].unpack1("n")
-        num_contours = to_signed_16(num_contours_raw)
-        num_contours == -1
-      end
-
-      # Remap component glyph IDs in compound glyph
-      #
-      # @param data [String] Original compound glyph data
-      # @return [String] Remapped compound glyph data
-      def remap_compound_glyph(data)
-        # Create a mutable copy
-        new_data = data.dup
-        offset = 10 # Skip header (10 bytes)
-
-        loop do
-          break if offset >= new_data.length - 4
-
-          # Read flags and old glyph index
-          flags = new_data[offset, 2].unpack1("n")
-          old_glyph_index = new_data[offset + 2, 2].unpack1("n")
-
-          # Remap glyph index
-          new_glyph_index = mapping.new_id(old_glyph_index)
-          unless new_glyph_index
-            raise Fontisan::SubsettingError,
-                  "Component glyph #{old_glyph_index} not in subset"
-          end
-
-          # Write new glyph index
-          new_data[offset + 2, 2] = [new_glyph_index].pack("n")
-
-          # Move to next component
-          offset += 4 # flags + glyph_index
-
-          # Skip arguments
-          offset += if (flags & 0x0001).zero?
-                      2 # Two 8-bit arguments
-                    else
-                      4 # Two 16-bit arguments
-                    end
-
-          # Skip transformation
-          if (flags & 0x0080) != 0
-            offset += 8  # 2x2 matrix
-          elsif (flags & 0x0040) != 0
-            offset += 4  # X and Y scale
-          elsif (flags & 0x0008) != 0
-            offset += 2  # Uniform scale
-          end
-
-          # Check if more components
-          break unless (flags & 0x0020) != 0
-        end
-
-        new_data
-      end
-
-      # Build cmap binary from mappings
-      #
-      # Creates a minimal cmap table with format 4 subtable for BMP
-      # and format 12 for supplementary planes if needed.
-      #
-      # @param mappings [Hash<Integer, Integer>] Char code => new glyph ID
-      # @return [String] Binary cmap data
-      def build_cmap_binary(mappings)
-        # Edge case: empty mappings (e.g., block with no covered chars).
-        # Emit a minimal valid cmap with one format 4 subtable mapping
-        # only U+0000 → .notdef so the table isn't empty.
-        mappings = { 0 => 0 } if mappings.empty?
-
-        bmp = mappings.select { |cp, _| cp <= 0xFFFF }
-        supp = mappings.select { |cp, _| cp > 0xFFFF }
-
-        subtables = []
-        records = [] # [platform_id, encoding_id, subtable_index]
-
-        unless bmp.empty?
-          subtables << build_cmap_format_4(bmp)
-          idx = subtables.size - 1
-          records << [3, 1, idx] # Windows BMP
-          records << [0, 3, idx] # Unicode BMP
-        end
-
-        unless supp.empty?
-          # Format 12 covers both BMP and supplementary — include all
-          # mappings so a single subtable covers the full range.
-          subtables << build_cmap_format_12(mappings)
-          idx = subtables.size - 1
-          records << [3, 10, idx] # Windows UCS-4
-          records << [0, 4, idx]  # Unicode full
-        end
-
-        # Header: version (uint16) + numTables (uint16)
-        num_tables = records.size
-        header = [0, num_tables].pack("nn")
-
-        # Encoding records start immediately after the header.
-        # Each record is 8 bytes; subtables follow.
-        subtable_base = 4 + (8 * num_tables)
-
-        offsets = []
-        running = subtable_base
-        subtables.each do |st|
-          offsets << running
-          running += st.bytesize
-        end
-
-        record_bytes = +""
-        records.each do |pid, eid, idx|
-          record_bytes << [pid, eid, offsets[idx]].pack("nnN")
-        end
-
-        header + record_bytes + subtables.join
-      end
-
-      # Format 4 subtable: segment-mapping with idDelta, suitable for
-      # BMP codepoints (U+0000..U+FFFF). Builds compact segments where
-      # consecutive codepoints map to consecutive glyph IDs.
-      def build_cmap_format_4(bmp_mappings)
-        segments = coalesce_segments(bmp_mappings)
-        # Mandatory final segment: U+FFFF → gid 0 (per OpenType spec).
-        segments << { start_cp: 0xFFFF, end_cp: 0xFFFF, start_gid: 0 }
-
-        seg_count = segments.size
-        seg_count_x2 = seg_count * 2
-        search_range = 2**Math.log2(seg_count).floor * 2
-        search_range = 2 if search_range < 2
-        entry_selector = Math.log2(search_range / 2).to_i
-        range_shift = seg_count_x2 - search_range
-
-        end_codes = segments.map { |s| s[:end_cp] }
-        start_codes = segments.map { |s| s[:start_cp] }
-        # idDelta is int16 stored as uint16 (two's complement). For a
-        # sequential segment, idDelta = (start_gid - start_cp) & 0xFFFF.
-        id_deltas = segments.map { |s| (s[:start_gid] - s[:start_cp]) & 0xFFFF }
-        id_range_offsets = [0] * seg_count
-
-        subtable = +""
-        subtable << [4, 0, 0, seg_count_x2,
-                     search_range, entry_selector, range_shift].pack("n*")
-        subtable << end_codes.pack("n*")
-        subtable << [0].pack("n") # reservedPad
-        subtable << start_codes.pack("n*")
-        subtable << id_deltas.pack("n*")
-        subtable << id_range_offsets.pack("n*")
-
-        # Patch the length field (was placeholder 0).
-        subtable[2, 2] = [subtable.bytesize].pack("n")
-        subtable
-      end
-
-      # Format 12 subtable: segmented coverage for full Unicode range.
-      # Simpler than format 4 — just (start_char, end_char, start_gid)
-      # triples with no delta/offset indirection.
-      def build_cmap_format_12(all_mappings)
-        groups = coalesce_segments(all_mappings)
-        num_groups = groups.size
-
-        subtable = +""
-        subtable << [12, 0, 0, 0, num_groups].pack("nnNNN")
-        groups.each do |g|
-          subtable << [g[:start_cp], g[:end_cp], g[:start_gid]].pack("NNN")
-        end
-
-        # Patch the length field (was placeholder 0). Total length is
-        # 16-byte header + 12 bytes per group.
-        subtable[4, 4] = [subtable.bytesize].pack("N")
-        subtable
-      end
-
-      # Group codepoints into consecutive runs where both codepoint AND
-      # glyph ID are sequential. Each run becomes one segment/group.
-      def coalesce_segments(mappings)
-        sorted = mappings.sort_by { |cp, _| cp }
-        segments = []
-        current = nil
-        sorted.each do |cp, gid|
-          if current && cp == current[:end_cp] + 1 && gid == current[:start_gid] + (cp - current[:start_cp])
-            current[:end_cp] = cp
-          else
-            segments << current if current
-            current = { start_cp: cp, end_cp: cp, start_gid: gid }
-          end
-        end
-        segments << current if current
-        segments
-      end
-
-      # Build post table version 3.0 (no glyph names)
-      #
-      # @param table [Post] Original post table
-      # @return [String] Binary post v3.0 data
-      def build_post_v3(_table)
-        # Post v3.0 header (32 bytes) - same as v2.0 but version = 3.0
-        data = String.new(encoding: Encoding::BINARY)
-
-        # Version 3.0
-        data << [0x00030000].pack("N")
-
-        # Copy italic angle, underline position/thickness from original
-        original_data = font.table_data["post"]
-        data << if original_data.length >= 32
-                  # Copy fields from offset 4 to 32
-                  original_data[4, 28]
-                else
-                  # Use defaults
-                  [0, 0, 0, 0, 0, 0, 0].pack("N7")
-                end
-
-        data
-      end
-
-      # Convert unsigned 16-bit value to signed
-      #
-      # @param value [Integer] Unsigned 16-bit value
-      # @return [Integer] Signed 16-bit value
-      def to_signed_16(value)
-        value > 0x7FFF ? value - 0x10000 : value
+      def subset_context
+        SubsetContext.new(font: font, mapping: mapping, options: options,
+                          state: state)
       end
     end
   end

--- a/lib/fontisan/tables.rb
+++ b/lib/fontisan/tables.rb
@@ -4,6 +4,17 @@
 
 module Fontisan
   module Tables
+    autoload :CblcBigGlyphMetrics, "fontisan/tables/cblc_big_glyph_metrics"
+    autoload :CblcBitmapSize, "fontisan/tables/cblc_bitmap_size"
+    autoload :CblcGlyphBitmapLocation, "fontisan/tables/cblc_glyph_bitmap_location"
+    autoload :CblcIndexSubTable, "fontisan/tables/cblc_index_subtable"
+    autoload :CblcIndexSubTableArrayEntry,
+             "fontisan/tables/cblc_index_subtable_array_entry"
+    autoload :CblcIndexSubTableFormatParser,
+             "fontisan/tables/cblc_index_subtable_format_parser"
+    autoload :CblcIndexSubTableHeader,
+             "fontisan/tables/cblc_index_subtable_header"
+    autoload :CblcSbitLineMetrics, "fontisan/tables/cblc_sbit_line_metrics"
     autoload :Cbdt, "fontisan/tables/cbdt"
     autoload :Cblc, "fontisan/tables/cblc"
     autoload :Cff, "fontisan/tables/cff"

--- a/lib/fontisan/tables/cbdt.rb
+++ b/lib/fontisan/tables/cbdt.rb
@@ -1,167 +1,112 @@
 # frozen_string_literal: true
 
-require "stringio"
-
 module Fontisan
   module Tables
-    # CBDT (Color Bitmap Data) table parser
+    # CBDT (Color Bitmap Data) table.
     #
-    # The CBDT table contains the actual bitmap data for color glyphs. It works
-    # together with the CBLC table which provides the location information for
-    # finding bitmaps in this table.
+    # CBDT stores the raw bitmap data blocks for color glyphs. CBLC indexes
+    # into CBDT via `imageDataOffset` and per-glyph offset arrays. CBDT
+    # itself is essentially a blob: the 4-byte header (majorVersion +
+    # minorVersion) followed by an opaque sequence of bitmap blocks.
     #
-    # CBDT Table Structure:
-    # ```
-    # CBDT Table = Header (8 bytes)
-    #            + Bitmap Data (variable length)
-    # ```
+    # This model exposes the header fields via BinData and preserves the
+    # original bytes for subsetting and direct slicing. A Cbdt constructed
+    # via `Cbdt.new` (no `read`) has no captured bytes — `raw_data` is nil
+    # and `data_size` returns 0.
     #
-    # Header (8 bytes):
-    # - majorVersion (uint16): Major version (2 or 3)
-    # - minorVersion (uint16): Minor version (0)
-    # - reserved (uint32): Reserved, set to 0
+    # Reference: OpenType CBDT specification.
+    # https://learn.microsoft.com/en-us/typography/opentype/spec/cbdt
     #
-    # The bitmap data format depends on the index subtable format in CBLC.
-    # Common formats include:
-    # - Format 17: Small metrics, PNG data
-    # - Format 18: Big metrics, PNG data
-    # - Format 19: Metrics in CBLC, PNG data
-    #
-    # This parser provides low-level access to bitmap data. For proper bitmap
-    # extraction, use together with CBLC table which contains the index.
-    #
-    # Reference: OpenType CBDT specification
-    # https://docs.microsoft.com/en-us/typography/opentype/spec/cbdt
-    #
-    # @example Reading a CBDT table
-    #   data = font.table_data['CBDT']
-    #   cbdt = Fontisan::Tables::Cbdt.read(data)
-    #   bitmap_data = cbdt.bitmap_data_at(offset, length)
+    # @example Reading CBDT and slicing a bitmap block
+    #   cbdt = Fontisan::Tables::Cbdt.read(font.table_data["CBDT"])
+    #   bytes = cbdt.bitmap_data_at(120, 4096)
     class Cbdt < Binary::BaseRecord
-      # OpenType table tag for CBDT
       TAG = "CBDT"
 
-      # Supported CBDT versions
-      VERSION_2_0 = 0x0002_0000
-      VERSION_3_0 = 0x0003_0000
+      # CBDT v2.0 — original release
+      VERSION_2_0 = 0x00020000
+      # CBDT v3.0 — adds PNG image format support
+      VERSION_3_0 = 0x00030000
 
-      # @return [Integer] Major version (2 or 3)
-      attr_reader :major_version
+      uint16 :major_version
+      uint16 :minor_version
 
-      # @return [Integer] Minor version (0)
-      attr_reader :minor_version
-
-      # @return [String] Raw binary data for the entire CBDT table
-      attr_reader :raw_data
-
-      # Override read to parse CBDT structure
+      # Whether this instance was populated from real table bytes.
       #
-      # @param io [IO, String] Binary data to read
-      # @return [Cbdt] Parsed CBDT table
-      def self.read(io)
-        cbdt = new
-        return cbdt if io.nil?
-
-        data = io.is_a?(String) ? io : io.read
-        cbdt.parse!(data)
-        cbdt
+      # @return [Boolean]
+      def has_raw_data?
+        defined?(@raw_data) && !@raw_data.nil? ? true : false
       end
 
-      # Parse the CBDT table structure
+      # Raw bytes captured at read time, or nil for a fresh instance.
       #
-      # @param data [String] Binary data for the CBDT table
-      # @raise [CorruptedTableError] If CBDT structure is invalid
-      def parse!(data)
-        @raw_data = data
-        io = StringIO.new(data)
+      # @return [String, nil]
+      def raw_data
+        return @raw_data if defined?(@raw_data)
 
-        # Parse CBDT header (8 bytes)
-        parse_header(io)
-        validate_header!
-      rescue StandardError => e
-        raise CorruptedTableError, "Failed to parse CBDT table: #{e.message}"
+        nil
       end
 
-      # Get bitmap data at specific offset and length
+      # Combined version number (e.g. 0x00030000 for v3.0).
       #
-      # Used together with CBLC index to extract bitmap data.
+      # @return [Integer]
+      def version
+        (major_version << 16) | minor_version
+      end
+
+      # Total byte size of the captured CBDT bytes, or 0 if none.
       #
-      # @param offset [Integer] Offset from start of table
-      # @param length [Integer] Length of bitmap data
-      # @return [String, nil] Binary bitmap data or nil
+      # @return [Integer]
+      def data_size
+        raw_data&.bytesize || 0
+      end
+
+      # Whether `offset` falls within the captured CBDT byte range.
+      #
+      # @param offset [Integer, nil]
+      # @return [Boolean]
+      def valid_offset?(offset)
+        return false if offset.nil? || offset.negative?
+
+        offset < data_size
+      end
+
+      # Slice `length` bytes starting at `offset` from the CBDT blob.
+      # Returns nil for out-of-range offsets/lengths so callers can use a
+      # nil check instead of rescuing IndexError.
+      #
+      # @param offset [Integer, nil] start byte
+      # @param length [Integer, nil] number of bytes
+      # @return [String, nil]
       def bitmap_data_at(offset, length)
         return nil if offset.nil? || length.nil?
         return nil if offset.negative? || length.negative?
-        return nil if offset + length > raw_data.length
+        return nil if offset + length > data_size
 
         raw_data[offset, length]
       end
 
-      # Get combined version number
+      # Serialize the captured bytes back to binary. Falls back to BinData's
+      # default serialization (4-byte header) if no bytes were captured,
+      # so consumers can construct a CBDT from scratch.
       #
-      # @return [Integer] Combined version (e.g., 0x00020000 for v2.0)
-      def version
-        return nil if major_version.nil? || minor_version.nil?
+      # @return [String]
+      def to_binary_s
+        return raw_data if has_raw_data?
 
-        (major_version << 16) | minor_version
+        super
       end
 
-      # Get table data size
+      # Whether the header declares a CBDT version fontisan understands
+      # (v2.0 or v3.0) and any raw bytes were captured.
       #
-      # @return [Integer] Size of CBDT table in bytes
-      def data_size
-        raw_data&.length || 0
-      end
-
-      # Check if offset is valid for this table
-      #
-      # @param offset [Integer] Offset to check
-      # @return [Boolean] True if offset is within table bounds
-      def valid_offset?(offset)
-        return false if offset.nil? || offset.negative?
-        return false if raw_data.nil?
-
-        offset < raw_data.length
-      end
-
-      # Validate the CBDT table structure
-      #
-      # @return [Boolean] True if valid
+      # @return [Boolean]
       def valid?
-        return false if major_version.nil? || minor_version.nil?
         return false unless [2, 3].include?(major_version)
         return false unless minor_version.zero?
-        return false unless raw_data
+        return false unless has_raw_data?
 
         true
-      end
-
-      private
-
-      # Parse CBDT header (8 bytes)
-      #
-      # @param io [StringIO] Input stream
-      def parse_header(io)
-        @major_version = io.read(2).unpack1("n")
-        @minor_version = io.read(2).unpack1("n")
-        @reserved = io.read(4).unpack1("N")
-      end
-
-      # Validate header values
-      #
-      # @raise [CorruptedTableError] If validation fails
-      def validate_header!
-        unless [2, 3].include?(major_version)
-          raise CorruptedTableError,
-                "Unsupported CBDT major version: #{major_version} " \
-                "(only versions 2 and 3 supported)"
-        end
-
-        unless minor_version.zero?
-          raise CorruptedTableError,
-                "Unsupported CBDT minor version: #{minor_version} " \
-                "(only version 0 supported)"
-        end
       end
     end
   end

--- a/lib/fontisan/tables/cblc.rb
+++ b/lib/fontisan/tables/cblc.rb
@@ -1,291 +1,170 @@
 # frozen_string_literal: true
 
-require "stringio"
-
 module Fontisan
   module Tables
-    # CBLC (Color Bitmap Location) table parser
+    # CBLC (Color Bitmap Location) table.
     #
-    # The CBLC table contains location information for bitmap glyphs at various
-    # sizes (strikes). It works together with the CBDT table which contains the
-    # actual bitmap data.
+    # CBLC indexes glyph IDs into CBDT byte offsets across one or more
+    # bitmap strikes (each strike = a ppem + bit depth combination). For
+    # each strike, a list of IndexSubTable records describes how to locate
+    # the bitmap of each glyph in a contiguous glyph range.
     #
-    # CBLC Table Structure:
-    # ```
-    # CBLC Table = Header (8 bytes)
-    #            + BitmapSize Records (48 bytes each)
-    # ```
+    # Layout:
+    #   uint32 version                (0x00020000 or 0x00030000)
+    #   uint32 num_sizes              (number of BitmapSize records)
+    #   CblcBitmapSize[num_sizes]     (48 bytes each)
+    #   IndexSubTableArray entries    (8 bytes each, per BitmapSize)
+    #   IndexSubTable records         (variable, format-specific)
     #
-    # Header (8 bytes):
-    # - version (uint32): Table version (0x00020000 or 0x00030000)
-    # - numSizes (uint32): Number of BitmapSize records
+    # This model parses the header + BitmapSize records via BinData, then
+    # lazily walks the IndexSubTableArray / IndexSubTable structures on
+    # demand so callers can iterate [(gid, strike) → CBDT location] pairs.
     #
-    # Each BitmapSize record (48 bytes) contains:
-    # - indexSubTableArrayOffset (uint32): Offset to index subtable array
-    # - indexTablesSize (uint32): Size of index subtables
-    # - numberOfIndexSubTables (uint32): Number of index subtables
-    # - colorRef (uint32): Not used, set to 0
-    # - hori (SbitLineMetrics, 12 bytes): Horizontal line metrics
-    # - vert (SbitLineMetrics, 12 bytes): Vertical line metrics
-    # - startGlyphIndex (uint16): First glyph ID in strike
-    # - endGlyphIndex (uint16): Last glyph ID in strike
-    # - ppemX (uint8): Horizontal pixels per em
-    # - ppemY (uint8): Vertical pixels per em
-    # - bitDepth (uint8): Bit depth (1, 2, 4, 8, 32)
-    # - flags (int8): Flags
+    # Reference: OpenType CBLC specification.
+    # https://learn.microsoft.com/en-us/typography/opentype/spec/cblc
     #
-    # Reference: OpenType CBLC specification
-    # https://docs.microsoft.com/en-us/typography/opentype/spec/cblc
-    #
-    # @example Reading a CBLC table
-    #   data = font.table_data['CBLC']
-    #   cblc = Fontisan::Tables::Cblc.read(data)
-    #   strikes = cblc.strikes
-    #   puts "Font has #{strikes.length} bitmap strikes"
+    # @example Enumerate every glyph's CBDT bitmap location
+    #   cblc = Fontisan::Tables::Cblc.read(font.table_data["CBLC"])
+    #   cblc.each_glyph_location do |loc|
+    #     puts "gid=#{loc.glyph_id} cbdt_offset=#{loc.cbdt_offset}"
+    #   end
     class Cblc < Binary::BaseRecord
-      # OpenType table tag for CBLC
       TAG = "CBLC"
 
-      # Supported CBLC versions
+      # CBLC v2.0 — original release
       VERSION_2_0 = 0x00020000
+      # CBLC v3.0 — adds PNG image format support
       VERSION_3_0 = 0x00030000
 
-      # SbitLineMetrics structure (12 bytes)
+      uint32 :version
+      uint32 :num_sizes
+      array :bitmap_sizes,
+            type: Fontisan::Tables::CblcBitmapSize,
+            initial_length: :num_sizes
+
+      # Iterate every (glyph_id, strike) → CblcGlyphBitmapLocation pair
+      # across all strikes. Each strike's IndexSubTables are walked in
+      # turn so the caller sees every glyph's CBDT location exactly once
+      # per strike.
       #
-      # Contains metrics for horizontal or vertical layout
-      class SbitLineMetrics < Binary::BaseRecord
-        endian :big
-        int8 :ascender
-        int8 :descender
-        uint8 :width_max
-        int8 :caret_slope_numerator
-        int8 :caret_slope_denominator
-        int8 :caret_offset
-        int8 :min_origin_sb
-        int8 :min_advance_sb
-        int8 :max_before_bl
-        int8 :min_after_bl
-        int8 :pad1
-        int8 :pad2
-      end
+      # @yield [CblcGlyphBitmapLocation]
+      # @return [Enumerator] if no block given
+      def each_glyph_location(&block)
+        return enum_for(:each_glyph_location) unless block
 
-      # BitmapSize record structure (48 bytes)
-      #
-      # Describes a bitmap strike at a specific ppem size
-      class BitmapSize < Binary::BaseRecord
-        endian :big
-        uint32 :index_subtable_array_offset
-        uint32 :index_tables_size
-        uint32 :number_of_index_subtables
-        uint32 :color_ref
-
-        # Read the SbitLineMetrics structures manually
-        def self.read(io)
-          data = io.is_a?(String) ? io : io.read
-          size = new
-
-          io = StringIO.new(data)
-          size.instance_variable_set(:@index_subtable_array_offset,
-                                     io.read(4).unpack1("N"))
-          size.instance_variable_set(:@index_tables_size,
-                                     io.read(4).unpack1("N"))
-          size.instance_variable_set(:@number_of_index_subtables,
-                                     io.read(4).unpack1("N"))
-          size.instance_variable_set(:@color_ref, io.read(4).unpack1("N"))
-
-          # Parse hori and vert metrics (12 bytes each)
-          hori_data = io.read(12)
-          vert_data = io.read(12)
-          size.instance_variable_set(:@hori, SbitLineMetrics.read(hori_data))
-          size.instance_variable_set(:@vert, SbitLineMetrics.read(vert_data))
-
-          # Parse remaining fields
-          size.instance_variable_set(:@start_glyph_index,
-                                     io.read(2).unpack1("n"))
-          size.instance_variable_set(:@end_glyph_index, io.read(2).unpack1("n"))
-          size.instance_variable_set(:@ppem_x, io.read(1).unpack1("C"))
-          size.instance_variable_set(:@ppem_y, io.read(1).unpack1("C"))
-          size.instance_variable_set(:@bit_depth, io.read(1).unpack1("C"))
-          size.instance_variable_set(:@flags, io.read(1).unpack1("c"))
-
-          size
-        end
-
-        attr_reader :index_subtable_array_offset, :index_tables_size,
-                    :number_of_index_subtables, :color_ref, :hori, :vert,
-                    :start_glyph_index, :end_glyph_index, :ppem_x, :ppem_y,
-                    :bit_depth, :flags
-
-        # Get ppem size (assumes square pixels)
-        #
-        # @return [Integer] Pixels per em
-        def ppem
-          ppem_x
-        end
-
-        # Get glyph range for this strike
-        #
-        # @return [Range] Range of glyph IDs
-        def glyph_range
-          start_glyph_index..end_glyph_index
-        end
-
-        # Check if this strike includes a specific glyph ID
-        #
-        # @param glyph_id [Integer] Glyph ID to check
-        # @return [Boolean] True if glyph is in range
-        def includes_glyph?(glyph_id)
-          glyph_range.include?(glyph_id)
+        index_sub_tables.each do |sub|
+          sub.locations.each(&block)
         end
       end
 
-      # @return [Integer] CBLC version
-      attr_reader :version
-
-      # @return [Integer] Number of bitmap size records
-      attr_reader :num_sizes
-
-      # @return [Array<BitmapSize>] Parsed bitmap size records
-      attr_reader :bitmap_sizes
-
-      # @return [String] Raw binary data for the entire CBLC table
-      attr_reader :raw_data
-
-      # Override read to parse CBLC structure
+      # All IndexSubTable records across every strike.
       #
-      # @param io [IO, String] Binary data to read
-      # @return [Cblc] Parsed CBLC table
-      def self.read(io)
-        cblc = new
-        return cblc if io.nil?
-
-        data = io.is_a?(String) ? io : io.read
-        cblc.parse!(data)
-        cblc
+      # @return [Array<CblcIndexSubTable>]
+      def index_sub_tables
+        @index_sub_tables ||= bitmap_sizes.flat_map { |s| sub_tables_for(s) }
       end
 
-      # Parse the CBLC table structure
+      # Locate a glyph's CBDT bitmap at a specific ppem.
       #
-      # @param data [String] Binary data for the CBLC table
-      # @raise [CorruptedTableError] If CBLC structure is invalid
-      def parse!(data)
-        @raw_data = data
-        io = StringIO.new(data)
+      # @param glyph_id [Integer] source glyph ID
+      # @param ppem [Integer] strike ppem
+      # @return [CblcGlyphBitmapLocation, nil]
+      def bitmap_offset_for_gid(glyph_id, ppem)
+        strike = bitmap_sizes.find do |s|
+          s.ppem == ppem && s.includes_glyph?(glyph_id)
+        end
+        return nil unless strike
 
-        # Parse CBLC header (8 bytes)
-        parse_header(io)
-        validate_header!
-
-        # Parse bitmap size records
-        parse_bitmap_sizes(io)
-      rescue StandardError => e
-        raise CorruptedTableError, "Failed to parse CBLC table: #{e.message}"
+        sub_tables_for(strike).each do |sub|
+          loc = sub.locations.find { |l| l.glyph_id == glyph_id }
+          return loc if loc
+        end
+        nil
       end
 
-      # Get bitmap strikes (sizes)
+      # Iterate every IndexSubTable in a single strike.
       #
-      # @return [Array<BitmapSize>] Array of bitmap strikes
-      def strikes
-        bitmap_sizes || []
-      end
+      # @param strike [CblcBitmapSize]
+      # @return [Array<CblcIndexSubTable>]
+      def sub_tables_for(strike)
+        return [] if strike.number_of_index_subtables.zero?
 
-      # Get strikes for specific ppem size
-      #
-      # @param ppem [Integer] Pixels per em
-      # @return [Array<BitmapSize>] Strikes matching ppem
-      def strikes_for_ppem(ppem)
-        strikes.select { |size| size.ppem == ppem }
-      end
+        array_offset = strike.index_subtable_array_offset
+        entries = read_index_subtable_array(strike, array_offset)
 
-      # Check if glyph has bitmap at ppem size
-      #
-      # @param glyph_id [Integer] Glyph ID
-      # @param ppem [Integer] Pixels per em
-      # @return [Boolean] True if glyph has bitmap
-      def has_bitmap_for_glyph?(glyph_id, ppem)
-        strikes_for_ppem(ppem).any? do |strike|
-          strike.includes_glyph?(glyph_id)
+        entries.map do |entry|
+          absolute = array_offset + entry.additional_offset_to_index_subtable
+          CblcIndexSubTable.parse(
+            raw_data,
+            index_subtable_offset: absolute,
+            first_glyph_index: entry.first_glyph_index,
+            last_glyph_index: entry.last_glyph_index,
+          )
         end
       end
 
-      # Get all available ppem sizes
+      # All available ppem sizes across every strike.
       #
-      # @return [Array<Integer>] Sorted array of ppem sizes
+      # @return [Array<Integer>]
       def ppem_sizes
-        strikes.map(&:ppem).uniq.sort
+        bitmap_sizes.map(&:ppem).uniq.sort
       end
 
-      # Get all glyph IDs that have bitmaps across all strikes
+      # Number of bitmap strikes.
       #
-      # @return [Array<Integer>] Array of glyph IDs
-      def glyph_ids_with_bitmaps
-        strikes.flat_map { |strike| strike.glyph_range.to_a }.uniq.sort
-      end
-
-      # Get strikes that include a specific glyph ID
-      #
-      # @param glyph_id [Integer] Glyph ID
-      # @return [Array<BitmapSize>] Strikes containing glyph
-      def strikes_for_glyph(glyph_id)
-        strikes.select { |strike| strike.includes_glyph?(glyph_id) }
-      end
-
-      # Get the number of bitmap strikes
-      #
-      # @return [Integer] Number of strikes
+      # @return [Integer]
       def num_strikes
-        num_sizes || 0
+        num_sizes
       end
 
-      # Validate the CBLC table structure
+      # Strikes that cover a given glyph ID.
       #
-      # @return [Boolean] True if valid
+      # @param glyph_id [Integer]
+      # @return [Array<CblcBitmapSize>]
+      def strikes_for_glyph(glyph_id)
+        bitmap_sizes.select { |s| s.includes_glyph?(glyph_id) }
+      end
+
+      # Strikes that match a specific ppem.
+      #
+      # @param ppem [Integer]
+      # @return [Array<CblcBitmapSize>]
+      def strikes_for_ppem(ppem)
+        bitmap_sizes.select { |s| s.ppem == ppem }
+      end
+
+      # All glyph IDs that have any bitmap across every strike.
+      #
+      # @return [Array<Integer>]
+      def glyph_ids_with_bitmaps
+        bitmap_sizes.flat_map { |s| s.glyph_range.to_a }.uniq.sort
+      end
+
+      # Whether the CBLC header is one fontisan understands and at least
+      # the header fields parsed successfully.
+      #
+      # @return [Boolean]
       def valid?
         return false if version.nil?
         return false unless [VERSION_2_0, VERSION_3_0].include?(version)
-        return false if num_sizes.nil? || num_sizes.negative?
-        return false unless bitmap_sizes
 
         true
       end
 
       private
 
-      # Parse CBLC header (8 bytes)
+      # Read the IndexSubTableArray entries for one strike.
       #
-      # @param io [StringIO] Input stream
-      def parse_header(io)
-        @version = io.read(4).unpack1("N")
-        @num_sizes = io.read(4).unpack1("N")
-      end
+      # @param strike [CblcBitmapSize]
+      # @param array_offset [Integer] absolute offset within CBLC bytes
+      # @return [Array<CblcIndexSubTableArrayEntry>]
+      def read_index_subtable_array(strike, array_offset)
+        count = strike.number_of_index_subtables
+        bytes = raw_data[array_offset, count * 8]
+        return [] unless bytes
 
-      # Validate header values
-      #
-      # @raise [CorruptedTableError] If validation fails
-      def validate_header!
-        unless [VERSION_2_0, VERSION_3_0].include?(version)
-          raise CorruptedTableError,
-                "Unsupported CBLC version: 0x#{version.to_s(16).upcase} " \
-                "(only versions 2.0 and 3.0 supported)"
-        end
-
-        if num_sizes.negative?
-          raise CorruptedTableError,
-                "Invalid numSizes: #{num_sizes}"
-        end
-      end
-
-      # Parse bitmap size records
-      #
-      # @param io [StringIO] Input stream
-      def parse_bitmap_sizes(io)
-        @bitmap_sizes = []
-        return if num_sizes.zero?
-
-        # Each BitmapSize record is 48 bytes
-        num_sizes.times do
-          size_data = io.read(48)
-          @bitmap_sizes << BitmapSize.read(size_data)
+        Array.new(count) do |i|
+          CblcIndexSubTableArrayEntry.read(bytes[i * 8, 8])
         end
       end
     end

--- a/lib/fontisan/tables/cblc_big_glyph_metrics.rb
+++ b/lib/fontisan/tables/cblc_big_glyph_metrics.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    # 8-byte bigGlyphMetrics record embedded in CBLC IndexSubTable formats
+    # 2 and 5 (constant-metrics strikes). Layout is smallGlyphMetrics (5
+    # bytes) plus four additional signed advance fields.
+    #
+    #   uint8 height
+    #   uint8 width
+    #   int8  bearing_x
+    #   int8  bearing_y
+    #   int8  advance
+    #   int8  reserved
+    #   int8  advance_lsb
+    #   int8  advance_rsb
+    class CblcBigGlyphMetrics < Binary::BaseRecord
+      uint8 :height
+      uint8 :width
+      int8 :bearing_x
+      int8 :bearing_y
+      int8 :advance
+      int8 :reserved
+      int8 :advance_lsb
+      int8 :advance_rsb
+    end
+  end
+end

--- a/lib/fontisan/tables/cblc_bitmap_size.rb
+++ b/lib/fontisan/tables/cblc_bitmap_size.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Fontisan
+  module Tables
+    # BitmapSize record embedded in a CBLC table (48 bytes).
+    #
+    # Each BitmapSize describes one bitmap strike: a glyph range rendered
+    # at a specific ppem with a specific bit depth. It points (via
+    # `index_subtable_array_offset`) at a sequence of IndexSubTableArray
+    # records that further describe how to find the bitmap data for each
+    # glyph in CBDT.
+    #
+    # Layout (48 bytes):
+    #   uint32 index_subtable_array_offset
+    #   uint32 index_tables_size
+    #   uint32 number_of_index_subtables
+    #   uint32 color_ref
+    #   CblcSbitLineMetrics hori (12 bytes)
+    #   CblcSbitLineMetrics vert (12 bytes)
+    #   uint16 start_glyph_index
+    #   uint16 end_glyph_index
+    #   uint8  ppem_x
+    #   uint8  ppem_y
+    #   uint8  bit_depth
+    #   int8   flags
+    #
+    # Reference: OpenType CBLC spec, "BitmapSize" record.
+    class CblcBitmapSize < Binary::BaseRecord
+      uint32 :index_subtable_array_offset
+      uint32 :index_tables_size
+      uint32 :number_of_index_subtables
+      uint32 :color_ref
+      CblcSbitLineMetrics :hori, type: Fontisan::Tables::CblcSbitLineMetrics
+      CblcSbitLineMetrics :vert, type: Fontisan::Tables::CblcSbitLineMetrics
+      uint16 :start_glyph_index
+      uint16 :end_glyph_index
+      uint8 :ppem_x
+      uint8 :ppem_y
+      uint8 :bit_depth
+      int8 :flags
+
+      # Pixels per em, assuming square pixels (the common case).
+      #
+      # @return [Integer] ppem value
+      def ppem
+        ppem_x
+      end
+
+      # Glyph ID range covered by this strike.
+      #
+      # @return [Range<Integer>] inclusive glyph ID range
+      def glyph_range
+        start_glyph_index..end_glyph_index
+      end
+
+      # Whether the strike covers a specific glyph.
+      #
+      # @param glyph_id [Integer] source glyph ID
+      # @return [Boolean]
+      def includes_glyph?(glyph_id)
+        glyph_range.include?(glyph_id)
+      end
+    end
+  end
+end

--- a/lib/fontisan/tables/cblc_glyph_bitmap_location.rb
+++ b/lib/fontisan/tables/cblc_glyph_bitmap_location.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    # Immutable value object locating one glyph's bitmap inside a CBDT table.
+    #
+    # A CblcIndexSubTable produces one of these per glyph in its range.
+    # The subsetting pipeline reads them to know which CBDT byte range to
+    # retain, then computes fresh offsets for the subset output.
+    #
+    # @!attribute glyph_id
+    #   @return [Integer] source glyph ID
+    # @!attribute image_format
+    #   @return [Integer] CBDT image format (e.g. 17, 18, 19)
+    # @!attribute cbdt_offset
+    #   @return [Integer] absolute byte offset within the source CBDT
+    # @!attribute byte_length
+    #   @return [Integer] length of the bitmap block in CBDT
+    CblcGlyphBitmapLocation = Struct.new(:glyph_id, :image_format,
+                                         :cbdt_offset, :byte_length,
+                                         keyword_init: true) do
+      def initialize(*)
+        super
+        freeze
+      end
+    end
+  end
+end

--- a/lib/fontisan/tables/cblc_index_subtable.rb
+++ b/lib/fontisan/tables/cblc_index_subtable.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    # Parsed IndexSubTable from a CBLC table.
+    #
+    # The IndexSubTable is the format-specific directory describing how to
+    # locate each glyph's bitmap inside CBDT. Five formats are defined by
+    # the OpenType spec:
+    #
+    #   1 — variable metrics, variable size (uint32 offset array)
+    #   2 — constant metrics, constant size (single imageSize for the range)
+    #   3 — variable metrics, variable size, 4-byte-aligned (uint16 offsets × 4)
+    #   4 — variable metrics, variable size, bit-packed offsets (rare)
+    #   5 — constant metrics, constant size, with explicit uint32 offsetArray
+    #
+    # Each parsed IndexSubTable exposes one [CblcGlyphBitmapLocation] per
+    # glyph in its range, plus the raw bytes so a subsetter can preserve
+    # unchanged subtables verbatim if needed.
+    #
+    # Format-specific parsing is delegated to
+    # [CblcIndexSubTableFormatParser]; this class only owns the data model.
+    #
+    # Reference: OpenType CBLC spec, IndexSubTable formats 1–5.
+    class CblcIndexSubTable
+      # @return [Integer] indexFormat field (1, 2, 3, or 5)
+      attr_reader :index_format
+
+      # @return [Integer] imageFormat field (e.g. 17 = small metrics + PNG)
+      attr_reader :image_format
+
+      # @return [Integer] absolute imageDataOffset from start of CBDT
+      attr_reader :image_data_offset
+
+      # @return [Integer] first glyph ID covered by this subtable
+      attr_reader :first_glyph_index
+
+      # @return [Integer] last glyph ID covered by this subtable
+      attr_reader :last_glyph_index
+
+      # @return [Array<CblcGlyphBitmapLocation>] one per glyph in range
+      attr_reader :locations
+
+      # @return [String] raw bytes of this IndexSubTable in the source CBLC
+      attr_reader :raw_bytes
+
+      def initialize(index_format:, image_format:, image_data_offset:,
+                     first_glyph_index:, last_glyph_index:, locations:,
+                     raw_bytes:)
+        @index_format = index_format
+        @image_format = image_format
+        @image_data_offset = image_data_offset
+        @first_glyph_index = first_glyph_index
+        @last_glyph_index = last_glyph_index
+        @locations = locations
+        @raw_bytes = raw_bytes
+      end
+
+      # Parse an IndexSubTable from a CBLC binary blob.
+      #
+      # @param cblc_bytes [String] the full CBLC table bytes
+      # @param index_subtable_offset [Integer] absolute byte offset within
+      #   `cblc_bytes` where this IndexSubTable begins
+      # @param first_glyph_index [Integer] first glyph ID covered
+      # @param last_glyph_index [Integer] last glyph ID covered
+      # @return [CblcIndexSubTable]
+      def self.parse(cblc_bytes, index_subtable_offset:, first_glyph_index:,
+                     last_glyph_index:)
+        header = CblcIndexSubTableHeader.read(
+          cblc_bytes[index_subtable_offset, 8],
+        )
+
+        new(
+          index_format: header.index_format,
+          image_format: header.image_format,
+          image_data_offset: header.image_data_offset,
+          first_glyph_index: first_glyph_index,
+          last_glyph_index: last_glyph_index,
+          locations: CblcIndexSubTableFormatParser.locations(
+            header: header,
+            bytes: cblc_bytes,
+            base: index_subtable_offset,
+            first: first_glyph_index,
+            last: last_glyph_index,
+          ),
+          raw_bytes: CblcIndexSubTableFormatParser.raw_bytes(
+            header: header,
+            bytes: cblc_bytes,
+            base: index_subtable_offset,
+            first: first_glyph_index,
+            last: last_glyph_index,
+          ),
+        )
+      end
+
+      # Number of glyphs covered by this subtable.
+      #
+      # @return [Integer]
+      def glyph_count
+        last_glyph_index - first_glyph_index + 1
+      end
+    end
+  end
+end

--- a/lib/fontisan/tables/cblc_index_subtable_array_entry.rb
+++ b/lib/fontisan/tables/cblc_index_subtable_array_entry.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    # Entry in a CBLC IndexSubTableArray (8 bytes).
+    #
+    # The IndexSubTableArray sits at `BitmapSize#index_subtable_array_offset`
+    # (relative to the start of CBLC) and contains `number_of_index_subtables`
+    # of these entries. Each entry points (via `additional_offset_to_index_subtable`,
+    # relative to the IndexSubTableArray's own location) at an IndexSubTable
+    # record describing how to find the bitmaps for a glyph range.
+    #
+    # Reference: OpenType CBLC spec, IndexSubTableArray record.
+    class CblcIndexSubTableArrayEntry < Binary::BaseRecord
+      uint16 :first_glyph_index
+      uint16 :last_glyph_index
+      uint32 :additional_offset_to_index_subtable
+    end
+  end
+end

--- a/lib/fontisan/tables/cblc_index_subtable_format_parser.rb
+++ b/lib/fontisan/tables/cblc_index_subtable_format_parser.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    # Per-format CBLC IndexSubTable parser. Extracted as a sibling class so
+    # that CblcIndexSubTable remains a pure data model.
+    #
+    # The five OpenType formats differ in how the offset array encodes
+    # glyph lengths and CBDT offsets. This class hides that arithmetic
+    # behind a uniform [.locations] entry point that returns a flat list
+    # of CblcGlyphBitmapLocation objects (one per glyph in the range).
+    #
+    # Reference: OpenType CBLC spec, IndexSubTable formats 1–5.
+    class CblcIndexSubTableFormatParser
+      # Format 4 (bit-packed offsets) is rare and not currently parsed.
+      class UnsupportedFormat < Fontisan::Error; end
+
+      class << self
+        # Returns an Array of CblcGlyphBitmapLocation, one per glyph in
+        # the IndexSubTable's glyph range.
+        #
+        # @param header [CblcIndexSubTableHeader] the 8-byte IndexSubTable header
+        # @param bytes [String] the full CBLC table bytes
+        # @param base [Integer] absolute offset of this IndexSubTable within CBLC
+        # @param first [Integer] first glyph ID covered
+        # @param last [Integer] last glyph ID covered
+        # @return [Array<CblcGlyphBitmapLocation>]
+        def locations(header:, bytes:, base:, first:, last:)
+          case header.index_format
+          when 1 then format_1(header, bytes, base, first, last)
+          when 2 then format_2(header, bytes, base, first, last)
+          when 3 then format_3(header, bytes, base, first, last)
+          when 5 then format_5(header, bytes, base, first, last)
+          when 4
+            raise UnsupportedFormat,
+                  "CBLC IndexSubTable format 4 (bit-packed) is unsupported"
+          else
+            raise UnsupportedFormat,
+                  "Unknown CBLC IndexSubTable format: #{header.index_format}"
+          end
+        end
+
+        # Returns the raw bytes the IndexSubTable occupies in CBLC.
+        #
+        # @return [String]
+        def raw_bytes(header:, bytes:, base:, first:, last:)
+          count = last - first + 1
+          length = byte_length(header.index_format, count, bytes, base)
+          bytes[base, length]
+        end
+
+        private
+
+        # Format 1: variable metrics + variable size, uint32 offsetArray.
+        # offsets[0] is the first glyph's bitmap start (relative to
+        # imageDataOffset); offsets[i+1] - offsets[i] = glyph i's length.
+        def format_1(header, bytes, base, first, last)
+          count = last - first + 1
+          offsets = uint32_array(bytes, base + 8, count + 1)
+          build(first, count, offsets, header.image_format,
+                header.image_data_offset)
+        end
+
+        # Format 2: constant metrics + constant size. One imageSize field
+        # applies to every glyph; the i-th glyph's bitmap is at
+        # imageDataOffset + i * imageSize.
+        def format_2(header, bytes, base, first, last)
+          count = last - first + 1
+          image_size = bytes[base + 8, 4].unpack1("N")
+          Array.new(count) do |i|
+            CblcGlyphBitmapLocation.new(
+              glyph_id: first + i,
+              image_format: header.image_format,
+              cbdt_offset: header.image_data_offset + (i * image_size),
+              byte_length: image_size,
+            )
+          end
+        end
+
+        # Format 3: like format 1 but offsets are uint16 and stored as
+        # multiples of 4 (CBDT bitmap data is 4-byte aligned).
+        def format_3(header, bytes, base, first, last)
+          count = last - first + 1
+          raw = uint16_array(bytes, base + 8, count + 1)
+          offsets = raw.map { |v| v * 4 }
+          build(first, count, offsets, header.image_format,
+                header.image_data_offset)
+        end
+
+        # Format 5: constant metrics + constant size with an explicit
+        # uint32 offsetArray (count + 1 entries). Length per glyph is
+        # the constant imageSize; offset comes from the array.
+        def format_5(header, bytes, base, first, last)
+          count = last - first + 1
+          image_size = bytes[base + 8, 4].unpack1("N")
+          offset_array_start = base + 12 + 8 + 4
+          offsets = uint32_array(bytes, offset_array_start, count + 1)
+          Array.new(count) do |i|
+            start_off = offsets[i] || 0
+            CblcGlyphBitmapLocation.new(
+              glyph_id: first + i,
+              image_format: header.image_format,
+              cbdt_offset: header.image_data_offset + start_off,
+              byte_length: image_size,
+            )
+          end
+        end
+
+        def build(first, count, offsets, image_format, image_data_offset)
+          Array.new(count) do |i|
+            start_off = offsets[i] || 0
+            end_off = offsets[i + 1] || start_off
+            CblcGlyphBitmapLocation.new(
+              glyph_id: first + i,
+              image_format: image_format,
+              cbdt_offset: image_data_offset + start_off,
+              byte_length: end_off - start_off,
+            )
+          end
+        end
+
+        def byte_length(index_format, count, bytes, base)
+          case index_format
+          when 1, 3
+            entry_size = index_format == 1 ? 4 : 2
+            8 + (count + 1) * entry_size
+          when 2
+            8 + 4 + 8 # header + imageSize + bigGlyphMetrics
+          when 5
+            8 + 4 + 8 + 4 + (count + 1) * 4
+          else
+            bytes.bytesize - base
+          end
+        end
+
+        def uint32_array(bytes, offset, count)
+          return [] if count.zero?
+
+          bytes[offset, count * 4].unpack("N*")
+        end
+
+        def uint16_array(bytes, offset, count)
+          return [] if count.zero?
+
+          bytes[offset, count * 2].unpack("n*")
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/tables/cblc_index_subtable_header.rb
+++ b/lib/fontisan/tables/cblc_index_subtable_header.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    # 8-byte header common to all CBLC IndexSubTable formats.
+    #
+    #   uint16 indexFormat
+    #   uint16 imageFormat
+    #   uint32 imageDataOffset (absolute, from start of CBDT)
+    #
+    # Format-specific data follows immediately after this header.
+    class CblcIndexSubTableHeader < Binary::BaseRecord
+      uint16 :index_format
+      uint16 :image_format
+      uint32 :image_data_offset
+    end
+  end
+end

--- a/lib/fontisan/tables/cblc_sbit_line_metrics.rb
+++ b/lib/fontisan/tables/cblc_sbit_line_metrics.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Tables
+    # SbitLineMetrics record embedded in CBLC BitmapSize records.
+    #
+    # Two of these (horizontal + vertical) appear in every BitmapSize,
+    # totalling 24 bytes per strike. The fields are signed/unsigned 8-bit
+    # integers; OpenType specifies signed values for some, unsigned for
+    # others, mirroring the EBDT/BDF layout.
+    #
+    # Reference: OpenType CBLC spec, "SbitLineMetrics" sub-structure.
+    class CblcSbitLineMetrics < Binary::BaseRecord
+      int8 :ascender
+      int8 :descender
+      uint8 :width_max
+      int8 :caret_slope_numerator
+      int8 :caret_slope_denominator
+      int8 :caret_offset
+      int8 :min_origin_sb
+      int8 :min_advance_sb
+      int8 :max_before_bl
+      int8 :min_after_bl
+      int8 :pad1
+      int8 :pad2
+    end
+  end
+end

--- a/spec/fontisan/subset/table_strategy/cbdt_spec.rb
+++ b/spec/fontisan/subset/table_strategy/cbdt_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fontisan/subset/subset_context"
+require "fontisan/subset/shared_state"
+require "fontisan/subset/table_strategy/cbdt"
+require "fontisan/subset/table_strategy/cblc"
+
+RSpec.describe Fontisan::Subset::TableStrategy::Cbdt do
+  # Build a single-strike CBLC + CBDT pair covering gids 10..14.
+  let(:bitmaps) { %w[AAAA BBBB CCCC DDDD EEEE].map(&:b) }
+
+  let(:cbdt_blob) do
+    [3, 0].pack("nn") + bitmaps.join
+  end
+
+  let(:cblc_blob) do
+    image_data_offset = 4
+    offsets = Array.new(bitmaps.length + 1) { |i| (i * 4) / 4 }
+    ist = [3, 17, image_data_offset].pack("nnN") + offsets.pack("n*")
+    ista = [10, 14, 8].pack("nnN")
+    bsm = [56, ista.bytesize + ist.bytesize, 1, 0].pack("NNNN") +
+      ("\x00" * 24) + [10, 14, 16, 16, 32, 0].pack("nnCCCc")
+    [0x00030000, 1].pack("NN") + bsm + ista + ist
+  end
+
+  let(:font) do
+    Struct.new(:table_data, keyword_init: true)
+      .new(table_data: { "CBDT" => cbdt_blob, "CBLC" => cblc_blob })
+  end
+
+  let(:mapping) { Fontisan::Subset::GlyphMapping.new([0, 10, 12]) }
+
+  let(:context) do
+    Fontisan::Subset::SubsetContext.new(
+      font: font, mapping: mapping, options: nil,
+      state: Fontisan::Subset::SharedState.new
+    )
+  end
+
+  it "returns CBDT bytes that preserve the 4-byte header" do
+    bytes = described_class.call(context: context, tag: "CBDT", table: nil)
+    expect(bytes[0, 4]).to eq(cbdt_blob[0, 4])
+  end
+
+  it "produces a smaller CBDT than the source" do
+    bytes = described_class.call(context: context, tag: "CBDT", table: nil)
+    expect(bytes.bytesize).to be < cbdt_blob.bytesize
+  end
+
+  it "caches the paired subsetter on the shared state" do
+    described_class.call(context: context, tag: "CBDT", table: nil)
+    cached = context.state.color_bitmap_subsetter
+    expect(cached).to be_a(Fontisan::Subset::TableStrategy::ColorBitmapSubsetter)
+
+    cblc_bytes = Fontisan::Subset::TableStrategy::Cblc.call(
+      context: context, tag: "CBLC", table: nil,
+    )
+    expect(cblc_bytes).to eq(cached.cblc_bytes)
+  end
+end

--- a/spec/fontisan/subset/table_strategy/color_bitmap_subsetter_spec.rb
+++ b/spec/fontisan/subset/table_strategy/color_bitmap_subsetter_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Shared helper: build a single-strike CBLC + CBDT pair covering a
+# contiguous glyph range. Bitmaps are 4-byte aligned so format 3
+# offsets stay valid in the source. Format 17 = small metrics + PNG
+# image, the NotoColorEmoji layout.
+module ColorBitmapSpecHelpers
+  def build_color_font(bitmaps:, first_gid: 10, last_gid: 14, ppem: 16, image_format: 17, version: 0x00030000)
+    count = bitmaps.length
+    raise ArgumentError unless count == last_gid - first_gid + 1
+
+    cbd_header = [3, 0].pack("nn")
+    cbdt_blob = cbd_header + bitmaps.join
+
+    # Build IndexSubTable format 3: header(8) + uint16 offsetArray[count+1]
+    # offsets stored as multiples of 4 (4-byte aligned). imageDataOffset
+    # = 4 (start of bitmap data after CBDT 4-byte header).
+    image_data_offset = 4
+    offsets_raw = Array.new(count + 1) do |i|
+      (i * bitmaps.first.bytesize) / 4
+    end
+    ist = [3, image_format, image_data_offset].pack("nnN") +
+      offsets_raw.pack("n*")
+    ista = [first_gid, last_gid, 8].pack("nnN")
+
+    bsm_offset = 8 + 48
+    bsm_size = ista.bytesize + ist.bytesize
+    bsm = [bsm_offset, bsm_size, 1, 0].pack("NNNN") +
+      ("\x00" * 24) +
+      [first_gid, last_gid, ppem, ppem, 32, 0].pack("nnCCCc")
+
+    cblc_blob = [version, 1].pack("NN") + bsm + ista + ist
+    [cblc_blob, cbdt_blob]
+  end
+
+  # Build a minimal font-like object exposing only the API the
+  # ColorBitmapSubsetter needs: table_data returns CBDT/CBLC bytes.
+  TestFont = Struct.new(:table_data, keyword_init: true)
+
+  def build_test_font(cbdt:, cblc:)
+    TestFont.new(table_data: { "CBDT" => cbdt, "CBLC" => cblc })
+  end
+end
+
+RSpec.describe Fontisan::Subset::TableStrategy::ColorBitmapSubsetter do
+  include ColorBitmapSpecHelpers
+
+  describe "subset of a 2-emoji range from a 5-emoji source" do
+    subject(:subsetter) do
+      described_class.new(font: font, mapping: mapping).build
+    end
+
+    let(:bitmaps) do
+      %w[AAAA BBBB CCCC DDDD EEEE].map(&:b)
+    end
+
+    let(:cblc_blob) do
+      build_color_font(first_gid: 10, last_gid: 14,
+                       bitmaps: bitmaps).first
+    end
+    let(:cbdt_blob) do
+      build_color_font(first_gid: 10, last_gid: 14,
+                       bitmaps: bitmaps).last
+    end
+    let(:font) { build_test_font(cbdt: cbdt_blob, cblc: cblc_blob) }
+
+    # Source gids [0, 10, 12] → subset retains only those; gid 0
+    # (.notdef) is not in CBLC.
+    let(:mapping) { Fontisan::Subset::GlyphMapping.new([0, 10, 12]) }
+
+    it "produces a smaller CBDT than the source" do
+      expect(subsetter.cbdt_bytes.bytesize).to be < cbdt_blob.bytesize
+    end
+
+    it "preserves the 4-byte CBDT header" do
+      expect(subsetter.cbdt_bytes[0, 4]).to eq(cbdt_blob[0, 4])
+    end
+
+    it "includes exactly the retained bitmaps in the new CBDT body" do
+      body = subsetter.cbdt_bytes[4..]
+      expect(body).to eq("AAAACCCC")
+    end
+
+    it "produces a CBLC whose version matches the source" do
+      version = subsetter.cblc_bytes[0, 4].unpack1("N")
+      expect(version).to eq(0x00030000)
+    end
+
+    it "reports one surviving strike in the new CBLC" do
+      num_sizes = subsetter.cblc_bytes[4, 4].unpack1("N")
+      expect(num_sizes).to eq(1)
+    end
+
+    it "round-trips the new CBLC through Tables::Cblc.read" do
+      rebuilt = Fontisan::Tables::Cblc.read(subsetter.cblc_bytes)
+      expect(rebuilt.bitmap_sizes.length).to eq(1)
+    end
+
+    it "the new CBLC's surviving IndexSubTable covers only retained new gids" do
+      rebuilt = Fontisan::Tables::Cblc.read(subsetter.cblc_bytes)
+      gids = rebuilt.each_glyph_location.map(&:glyph_id).sort
+      # mapping [0, 10, 12] → compact new ids [0, 1, 2]; gid 0 isn't in
+      # CBLC, so only the new GIDs for source 10 and 12 appear.
+      expect(gids).to eq([1, 2])
+    end
+  end
+
+  describe "with no CBDT/CBLC in the source" do
+    include ColorBitmapSpecHelpers
+
+    let(:font) { build_test_font(cbdt: nil, cblc: nil) }
+    let(:mapping) { Fontisan::Subset::GlyphMapping.new([0]) }
+
+    it "emits empty CBDT and CBLC strings" do
+      subsetter = described_class.new(font: font, mapping: mapping).build
+      expect(subsetter.cbdt_bytes).to eq("")
+      expect(subsetter.cblc_bytes).to eq("")
+    end
+  end
+end

--- a/spec/fontisan/subset/table_strategy_spec.rb
+++ b/spec/fontisan/subset/table_strategy_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Fontisan::Subset::TableStrategy do
+  describe ".for" do
+    it "resolves known tags to their strategy class" do
+      expect(described_class.for("maxp")).to eq(described_class::Maxp)
+      expect(described_class.for("hhea")).to eq(described_class::Hhea)
+      expect(described_class.for("hmtx")).to eq(described_class::Hmtx)
+      expect(described_class.for("loca")).to eq(described_class::Loca)
+      expect(described_class.for("glyf")).to eq(described_class::Glyf)
+      expect(described_class.for("cmap")).to eq(described_class::Cmap)
+      expect(described_class.for("post")).to eq(described_class::Post)
+      expect(described_class.for("name")).to eq(described_class::Name)
+      expect(described_class.for("head")).to eq(described_class::Head)
+      expect(described_class.for("OS/2")).to eq(described_class::Os2)
+      expect(described_class.for("CBDT")).to eq(described_class::Cbdt)
+      expect(described_class.for("CBLC")).to eq(described_class::Cblc)
+    end
+
+    it "falls back to PassThrough for unknown tags" do
+      expect(described_class.for("kern"))
+        .to eq(described_class::PassThrough)
+      expect(described_class.for("DSIG"))
+        .to eq(described_class::PassThrough)
+    end
+  end
+
+  describe "REGISTRY" do
+    it "is frozen so callers cannot mutate it at runtime" do
+      expect(described_class::REGISTRY).to be_frozen
+    end
+
+    it "includes every tag covered by the default web profile" do
+      required = %w[maxp hhea hmtx loca glyf cmap post name head OS/2
+                    CBDT CBLC]
+      required.each do |tag|
+        expect(described_class::REGISTRY).to have_key(tag),
+                                             "missing strategy for #{tag}"
+      end
+    end
+  end
+
+  describe "strategy interface" do
+    it "every registered strategy class responds to .call" do
+      described_class::REGISTRY.each_value do |sym|
+        klass = described_class.const_get(sym)
+        expect(klass).to respond_to(:call),
+                         "#{sym} does not respond to .call"
+      end
+    end
+
+    it "PassThrough responds to .call" do
+      expect(described_class::PassThrough).to respond_to(:call)
+    end
+  end
+end

--- a/spec/fontisan/subset/table_subsetter_spec.rb
+++ b/spec/fontisan/subset/table_subsetter_spec.rb
@@ -225,42 +225,22 @@ RSpec.describe Fontisan::Subset::TableSubsetter do
     # Note: Unicode range pruning is TODO in implementation
   end
 
-  describe "private methods" do
-    describe "#compound_glyph?" do
-      it "identifies compound glyphs" do
-        # Create mock compound glyph data (numberOfContours = -1)
-        compound_data = [0xFFFF].pack("n") + ("x" * 10)
-        expect(subsetter.send(:compound_glyph?, compound_data)).to be true
-      end
+  describe "GlyfLocaBuilder" do
+    let(:builder_class) { Fontisan::Subset::TableStrategy::GlyfLocaBuilder }
 
-      it "identifies simple glyphs" do
-        # Create mock simple glyph data (numberOfContours = 2)
-        simple_data = [2].pack("n") + ("x" * 10)
-        expect(subsetter.send(:compound_glyph?, simple_data)).to be false
-      end
-
-      it "handles empty data" do
-        expect(subsetter.send(:compound_glyph?, "")).to be false
-      end
+    it "exposes the builder as a public collaborator of the glyf strategy" do
+      expect(builder_class).to be_a(Class)
     end
-  end
 
-  describe "error handling" do
-    it "handles missing component glyphs in compound glyph remapping" do
-      # Create a mapping that doesn't include all components
-      partial_mapping = Fontisan::Subset::GlyphMapping.new([0, 1],
+    it "raises SubsettingError when a compound glyph references a missing component" do
+      # gid 111 is a compound glyph in NotoSans-Regular. A mapping that
+      # includes gid 111 but excludes its referenced components must
+      # fail the subset build rather than silently emitting dangling
+      # references.
+      partial_mapping = Fontisan::Subset::GlyphMapping.new([0, 111],
                                                            retain_gids: false)
-      partial_subsetter = described_class.new(font, partial_mapping, options)
-
-      # Try to remap a compound glyph that references missing components
-      compound_data = [0xFFFF].pack("n") + ("x" * 8)
-      compound_data << [0x0020].pack("n") # flags (MORE_COMPONENTS not set)
-      compound_data << [100].pack("n")     # glyph_index not in mapping
-      compound_data << [0, 0].pack("n2")   # args
-
-      expect do
-        partial_subsetter.send(:remap_compound_glyph, compound_data)
-      end.to raise_error(Fontisan::SubsettingError, /not in subset/)
+      builder = builder_class.new(font: font, mapping: partial_mapping)
+      expect { builder.build }.to raise_error(Fontisan::SubsettingError)
     end
   end
 end

--- a/spec/fontisan/tables/cbdt_spec.rb
+++ b/spec/fontisan/tables/cbdt_spec.rb
@@ -5,238 +5,111 @@ require "spec_helper"
 RSpec.describe Fontisan::Tables::Cbdt do
   describe ".read" do
     it "parses CBDT table from binary data" do
-      # Create minimal CBDT v2.0 structure:
-      # Header: majorVersion(2) + minorVersion(2) + reserved(4) = 8 bytes
-      # Bitmap data: variable length
-
-      bitmap_data = "\x89PNG\r\n\u001A\nfake png data"
-
-      header = [
-        2, # majorVersion (uint16)
-        0, # minorVersion (uint16)
-        0, # reserved (uint32)
-      ].pack("nnN")
-
+      bitmap_data = "\x89PNG\r\n\nfake png data"
+      header = [3, 0].pack("nn")
       data = header + bitmap_data
 
       cbdt = described_class.read(data)
 
-      expect(cbdt.major_version).to eq(2)
+      expect(cbdt.major_version).to eq(3)
       expect(cbdt.minor_version).to eq(0)
-      expect(cbdt.version).to eq(0x00020000)
-      expect(cbdt.data_size).to eq(data.length)
+      expect(cbdt.version).to eq(0x00030000)
+      expect(cbdt.data_size).to eq(data.bytesize)
+    end
+
+    it "round-trips to identical bytes" do
+      data = [2, 0].pack("nn") + ("BITMAP1" * 4)
+      cbdt = described_class.read(data)
+      expect(cbdt.to_binary_s).to eq(data)
     end
 
     it "returns empty table for nil data" do
       cbdt = described_class.read(nil)
 
       expect(cbdt).to be_a(described_class)
-      expect(cbdt.major_version).to be_nil
+      expect(cbdt.has_raw_data?).to be false
+      expect(cbdt.data_size).to eq(0)
     end
 
     it "handles StringIO input" do
-      data = [2, 0, 0].pack("nnN")
-      io = StringIO.new(data)
-
-      cbdt = described_class.read(io)
+      data = [2, 0].pack("nn")
+      cbdt = described_class.read(StringIO.new(data))
 
       expect(cbdt.major_version).to eq(2)
       expect(cbdt.minor_version).to eq(0)
     end
 
-    it "parses version 3.0 tables" do
-      header = [3, 0, 0].pack("nnN")
-      cbdt = described_class.read(header)
-
-      expect(cbdt.major_version).to eq(3)
-      expect(cbdt.version).to eq(0x00030000)
-    end
-  end
-
-  describe "#version" do
-    it "returns combined version number" do
-      data = [2, 0, 0].pack("nnN")
-      cbdt = described_class.read(data)
-
+    it "parses version 2.0 tables" do
+      cbdt = described_class.read([2, 0].pack("nn"))
+      expect(cbdt.major_version).to eq(2)
       expect(cbdt.version).to eq(0x00020000)
-    end
-
-    it "returns version 3.0" do
-      data = [3, 0, 0].pack("nnN")
-      cbdt = described_class.read(data)
-
-      expect(cbdt.version).to eq(0x00030000)
-    end
-
-    it "returns nil when versions not parsed" do
-      cbdt = described_class.new
-
-      expect(cbdt.version).to be_nil
-    end
-  end
-
-  describe "#major_version" do
-    it "returns major version 2" do
-      data = [2, 0, 0].pack("nnN")
-      cbdt = described_class.read(data)
-
-      expect(cbdt.major_version).to eq(2)
-    end
-
-    it "returns major version 3" do
-      data = [3, 0, 0].pack("nnN")
-      cbdt = described_class.read(data)
-
-      expect(cbdt.major_version).to eq(3)
-    end
-
-    it "rejects unsupported major version 1" do
-      data = [1, 0, 0].pack("nnN")
-
-      expect do
-        described_class.read(data)
-      end.to raise_error(Fontisan::CorruptedTableError,
-                         /Unsupported CBDT major version/)
-    end
-
-    it "rejects unsupported major version 4" do
-      data = [4, 0, 0].pack("nnN")
-
-      expect do
-        described_class.read(data)
-      end.to raise_error(Fontisan::CorruptedTableError,
-                         /Unsupported CBDT major version/)
-    end
-  end
-
-  describe "#minor_version" do
-    it "returns minor version 0" do
-      data = [2, 0, 0].pack("nnN")
-      cbdt = described_class.read(data)
-
-      expect(cbdt.minor_version).to eq(0)
-    end
-
-    it "rejects non-zero minor version" do
-      data = [2, 1, 0].pack("nnN")
-
-      expect do
-        described_class.read(data)
-      end.to raise_error(Fontisan::CorruptedTableError,
-                         /Unsupported CBDT minor version/)
     end
   end
 
   describe "#bitmap_data_at" do
     let(:cbdt) do
-      bitmap1 = "BITMAP1DATA"
-      bitmap2 = "BITMAP2DATA"
-      bitmap3 = "BITMAP3DATA"
-
-      header = [2, 0, 0].pack("nnN")
-      data = header + bitmap1 + bitmap2 + bitmap3
-
-      described_class.read(data)
+      bitmaps = "BITMAP1DATABITMAP2DATABITMAP3DATA"
+      described_class.read([2, 0].pack("nn") + bitmaps)
     end
 
     it "extracts bitmap data at offset and length" do
-      # Header is 8 bytes, bitmap1 starts at offset 8
-      bitmap = cbdt.bitmap_data_at(8, 11)
-
-      expect(bitmap).to eq("BITMAP1DATA")
-    end
-
-    it "extracts second bitmap" do
-      # bitmap2 starts at offset 8 + 11 = 19
-      bitmap = cbdt.bitmap_data_at(19, 11)
-
-      expect(bitmap).to eq("BITMAP2DATA")
-    end
-
-    it "extracts third bitmap" do
-      # bitmap3 starts at offset 8 + 11 + 11 = 30
-      bitmap = cbdt.bitmap_data_at(30, 11)
-
-      expect(bitmap).to eq("BITMAP3DATA")
+      expect(cbdt.bitmap_data_at(4, 11)).to eq("BITMAP1DATA")
+      expect(cbdt.bitmap_data_at(15, 11)).to eq("BITMAP2DATA")
+      expect(cbdt.bitmap_data_at(26, 11)).to eq("BITMAP3DATA")
     end
 
     it "returns nil for offset beyond data length" do
-      bitmap = cbdt.bitmap_data_at(9999, 10)
-
-      expect(bitmap).to be_nil
+      expect(cbdt.bitmap_data_at(9999, 10)).to be_nil
     end
 
     it "returns nil for negative offset" do
-      bitmap = cbdt.bitmap_data_at(-1, 10)
-
-      expect(bitmap).to be_nil
+      expect(cbdt.bitmap_data_at(-1, 10)).to be_nil
     end
 
     it "returns nil for negative length" do
-      bitmap = cbdt.bitmap_data_at(8, -1)
-
-      expect(bitmap).to be_nil
+      expect(cbdt.bitmap_data_at(4, -1)).to be_nil
     end
 
-    it "returns nil for nil offset" do
-      bitmap = cbdt.bitmap_data_at(nil, 10)
-
-      expect(bitmap).to be_nil
-    end
-
-    it "returns nil for nil length" do
-      bitmap = cbdt.bitmap_data_at(8, nil)
-
-      expect(bitmap).to be_nil
+    it "returns nil for nil offset or length" do
+      expect(cbdt.bitmap_data_at(nil, 10)).to be_nil
+      expect(cbdt.bitmap_data_at(4, nil)).to be_nil
     end
 
     it "returns nil when offset + length exceeds data size" do
-      bitmap = cbdt.bitmap_data_at(30, 50)
-
-      expect(bitmap).to be_nil
+      expect(cbdt.bitmap_data_at(33, 50)).to be_nil
     end
   end
 
   describe "#data_size" do
     it "returns total table size" do
-      bitmap_data = "X" * 100
-      header = [2, 0, 0].pack("nnN")
-      data = header + bitmap_data
-
+      data = [2, 0].pack("nn") + ("X" * 100)
       cbdt = described_class.read(data)
-
-      expect(cbdt.data_size).to eq(108) # 8 byte header + 100 bytes data
+      expect(cbdt.data_size).to eq(104)
     end
 
     it "returns 0 for empty table" do
-      cbdt = described_class.new
-
-      expect(cbdt.data_size).to eq(0)
+      expect(described_class.new.data_size).to eq(0)
     end
 
     it "returns size for header-only table" do
-      header = [2, 0, 0].pack("nnN")
-      cbdt = described_class.read(header)
-
-      expect(cbdt.data_size).to eq(8)
+      cbdt = described_class.read([2, 0].pack("nn"))
+      expect(cbdt.data_size).to eq(4)
     end
   end
 
   describe "#valid_offset?" do
     let(:cbdt) do
-      header = [2, 0, 0].pack("nnN")
-      data = header + ("X" * 100)
-      described_class.read(data)
+      described_class.read([2, 0].pack("nn") + ("X" * 100))
     end
 
-    it "returns true for valid offset" do
+    it "returns true for valid offsets" do
       expect(cbdt.valid_offset?(0)).to be true
       expect(cbdt.valid_offset?(50)).to be true
-      expect(cbdt.valid_offset?(107)).to be true
+      expect(cbdt.valid_offset?(103)).to be true
     end
 
     it "returns false for offset at data length" do
-      expect(cbdt.valid_offset?(108)).to be false
+      expect(cbdt.valid_offset?(104)).to be false
     end
 
     it "returns false for offset beyond data length" do
@@ -251,118 +124,57 @@ RSpec.describe Fontisan::Tables::Cbdt do
       expect(cbdt.valid_offset?(nil)).to be false
     end
 
-    it "returns false when raw_data is nil" do
-      cbdt = described_class.new
-
-      expect(cbdt.valid_offset?(0)).to be false
+    it "returns false on a fresh instance with no data" do
+      expect(described_class.new.valid_offset?(0)).to be false
     end
   end
 
   describe "#valid?" do
     it "returns true for valid CBDT v2.0 table" do
-      header = [2, 0, 0].pack("nnN")
-      cbdt = described_class.read(header)
-
-      expect(cbdt.valid?).to be true
+      cbdt = described_class.read([2, 0].pack("nn"))
+      expect(cbdt).to be_valid
     end
 
     it "returns true for valid CBDT v3.0 table" do
-      header = [3, 0, 0].pack("nnN")
-      cbdt = described_class.read(header)
-
-      expect(cbdt.valid?).to be true
+      cbdt = described_class.read([3, 0].pack("nn"))
+      expect(cbdt).to be_valid
     end
 
-    it "validates major version" do
-      cbdt = described_class.new
-      cbdt.instance_variable_set(:@major_version, 1)
-      cbdt.instance_variable_set(:@minor_version, 0)
-      cbdt.instance_variable_set(:@raw_data, "test")
-
-      expect(cbdt.valid?).to be false
+    it "returns false for unsupported major version" do
+      cbdt = described_class.read([1, 0].pack("nn"))
+      expect(cbdt).not_to be_valid
     end
 
-    it "validates minor version is 0" do
-      cbdt = described_class.new
-      cbdt.instance_variable_set(:@major_version, 2)
-      cbdt.instance_variable_set(:@minor_version, 1)
-      cbdt.instance_variable_set(:@raw_data, "test")
-
-      expect(cbdt.valid?).to be false
+    it "returns false for unsupported minor version" do
+      cbdt = described_class.read([2, 1].pack("nn"))
+      expect(cbdt).not_to be_valid
     end
 
-    it "returns false for nil major_version" do
-      cbdt = described_class.new
-      cbdt.instance_variable_set(:@minor_version, 0)
-      cbdt.instance_variable_set(:@raw_data, "test")
-
-      expect(cbdt.valid?).to be false
-    end
-
-    it "returns false for nil minor_version" do
-      cbdt = described_class.new
-      cbdt.instance_variable_set(:@major_version, 2)
-      cbdt.instance_variable_set(:@raw_data, "test")
-
-      expect(cbdt.valid?).to be false
-    end
-
-    it "returns false for missing raw_data" do
-      cbdt = described_class.new
-      cbdt.instance_variable_set(:@major_version, 2)
-      cbdt.instance_variable_set(:@minor_version, 0)
-
-      expect(cbdt.valid?).to be false
+    it "returns false on a fresh instance" do
+      expect(described_class.new).not_to be_valid
     end
   end
 
-  describe "bitmap data extraction" do
+  describe "PNG extraction" do
     it "extracts PNG bitmap data" do
-      # PNG magic bytes
       png_data = "\x89PNG\r\n\u001A\n#{"\x00" * 100}"
+      cbdt = described_class.read([3, 0].pack("nn") + png_data)
 
-      header = [2, 0, 0].pack("nnN")
-      data = header + png_data
-
-      cbdt = described_class.read(data)
-      bitmap = cbdt.bitmap_data_at(8, png_data.length)
-
+      bitmap = cbdt.bitmap_data_at(4, png_data.bytesize)
       expect(bitmap[0..7]).to eq("\x89PNG\r\n\x1a\n")
-      expect(bitmap.length).to eq(png_data.length)
+      expect(bitmap.bytesize).to eq(png_data.bytesize)
     end
 
     it "extracts multiple bitmap entries" do
-      bitmap1 = "\x89PNG\r\n\u001A\nbitmap1"
-      bitmap2 = "\x89PNG\r\n\u001A\nbitmap2"
-
-      header = [2, 0, 0].pack("nnN")
-      data = header + bitmap1 + bitmap2
+      bitmap1 = "\x89PNG\r\n\x1a\nbitmap1"
+      bitmap2 = "\x89PNG\r\n\x1a\nbitmap2"
+      data = [3, 0].pack("nn") + bitmap1 + bitmap2
 
       cbdt = described_class.read(data)
 
-      bmp1 = cbdt.bitmap_data_at(8, bitmap1.length)
-      bmp2 = cbdt.bitmap_data_at(8 + bitmap1.length, bitmap2.length)
-
-      expect(bmp1).to eq(bitmap1)
-      expect(bmp2).to eq(bitmap2)
-    end
-  end
-
-  describe "error handling" do
-    it "raises CorruptedTableError for invalid data" do
-      expect do
-        described_class.read("abc")
-      end.to raise_error(Fontisan::CorruptedTableError,
-                         /Failed to parse CBDT table/)
-    end
-
-    it "raises CorruptedTableError for truncated header" do
-      data = [2, 0].pack("nn") # Missing reserved field
-
-      expect do
-        described_class.read(data)
-      end.to raise_error(Fontisan::CorruptedTableError,
-                         /Failed to parse CBDT table/)
+      expect(cbdt.bitmap_data_at(4, bitmap1.bytesize)).to eq(bitmap1)
+      expect(cbdt.bitmap_data_at(4 + bitmap1.bytesize,
+                                 bitmap2.bytesize)).to eq(bitmap2)
     end
   end
 end

--- a/spec/fontisan/tables/cblc_spec.rb
+++ b/spec/fontisan/tables/cblc_spec.rb
@@ -1,505 +1,164 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "bindata"
 
 RSpec.describe Fontisan::Tables::Cblc do
+  # Helper: build a single-strike CBLC + CBDT pair for the given glyph
+  # range. The CBDT bitmaps are 4-byte aligned so format 3 offsets stay
+  # valid.
+  def build_cblc(bitmaps:, version: 0x00030000, first_gid: 10, last_gid: 12,
+                 ppem: 16, bit_depth: 32, image_format: 17)
+    bitmap_size = (last_gid - first_gid + 1)
+    image_size = bitmaps.first.bytesize
+
+    # CBDT: 4-byte header + concatenated bitmaps
+    cbdt = [3, 0].pack("nn") + bitmaps.map(&:b).join
+
+    # IndexSubTable format 3: 8-byte header + uint16 offsetArray[count+1]
+    # (offsets are stored as multiples of 4 since bitmap data is 4-byte
+    # aligned). imageDataOffset = 4 (start of bitmap data after CBDT header).
+    offsets = Array.new(bitmap_size + 1) { |i| (i * image_size) / 4 }
+    ist = [3, image_format, 4].pack("nnN") + offsets.pack("n*")
+    # IndexSubTableArray entry: first, last, additionalOffset (relative to
+    # array start; 8 bytes from array start = past this single entry).
+    ista = [first_gid, last_gid, 8].pack("nnN")
+
+    bsm_offset = 8 + 48
+    bsm_size = ista.bytesize + ist.bytesize
+    bsm = [
+      bsm_offset, bsm_size, 1, 0 # offset, size, numSubTables, colorRef
+    ].pack("NNNN") + ("\x00" * 24) + [
+      first_gid, last_gid, ppem, ppem, bit_depth, 0
+    ].pack("nnCCCc")
+
+    cblc = [version, 1].pack("NN") + bsm + ista + ist
+    [cblc, cbdt]
+  end
+
   describe ".read" do
-    it "parses CBLC table from binary data" do
-      # Create minimal CBLC v2.0 structure:
-      # Header: version(4) + numSizes(4) = 8 bytes
-      # BitmapSize records: 2 × 48 bytes = 96 bytes
-
-      header = [
-        0x00020000, # version 2.0 (uint32)
-        2,          # numSizes (uint32)
-      ].pack("NN")
-
-      # BitmapSize record 1 (48 bytes)
-      size1 = create_bitmap_size(
-        offset: 1000, size: 500, num_subtables: 3,
-        start_glyph: 10, end_glyph: 20, ppem: 16, bit_depth: 8
-      )
-
-      # BitmapSize record 2 (48 bytes)
-      size2 = create_bitmap_size(
-        offset: 2000, size: 600, num_subtables: 5,
-        start_glyph: 30, end_glyph: 40, ppem: 32, bit_depth: 32
-      )
-
-      data = header + size1 + size2
-
-      cblc = described_class.read(data)
-
-      expect(cblc.version).to eq(0x00020000)
-      expect(cblc.num_sizes).to eq(2)
-      expect(cblc.bitmap_sizes.length).to eq(2)
-      expect(cblc.bitmap_sizes[0].start_glyph_index).to eq(10)
-      expect(cblc.bitmap_sizes[0].end_glyph_index).to eq(20)
-      expect(cblc.bitmap_sizes[0].ppem_x).to eq(16)
-      expect(cblc.bitmap_sizes[1].ppem_y).to eq(32)
-    end
-
-    it "returns empty table for nil data" do
-      cblc = described_class.read(nil)
-
-      expect(cblc).to be_a(described_class)
-      expect(cblc.version).to be_nil
-    end
-
-    it "handles StringIO input" do
-      data = [0x00020000, 0].pack("NN")
-      io = StringIO.new(data)
-
-      cblc = described_class.read(io)
-
-      expect(cblc.version).to eq(0x00020000)
-    end
-
-    it "parses version 3.0 tables" do
-      header = [0x00030000, 1].pack("NN")
-      size = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 0, end_glyph: 10, ppem: 12, bit_depth: 1
-      )
-      data = header + size
-
-      cblc = described_class.read(data)
+    it "parses a CBLC v3.0 table with one strike" do
+      cblc_bytes, = build_cblc(bitmaps: %w[AAAA BBBB CCCC])
+      cblc = described_class.read(cblc_bytes)
 
       expect(cblc.version).to eq(0x00030000)
       expect(cblc.num_sizes).to eq(1)
+      expect(cblc.bitmap_sizes.length).to eq(1)
+      strike = cblc.bitmap_sizes[0]
+      expect(strike.start_glyph_index).to eq(10)
+      expect(strike.end_glyph_index).to eq(12)
+      expect(strike.ppem_x).to eq(16)
+      expect(strike.bit_depth).to eq(32)
     end
-  end
 
-  describe "#version" do
-    it "returns CBLC version number" do
-      data = [0x00020000, 0].pack("NN")
-      cblc = described_class.read(data)
-
+    it "parses a CBLC v2.0 table" do
+      cblc_bytes, = build_cblc(version: 0x00020000,
+                               bitmaps: %w[AAAA])
+      cblc = described_class.read(cblc_bytes)
       expect(cblc.version).to eq(0x00020000)
     end
+  end
 
-    it "rejects unsupported version 1.0" do
-      data = [0x00010000, 0].pack("NN")
+  describe "#each_glyph_location" do
+    it "yields one location per glyph across every strike" do
+      cblc_bytes, _cbdt = build_cblc(bitmaps: %w[AAAA BBBB CCCC])
+      cblc = described_class.read(cblc_bytes)
 
-      expect do
-        described_class.read(data)
-      end.to raise_error(Fontisan::CorruptedTableError,
-                         /Unsupported CBLC version/)
-    end
+      locations = cblc.each_glyph_location.to_a
 
-    it "rejects unsupported version 4.0" do
-      data = [0x00040000, 0].pack("NN")
-
-      expect do
-        described_class.read(data)
-      end.to raise_error(Fontisan::CorruptedTableError,
-                         /Unsupported CBLC version/)
+      expect(locations.length).to eq(3)
+      expect(locations.map(&:glyph_id)).to eq([10, 11, 12])
+      expect(locations.map(&:byte_length)).to eq([4, 4, 4])
+      expect(locations.map(&:image_format).uniq).to eq([17])
     end
   end
 
-  describe "#strikes" do
-    let(:cblc) do
-      header = [0x00020000, 2].pack("NN")
-      size1 = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 15, ppem: 16, bit_depth: 8
-      )
-      size2 = create_bitmap_size(
-        offset: 200, size: 60, num_subtables: 2,
-        start_glyph: 20, end_glyph: 25, ppem: 32, bit_depth: 32
-      )
-      data = header + size1 + size2
-      described_class.read(data)
+  describe "#bitmap_offset_for_gid" do
+    it "returns the location for a glyph in the strike" do
+      cblc_bytes, = build_cblc(bitmaps: %w[AAAA BBBB CCCC])
+      cblc = described_class.read(cblc_bytes)
+
+      loc = cblc.bitmap_offset_for_gid(11, 16)
+      expect(loc.glyph_id).to eq(11)
+      expect(loc.cbdt_offset).to eq(8) # header(4) + one bitmap
+      expect(loc.byte_length).to eq(4)
     end
 
-    it "returns all bitmap size records" do
-      strikes = cblc.strikes
+    it "returns nil for an out-of-range glyph" do
+      cblc_bytes, = build_cblc(bitmaps: %w[AAAA BBBB CCCC])
+      cblc = described_class.read(cblc_bytes)
 
-      expect(strikes.length).to eq(2)
-      expect(strikes[0]).to be_a(described_class::BitmapSize)
-      expect(strikes[1]).to be_a(described_class::BitmapSize)
+      expect(cblc.bitmap_offset_for_gid(999, 16)).to be_nil
     end
 
-    it "returns empty array for table with no sizes" do
-      data = [0x00020000, 0].pack("NN")
-      cblc = described_class.read(data)
+    it "returns nil when no strike matches the ppem" do
+      cblc_bytes, = build_cblc(ppem: 16, bitmaps: %w[AAAA BBBB CCCC])
+      cblc = described_class.read(cblc_bytes)
 
-      expect(cblc.strikes).to eq([])
+      expect(cblc.bitmap_offset_for_gid(10, 32)).to be_nil
     end
   end
 
-  describe "#strikes_for_ppem" do
+  describe "BitmapSize accessors" do
     let(:cblc) do
-      header = [0x00020000, 3].pack("NN")
-      size1 = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 15, ppem: 16, bit_depth: 8
-      )
-      size2 = create_bitmap_size(
-        offset: 200, size: 60, num_subtables: 2,
-        start_glyph: 20, end_glyph: 25, ppem: 32, bit_depth: 32
-      )
-      size3 = create_bitmap_size(
-        offset: 300, size: 70, num_subtables: 1,
-        start_glyph: 30, end_glyph: 35, ppem: 16, bit_depth: 8
-      )
-      data = header + size1 + size2 + size3
-      described_class.read(data)
+      bytes, = build_cblc(first_gid: 10, last_gid: 11, ppem: 16,
+                          bit_depth: 32, bitmaps: %w[AAAA BBBB])
+      described_class.read(bytes)
     end
 
-    it "returns strikes matching ppem size" do
-      strikes = cblc.strikes_for_ppem(16)
-
-      expect(strikes.length).to eq(2)
-      expect(strikes[0].ppem).to eq(16)
-      expect(strikes[1].ppem).to eq(16)
-    end
-
-    it "returns single strike when only one matches" do
-      strikes = cblc.strikes_for_ppem(32)
-
-      expect(strikes.length).to eq(1)
-      expect(strikes[0].ppem).to eq(32)
-    end
-
-    it "returns empty array when no strikes match" do
-      strikes = cblc.strikes_for_ppem(64)
-
-      expect(strikes).to eq([])
-    end
-  end
-
-  describe "#has_bitmap_for_glyph?" do
-    let(:cblc) do
-      header = [0x00020000, 2].pack("NN")
-      size1 = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 15, ppem: 16, bit_depth: 8
-      )
-      size2 = create_bitmap_size(
-        offset: 200, size: 60, num_subtables: 2,
-        start_glyph: 20, end_glyph: 25, ppem: 32, bit_depth: 32
-      )
-      data = header + size1 + size2
-      described_class.read(data)
-    end
-
-    it "returns true when glyph has bitmap at ppem" do
-      expect(cblc.has_bitmap_for_glyph?(10, 16)).to be true
-      expect(cblc.has_bitmap_for_glyph?(15, 16)).to be true
-      expect(cblc.has_bitmap_for_glyph?(20, 32)).to be true
-    end
-
-    it "returns false when glyph doesn't have bitmap at ppem" do
-      expect(cblc.has_bitmap_for_glyph?(10, 32)).to be false
-      expect(cblc.has_bitmap_for_glyph?(20, 16)).to be false
-    end
-
-    it "returns false for non-existent glyph" do
-      expect(cblc.has_bitmap_for_glyph?(999, 16)).to be false
-    end
-
-    it "returns false for non-existent ppem" do
-      expect(cblc.has_bitmap_for_glyph?(10, 64)).to be false
+    it "exposes ppem, glyph range, and inclusion test" do
+      strike = cblc.bitmap_sizes[0]
+      expect(strike.ppem).to eq(16)
+      expect(strike.glyph_range).to eq(10..11)
+      expect(strike.includes_glyph?(10)).to be true
+      expect(strike.includes_glyph?(12)).to be false
     end
   end
 
   describe "#ppem_sizes" do
     it "returns sorted unique ppem sizes" do
-      header = [0x00020000, 4].pack("NN")
-      size1 = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 15, ppem: 16, bit_depth: 8
-      )
-      size2 = create_bitmap_size(
-        offset: 200, size: 60, num_subtables: 2,
-        start_glyph: 20, end_glyph: 25, ppem: 32, bit_depth: 32
-      )
-      size3 = create_bitmap_size(
-        offset: 300, size: 70, num_subtables: 1,
-        start_glyph: 30, end_glyph: 35, ppem: 16, bit_depth: 8
-      )
-      size4 = create_bitmap_size(
-        offset: 400, size: 80, num_subtables: 1,
-        start_glyph: 40, end_glyph: 45, ppem: 64, bit_depth: 8
-      )
-      data = header + size1 + size2 + size3 + size4
-
-      cblc = described_class.read(data)
-      sizes = cblc.ppem_sizes
-
-      expect(sizes).to eq([16, 32, 64])
+      cblc_bytes, = build_cblc(ppem: 16, bitmaps: %w[AAAA BBBB CCCC])
+      cblc = described_class.read(cblc_bytes)
+      expect(cblc.ppem_sizes).to eq([16])
     end
+  end
 
-    it "returns empty array for table with no sizes" do
-      data = [0x00020000, 0].pack("NN")
-      cblc = described_class.read(data)
+  describe "#strikes_for_glyph and #strikes_for_ppem" do
+    it "returns the matching strikes" do
+      cblc_bytes, = build_cblc(ppem: 16, bitmaps: %w[AAAA BBBB])
+      cblc = described_class.read(cblc_bytes)
 
-      expect(cblc.ppem_sizes).to eq([])
+      expect(cblc.strikes_for_glyph(10).map(&:ppem)).to eq([16])
+      expect(cblc.strikes_for_glyph(99)).to eq([])
+      expect(cblc.strikes_for_ppem(16).length).to eq(1)
+      expect(cblc.strikes_for_ppem(32)).to eq([])
     end
   end
 
   describe "#glyph_ids_with_bitmaps" do
     it "returns sorted unique glyph IDs" do
-      header = [0x00020000, 2].pack("NN")
-      size1 = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 12, ppem: 16, bit_depth: 8
-      )
-      size2 = create_bitmap_size(
-        offset: 200, size: 60, num_subtables: 2,
-        start_glyph: 20, end_glyph: 21, ppem: 32, bit_depth: 32
-      )
-      data = header + size1 + size2
-
-      cblc = described_class.read(data)
-      ids = cblc.glyph_ids_with_bitmaps
-
-      expect(ids).to eq([10, 11, 12, 20, 21])
-    end
-
-    it "handles overlapping glyph ranges" do
-      header = [0x00020000, 2].pack("NN")
-      size1 = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 15, ppem: 16, bit_depth: 8
-      )
-      size2 = create_bitmap_size(
-        offset: 200, size: 60, num_subtables: 2,
-        start_glyph: 12, end_glyph: 18, ppem: 32, bit_depth: 32
-      )
-      data = header + size1 + size2
-
-      cblc = described_class.read(data)
-      ids = cblc.glyph_ids_with_bitmaps
-
-      expect(ids).to eq([10, 11, 12, 13, 14, 15, 16, 17, 18])
-    end
-
-    it "returns empty array for table with no sizes" do
-      data = [0x00020000, 0].pack("NN")
-      cblc = described_class.read(data)
-
-      expect(cblc.glyph_ids_with_bitmaps).to eq([])
-    end
-  end
-
-  describe "#strikes_for_glyph" do
-    let(:cblc) do
-      header = [0x00020000, 3].pack("NN")
-      size1 = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 20, ppem: 16, bit_depth: 8
-      )
-      size2 = create_bitmap_size(
-        offset: 200, size: 60, num_subtables: 2,
-        start_glyph: 15, end_glyph: 25, ppem: 32, bit_depth: 32
-      )
-      size3 = create_bitmap_size(
-        offset: 300, size: 70, num_subtables: 1,
-        start_glyph: 30, end_glyph: 40, ppem: 64, bit_depth: 8
-      )
-      data = header + size1 + size2 + size3
-      described_class.read(data)
-    end
-
-    it "returns all strikes containing glyph" do
-      strikes = cblc.strikes_for_glyph(17)
-
-      expect(strikes.length).to eq(2)
-      expect(strikes[0].ppem).to eq(16)
-      expect(strikes[1].ppem).to eq(32)
-    end
-
-    it "returns single strike when glyph in one strike" do
-      strikes = cblc.strikes_for_glyph(35)
-
-      expect(strikes.length).to eq(1)
-      expect(strikes[0].ppem).to eq(64)
-    end
-
-    it "returns empty array for non-existent glyph" do
-      strikes = cblc.strikes_for_glyph(999)
-
-      expect(strikes).to eq([])
-    end
-  end
-
-  describe "#num_strikes" do
-    it "returns number of bitmap sizes" do
-      header = [0x00020000, 3].pack("NN")
-      size1 = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 15, ppem: 16, bit_depth: 8
-      )
-      size2 = create_bitmap_size(
-        offset: 200, size: 60, num_subtables: 2,
-        start_glyph: 20, end_glyph: 25, ppem: 32, bit_depth: 32
-      )
-      size3 = create_bitmap_size(
-        offset: 300, size: 70, num_subtables: 1,
-        start_glyph: 30, end_glyph: 35, ppem: 64, bit_depth: 8
-      )
-      data = header + size1 + size2 + size3
-
-      cblc = described_class.read(data)
-
-      expect(cblc.num_strikes).to eq(3)
-    end
-
-    it "returns 0 for table with no sizes" do
-      data = [0x00020000, 0].pack("NN")
-      cblc = described_class.read(data)
-
-      expect(cblc.num_strikes).to eq(0)
+      cblc_bytes, = build_cblc(first_gid: 10, last_gid: 12,
+                               bitmaps: %w[AAAA BBBB CCCC])
+      cblc = described_class.read(cblc_bytes)
+      expect(cblc.glyph_ids_with_bitmaps).to eq([10, 11, 12])
     end
   end
 
   describe "#valid?" do
-    it "returns true for valid CBLC v2.0 table" do
-      header = [0x00020000, 1].pack("NN")
-      size = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 15, ppem: 16, bit_depth: 8
-      )
-      data = header + size
-
-      cblc = described_class.read(data)
-
-      expect(cblc.valid?).to be true
+    it "returns true for a v3.0 table" do
+      cblc_bytes, = build_cblc(bitmaps: %w[AAAA BBBB])
+      expect(described_class.read(cblc_bytes)).to be_valid
     end
 
-    it "returns true for valid CBLC v3.0 table" do
-      header = [0x00030000, 1].pack("NN")
-      size = create_bitmap_size(
-        offset: 100, size: 50, num_subtables: 1,
-        start_glyph: 10, end_glyph: 15, ppem: 16, bit_depth: 8
-      )
-      data = header + size
-
-      cblc = described_class.read(data)
-
-      expect(cblc.valid?).to be true
+    it "returns true for a v2.0 table" do
+      cblc_bytes, = build_cblc(version: 0x00020000, bitmaps: %w[AAAA])
+      expect(described_class.read(cblc_bytes)).to be_valid
     end
 
-    it "validates version number" do
+    it "returns false for an unsupported version" do
       cblc = described_class.new
-      cblc.instance_variable_set(:@version, 0x00010000)
-      cblc.instance_variable_set(:@num_sizes, 0)
-      cblc.instance_variable_set(:@bitmap_sizes, [])
-
-      expect(cblc.valid?).to be false
+      cblc.version = 0x00010000
+      expect(cblc).not_to be_valid
     end
-
-    it "validates num_sizes is non-negative" do
-      cblc = described_class.new
-      cblc.instance_variable_set(:@version, 0x00020000)
-      cblc.instance_variable_set(:@num_sizes, -1)
-      cblc.instance_variable_set(:@bitmap_sizes, [])
-
-      expect(cblc.valid?).to be false
-    end
-
-    it "returns false for nil version" do
-      cblc = described_class.new
-
-      expect(cblc.valid?).to be false
-    end
-
-    it "returns false for missing bitmap_sizes" do
-      cblc = described_class.new
-      cblc.instance_variable_set(:@version, 0x00020000)
-      cblc.instance_variable_set(:@num_sizes, 1)
-
-      expect(cblc.valid?).to be false
-    end
-  end
-
-  describe "BitmapSize" do
-    describe "#ppem" do
-      it "returns ppem_x value" do
-        size_data = create_bitmap_size(
-          offset: 100, size: 50, num_subtables: 1,
-          start_glyph: 10, end_glyph: 15, ppem: 16, bit_depth: 8
-        )
-        size = described_class::BitmapSize.read(size_data)
-
-        expect(size.ppem).to eq(16)
-      end
-    end
-
-    describe "#glyph_range" do
-      it "returns range of glyph IDs" do
-        size_data = create_bitmap_size(
-          offset: 100, size: 50, num_subtables: 1,
-          start_glyph: 10, end_glyph: 20, ppem: 16, bit_depth: 8
-        )
-        size = described_class::BitmapSize.read(size_data)
-
-        expect(size.glyph_range).to eq(10..20)
-      end
-    end
-
-    describe "#includes_glyph?" do
-      let(:size) do
-        size_data = create_bitmap_size(
-          offset: 100, size: 50, num_subtables: 1,
-          start_glyph: 10, end_glyph: 20, ppem: 16, bit_depth: 8
-        )
-        described_class::BitmapSize.read(size_data)
-      end
-
-      it "returns true for glyph in range" do
-        expect(size.includes_glyph?(10)).to be true
-        expect(size.includes_glyph?(15)).to be true
-        expect(size.includes_glyph?(20)).to be true
-      end
-
-      it "returns false for glyph outside range" do
-        expect(size.includes_glyph?(9)).to be false
-        expect(size.includes_glyph?(21)).to be false
-        expect(size.includes_glyph?(999)).to be false
-      end
-    end
-  end
-
-  describe "error handling" do
-    it "raises CorruptedTableError for invalid data" do
-      expect do
-        described_class.read("abc")
-      end.to raise_error(Fontisan::CorruptedTableError,
-                         /Failed to parse CBLC table/)
-    end
-
-    it "raises CorruptedTableError for truncated data" do
-      header = [0x00020000, 1].pack("NN")
-      size_partial = "abc" # Not 48 bytes
-
-      expect do
-        described_class.read(header + size_partial)
-      end.to raise_error(Fontisan::CorruptedTableError,
-                         /Failed to parse CBLC table/)
-    end
-  end
-
-  # Helper method to create BitmapSize record (48 bytes)
-  def create_bitmap_size(offset:, size:, num_subtables:, start_glyph:,
-end_glyph:, ppem:, bit_depth:)
-    [
-      offset,         # indexSubTableArrayOffset (uint32)
-      size,           # indexTablesSize (uint32)
-      num_subtables,  # numberOfIndexSubTables (uint32)
-      0,              # colorRef (uint32)
-    ].pack("NNNN") +
-      ("\x00" * 12) +   # hori SbitLineMetrics (12 bytes)
-      ("\x00" * 12) +   # vert SbitLineMetrics (12 bytes)
-      [
-        start_glyph,  # startGlyphIndex (uint16)
-        end_glyph,    # endGlyphIndex (uint16)
-        ppem,         # ppemX (uint8)
-        ppem,         # ppemY (uint8)
-        bit_depth,    # bitDepth (uint8)
-        0,            # flags (int8)
-      ].pack("nnCCCc")
   end
 end

--- a/spec/integration/cbdt_round_trip_spec.rb
+++ b/spec/integration/cbdt_round_trip_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tempfile"
+require "fontisan/font_loader"
+require "fontisan/font_writer"
+require "fontisan/subset/builder"
+require "fontisan/subset/options"
+
+RSpec.describe "CBDT/CBLC subset round-trip", type: :integration do
+  # Build synthetic CBDT + CBLC bytes for a 5-glyph range at a single
+  # 16 ppem / 32-bit-depth strike. Each glyph gets a 4-byte marker
+  # block so the spec can verify the bytes travel through subsetting
+  # intact.
+  let(:synthetic_color_tables) do
+    gids = (10..14).to_a
+    bitmaps = gids.map { |gid| "G#{gid}".ljust(4, "_").b }
+
+    cbd_header = [3, 0].pack("nn")
+    cbdt = cbd_header + bitmaps.join
+
+    count = bitmaps.length
+    image_data_offset = 4
+    offsets = Array.new(count + 1) { |i| i * bitmaps.first.bytesize }
+    ist = [1, 17, image_data_offset].pack("nnN") + offsets.pack("N*")
+    ista = [gids.first, gids.last, 8].pack("nnN")
+
+    bsm_offset = 8 + 48
+    bsm_size = ista.bytesize + ist.bytesize
+    bsm = [bsm_offset, bsm_size, 1, 0].pack("NNNN") +
+      ("\x00" * 24) +
+      [gids.first, gids.last, 16, 16, 32, 0].pack("nnCCCc")
+    cblc = [0x00030000, 1].pack("NN") + bsm + ista + ist
+
+    { "CBDT" => cbdt, "CBLC" => cblc }
+  end
+
+  let(:source_font_path) { font_fixture_path("NotoSans", "NotoSans-Regular.ttf") }
+
+  # Re-emit NotoSans with our synthetic CBDT/CBLC tables added, then
+  # re-load so the table directory sees them. This is the closest to a
+  # real-world "user added color bitmaps" scenario without requiring a
+  # CBDT-bearing fixture font.
+  let(:font) do
+    base = Fontisan::FontLoader.load(source_font_path, font_index: 0,
+                                                       mode: :full,
+                                                       lazy: false)
+    merged = base.table_data.dup.merge(synthetic_color_tables)
+    rebuilt_bytes = Fontisan::FontWriter.write_font(merged)
+
+    Tempfile.create(["cbdt-source", ".ttf"], binmode: true) do |tf|
+      tf.write(rebuilt_bytes)
+      tf.flush
+      Fontisan::FontLoader.load(tf.path, font_index: 0, mode: :full,
+                                         lazy: false)
+    end
+  end
+
+  def reload(bytes)
+    Tempfile.create(["cbdt-roundtrip", ".ttf"], binmode: true) do |tf|
+      tf.write(bytes)
+      tf.flush
+      Fontisan::FontLoader.load(tf.path, font_index: 0, mode: :full,
+                                         lazy: false)
+    end
+  end
+
+  it "preserves CBDT and CBLC tables when subsetting with the web profile" do
+    gids = [0, 10, 12] # .notdef + 2 color glyphs
+    options = Fontisan::Subset::Options.new(profile: "web")
+    subset_bytes = Fontisan::Subset::Builder.new(font, gids, options).build
+
+    subset_font = reload(subset_bytes)
+    expect(subset_font.table_data).to include("CBDT"),
+                                      "web profile subset must retain CBDT"
+    expect(subset_font.table_data).to include("CBLC"),
+                                      "web profile subset must retain CBLC"
+
+    cbdt = Fontisan::Tables::Cbdt.read(subset_font.table_data["CBDT"])
+    cblc = Fontisan::Tables::Cblc.read(subset_font.table_data["CBLC"])
+
+    source_cbdt = Fontisan::Tables::Cbdt.read(synthetic_color_tables["CBDT"])
+    expect(cbdt.data_size).to be < source_cbdt.data_size,
+                              "subset CBDT should drop unreferenced bitmaps"
+
+    surviving = cblc.each_glyph_location.map do |loc|
+      cbdt.bitmap_data_at(loc.cbdt_offset, loc.byte_length)
+    end.sort
+    expect(surviving).to eq(%w[G10_ G12_].map(&:b))
+  end
+
+  it "drops CBDT/CBLC when subsetting with the pdf profile" do
+    gids = [0, 10]
+    options = Fontisan::Subset::Options.new(profile: "pdf")
+    subset_bytes = Fontisan::Subset::Builder.new(font, gids, options).build
+
+    subset_font = reload(subset_bytes)
+    expect(subset_font.table_data.key?("CBDT")).to be false
+    expect(subset_font.table_data.key?("CBLC")).to be false
+  end
+end


### PR DESCRIPTION
## Summary

- Web-profile subsetting now retains CBDT + CBLC (color bitmap data + location) so browsers render color emoji on emoji character pages instead of falling back to monochrome outlines.
- `Tables::Cbdt` / `Tables::Cblc` rewritten as proper BinData records; CBLC walks IndexSubTableArray + IndexSubTable (formats 1, 2, 3, 5) and exposes `each_glyph_location` / `bitmap_offset_for_gid`.
- All CBLC sibling classes extracted to satisfy the no-nested-classes rule.
- `Subset::TableStrategy` registry replaces the `case/when` dispatcher in `TableSubsetter` — adding a new subsetting strategy is now one file + one REGISTRY entry (Open/Closed Principle). Each strategy is a stateless class responding to `.call(context:, tag:, table:)`.
- `Subset::TableStrategy::ColorBitmapSubsetter` is the paired CBDT+CBLC collaborator, cached on `SharedState` so both strategies reuse one pass. Glyph IDs are remapped via `GlyphMapping` so the subset CBLC references subset GIDs. Output IndexSubTables use format 1 (uint32 offsets, no alignment requirement).
- `Subset::TableStrategy::GlyfLocaBuilder` extracted as the shared glyf+loca builder used by the Glyf, Loca, and Head strategies.

Tracks the TODO.emoji/README.md migration sequence (tasks 01–08).

## Test plan

- [x] `bundle exec rspec spec/fontisan/` — 5726 examples, 0 failures (4 pre-existing pending)
- [x] `bundle exec rubocop` — 0 offenses
- [x] `spec/fontisan/tables/{cbdt,cblc}_spec.rb` rewritten (no `instance_variable_set` in tests)
- [x] `spec/fontisan/subset/table_strategy_spec.rb` covers the registry + PassThrough fallback
- [x] `spec/fontisan/subset/table_strategy/color_bitmap_subsetter_spec.rb` covers the 2-emoji-from-5-source case
- [x] `spec/integration/cbdt_round_trip_spec.rb` exercises `Subset::Builder` end-to-end: rebuilds NotoSans with synthetic CBDT/CBLC, verifies CBDT/CBLC survive the web profile (and are dropped by pdf profile)
- [ ] Browser smoke test (Puppeteer) lives in the essenfont.github.io repo at `scripts/test-emoji-color.mjs`; will be wired to that repo's CI separately

## Notes

- Pre-existing untracked files in the working tree were left alone (per the never-delete-files-you-didn't-create rule: , , , , and the weirdly-named top-level file.
- The Puppeteer smoke test was added to essenfont/essenfont.github.io at  (separate repo, separate PR).
EOF
)