### PR TITLE
ufo/layer: tighten add contract — raise on name conflict (fixes Ext G cmap loss)

### DIFF
--- a/lib/fontisan/stitcher.rb
+++ b/lib/fontisan/stitcher.rb
@@ -36,6 +36,7 @@ module Fontisan
     autoload :PartitionStrategy, "fontisan/stitcher/partition_strategy"
     autoload :CbdtPropagator,   "fontisan/stitcher/cbdt_propagator"
     autoload :GlyphCopier,      "fontisan/stitcher/glyph_copier"
+    autoload :UniqueGlyphName,  "fontisan/stitcher/unique_glyph_name"
 
     # Internal: pairs a compiled loaded font with its stats so
     # +write_collection+ can build the collection and the result from a

--- a/lib/fontisan/stitcher.rb
+++ b/lib/fontisan/stitcher.rb
@@ -35,6 +35,7 @@ module Fontisan
     autoload :FormatMetadata,   "fontisan/stitcher/format_metadata"
     autoload :PartitionStrategy, "fontisan/stitcher/partition_strategy"
     autoload :CbdtPropagator,   "fontisan/stitcher/cbdt_propagator"
+    autoload :GlyphCloner,      "fontisan/stitcher/glyph_cloner"
     autoload :GlyphCopier,      "fontisan/stitcher/glyph_copier"
     autoload :UniqueGlyphName,  "fontisan/stitcher/unique_glyph_name"
 

--- a/lib/fontisan/stitcher/cbdt_propagator.rb
+++ b/lib/fontisan/stitcher/cbdt_propagator.rb
@@ -60,6 +60,19 @@ module Fontisan
       # Outline data is intentionally absent — the bitmap lives in
       # the CBDT table that #propagate_tables_into will copy later.
       #
+      # == Why placeholders are name-deconflicted
+      #
+      # Placeholders are named after the CBDT source's gid ("gid{N}").
+      # Outline donors compiled earlier into the same target use the
+      # SAME naming scheme (see Source#extract_truetype_glyph), so a
+      # CBDT placeholder at "gid110" would collide with an outline
+      # glyph at "gid110" from a different donor. Layer#add raises on
+      # conflict (it never silently overwrites — that path previously
+      # erased real outline glyphs and dropped their cmap entries,
+      # causing the CJK Ext G loss in Essenfont-Regular.ttc). We
+      # allocate a unique name via UniqueGlyphName so each placeholder
+      # lands at its own GID slot without touching the outlines.
+      #
       # Glyphs are NOT registered with the deduplicator: each CBDT
       # glyph is unique to its source, and deduplication would
       # incorrectly collapse distinct bitmaps.
@@ -69,7 +82,10 @@ module Fontisan
       def add_placeholder_glyphs(source, target)
         ufo = source.font.is_a?(Ufo::Font) ? source.font : nil
         if ufo
-          ufo.glyphs.each_value { |g| target.layers.default_layer.add(clone_glyph(g, name: g.name)) }
+          ufo.glyphs.each_value do |g|
+            name = UniqueGlyphName.in(target, g.name)
+            target.layers.default_layer.add(clone_glyph(g, name: name))
+          end
           return
         end
 
@@ -82,7 +98,8 @@ module Fontisan
         mappings.each { |cp, gid| gid_cps[gid] << cp }
 
         num_glyphs.times do |gid|
-          name = gid.zero? ? ".notdef" : "gid#{gid}"
+          base_name = gid.zero? ? ".notdef" : "gid#{gid}"
+          name = UniqueGlyphName.in(target, base_name)
           glyph = Ufo::Glyph.new(name: name)
           glyph.width = 0
           gid_cps[gid].each { |cp| glyph.add_unicode(cp) }

--- a/lib/fontisan/stitcher/cbdt_propagator.rb
+++ b/lib/fontisan/stitcher/cbdt_propagator.rb
@@ -84,7 +84,7 @@ module Fontisan
         if ufo
           ufo.glyphs.each_value do |g|
             name = UniqueGlyphName.in(target, g.name)
-            target.layers.default_layer.add(clone_glyph(g, name: name))
+            target.layers.default_layer.add(GlyphCloner.clone(g, name: name))
           end
           return
         end
@@ -117,6 +117,31 @@ module Fontisan
       #
       # No-op when called with a non-CBDT source or nil.
       #
+      # == Limitation: GID stability
+      #
+      # The propagation copies CBDT/CBLC bytes verbatim. CBLC indexes
+      # glyphs by SOURCE GID — the GIDs of the CBDT donor. The compiled
+      # font's GIDs may differ because:
+      #
+      #   1. +add_placeholder_glyphs+ renames CBDT placeholders via
+      #      UniqueGlyphName when their default "gid{N}" name collides
+      #      with outline glyphs sharing the same donor-gid scheme
+      #      (see Layer's naming contract).
+      #   2. The compiler assigns GIDs in target-namespace order, which
+      #      is not the same as source-GID order once renaming happens.
+      #
+      # The bitmaps line up correctly only when the CBDT source and
+      # every outline source cover disjoint codepoint ranges (the
+      # Essenfont TTC case: emoji vs CJK Ext G). When ranges overlap,
+      # CBLC's source-GID-indexed bitmaps may point at the wrong
+      # compiled glyphs and the colour rendering for affected
+      # codepoints will fall back to outlines.
+      #
+      # A proper fix requires a CBLC rebuild pass: walk the compiled
+      # font's cmap to find the new GID for every CBDT-covered source
+      # glyph, then rewrite CBLC's IndexSubTableArray + IndexSubTable
+      # offsets to match. Tracked as a follow-up.
+      #
       # @param source [Stitcher::Source, nil] the CBDT source
       # @param path [String] compiled font file to rewrite
       def propagate_tables_into(source, path)
@@ -142,26 +167,6 @@ module Fontisan
 
         sfnt = tables.key?("CFF ") || tables.key?("CFF2") ? 0x4F54544F : 0x00010000
         FontWriter.write_to_file(tables, path, sfnt_version: sfnt)
-      end
-
-      private
-
-      def clone_glyph(original, name:)
-        copy = Ufo::Glyph.new(name: name)
-        copy.width = original.width
-        copy.height = original.height
-        original.contours.each { |c| copy.add_contour(clone_contour(c)) }
-        original.components.each { |c| copy.add_component(c) }
-        original.anchors.each { |a| copy.add_anchor(a) }
-        original.guidelines.each { |g| copy.add_guideline(g) }
-        copy
-      end
-
-      def clone_contour(original)
-        points = original.points.map do |p|
-          Ufo::Point.new(x: p.x, y: p.y, type: p.type, smooth: p.smooth)
-        end
-        Ufo::Contour.new(points)
       end
     end
   end

--- a/lib/fontisan/stitcher/glyph_cloner.rb
+++ b/lib/fontisan/stitcher/glyph_cloner.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    # Deep-clone helper for UFO glyphs. Stateless — every call returns
+    # a fresh +Ufo::Glyph+ with copied contours, components, anchors,
+    # and guidelines plus the original's width/height.
+    #
+    # Extracted as a collaborator so +GlyphCopier+ and +CbdtPropagator+
+    # share one implementation of the clone algorithm. Both previously
+    # defined identical +clone_glyph+ / +clone_contour+ private methods
+    # — a DRY violation that risked drifting apart as the glyph model
+    # gained fields.
+    module GlyphCloner
+      # @param original [Ufo::Glyph] glyph to copy
+      # @param name [String, nil] name for the copy; defaults to the
+      #   original's name (used by callers that have already allocated
+      #   a unique name via +UniqueGlyphName+).
+      # @return [Ufo::Glyph] a fresh glyph with the original's geometry
+      #   and metrics, sharing no mutable state with it.
+      def self.clone(original, name: nil)
+        copy = Ufo::Glyph.new(name: name || original.name)
+        copy.width = original.width
+        copy.height = original.height
+        original.contours.each { |c| copy.add_contour(clone_contour(c)) }
+        original.components.each { |c| copy.add_component(c) }
+        original.anchors.each { |a| copy.add_anchor(a) }
+        original.guidelines.each { |g| copy.add_guideline(g) }
+        copy
+      end
+
+      def self.clone_contour(original)
+        points = original.points.map do |p|
+          Ufo::Point.new(x: p.x, y: p.y, type: p.type, smooth: p.smooth)
+        end
+        Ufo::Contour.new(points)
+      end
+      private_class_method :clone_contour
+    end
+  end
+end

--- a/lib/fontisan/stitcher/glyph_copier.rb
+++ b/lib/fontisan/stitcher/glyph_copier.rb
@@ -1,4 +1,4 @@
-# frozen_string: true
+# frozen_string_literal: true
 
 module Fontisan
   class Stitcher
@@ -74,7 +74,7 @@ module Fontisan
           if canonical && target.glyphs.key?(canonical)
             add_extra_unicode(target, canonical, binding[:codepoint])
           else
-            name = unique_target_name(target, glyph.name)
+            name = UniqueGlyphName.in(target, glyph.name)
             copy_glyph_into(target, name: name, source: binding[:source],
                                     donor_gid: binding[:donor_gid],
                                     codepoint: binding[:codepoint])
@@ -93,7 +93,7 @@ module Fontisan
         original = source.glyph_for_gid(donor_gid)
         return unless original
 
-        copy = clone_glyph(original, name: name)
+        copy = GlyphCloner.clone(original, name: name)
         copy.add_unicode(codepoint) if codepoint
         target_font.layers.default_layer.add(copy)
       end
@@ -103,28 +103,6 @@ module Fontisan
 
         glyph = target_font.glyph(glyph_name)
         glyph.add_unicode(codepoint) unless glyph.unicodes.include?(codepoint)
-      end
-
-      def unique_target_name(target_font, base_name)
-        UniqueGlyphName.in(target_font, base_name)
-      end
-
-      def clone_glyph(original, name:)
-        copy = Ufo::Glyph.new(name: name)
-        copy.width = original.width
-        copy.height = original.height
-        original.contours.each { |c| copy.add_contour(clone_contour(c)) }
-        original.components.each { |c| copy.add_component(c) }
-        original.anchors.each { |a| copy.add_anchor(a) }
-        original.guidelines.each { |g| copy.add_guideline(g) }
-        copy
-      end
-
-      def clone_contour(original)
-        points = original.points.map do |p|
-          Ufo::Point.new(x: p.x, y: p.y, type: p.type, smooth: p.smooth)
-        end
-        Ufo::Contour.new(points)
       end
     end
   end

--- a/lib/fontisan/stitcher/glyph_copier.rb
+++ b/lib/fontisan/stitcher/glyph_copier.rb
@@ -106,15 +106,7 @@ module Fontisan
       end
 
       def unique_target_name(target_font, base_name)
-        return base_name unless target_font.glyphs.key?(base_name)
-
-        suffix = 1
-        loop do
-          candidate = "#{base_name}.#{suffix}"
-          return candidate unless target_font.glyphs.key?(candidate)
-
-          suffix += 1
-        end
+        UniqueGlyphName.in(target_font, base_name)
       end
 
       def clone_glyph(original, name:)

--- a/lib/fontisan/stitcher/unique_glyph_name.rb
+++ b/lib/fontisan/stitcher/unique_glyph_name.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Fontisan
+  class Stitcher
+    # Stateless glyph-name deconfliction for the Stitcher's target UFO.
+    #
+    # The Layer's contract (see +Ufo::Layer+) is that two glyphs cannot
+    # share a name — +#add+ raises on conflict. Most Stitcher call sites
+    # already know the name they want is free (e.g. they just synthesised
+    # it). The two that don't — GlyphCopier (outline donors may share
+    # post-table names) and CbdtPropagator (placeholders named "gid{N}"
+    # collide with outline glyphs sharing the same donor-gid scheme) —
+    # ask this helper to allocate a non-colliding name first.
+    #
+    # Centralising the rule here keeps the deconfliction algorithm in
+    # one place: the suffix-search loop, the separator, the order in
+    # which candidates are tried. Changing the rule (e.g. to a UUID
+    # scheme) is a one-file edit.
+    module UniqueGlyphName
+      # Separator between the base name and the disambiguating suffix.
+      # A literal period so the generated name ("gid110.1") still
+      # reads as a variant of the original.
+      SUFFIX_SEPARATOR = "."
+
+      # @param target [Ufo::Font, #glyphs] the target whose +#glyphs+
+      #   hash is the namespace being deconflicted against. Accepts the
+      #   UFO font directly so callers don't have to dig out the layer.
+      # @param base_name [String, #to_s] the requested name.
+      # @return [String] +base_name+ unchanged if no glyph with that
+      #   name exists in +target.glyphs+; otherwise the first
+      #   +"base.1"+, +"base.2"+, ... that does not exist.
+      def self.in(target, base_name)
+        base = base_name.to_s
+        return base unless target.glyphs.key?(base)
+
+        suffix = 1
+        loop do
+          candidate = "#{base}#{SUFFIX_SEPARATOR}#{suffix}"
+          return candidate unless target.glyphs.key?(candidate)
+
+          suffix += 1
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo.rb
+++ b/lib/fontisan/ufo.rb
@@ -17,7 +17,8 @@ module Fontisan
   #
   # Reference: https://unifiedfontobject.org
   module Ufo
-    autoload :Font,        "fontisan/ufo/font"
+    autoload :Font, "fontisan/ufo/font"
+    autoload :GlyphExistsError, "fontisan/ufo/glyph_exists_error"
     autoload :Info,        "fontisan/ufo/info"
     autoload :Layer,       "fontisan/ufo/layer"
     autoload :LayerSet,    "fontisan/ufo/layer_set"

--- a/lib/fontisan/ufo/glyph_exists_error.rb
+++ b/lib/fontisan/ufo/glyph_exists_error.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Ufo
+    # Raised by +Layer#add+ when a glyph with the same name is already
+    # present. Surfaces what would otherwise be a silent overwrite so
+    # the caller can decide between +Layer#put+ (intentional replace)
+    # and +Stitcher::UniqueGlyphName.in+ (auto-rename).
+    #
+    # Extracted as a sibling of +Layer+ (rather than nested inside it)
+    # so the namespace stays flat and the error can be referenced
+    # without pulling in the full Layer implementation.
+    class GlyphExistsError < StandardError
+      attr_reader :name
+
+      def initialize(name)
+        @name = name
+        super("a glyph named #{name.inspect} already exists; use #put " \
+              "to overwrite or UniqueGlyphName.in to deconflict")
+      end
+    end
+  end
+end

--- a/lib/fontisan/ufo/layer.rb
+++ b/lib/fontisan/ufo/layer.rb
@@ -13,32 +13,21 @@ module Fontisan
     # data (e.g. CJK Ext G cmap loss when CBDT placeholders collided
     # with outline glyphs sharing "gid{N}" names).
     #
-    # To make that contract unbreakable, +#add+ RAISES on conflict.
-    # Callers who want one of the other two semantics pick the method
-    # that names it:
+    # To make that contract unbreakable, +#add+ RAISES +GlyphExistsError+
+    # on conflict. Callers who want one of the other two semantics pick
+    # the method that names it:
     #
     #   +#add+::    insert; raise if the name is taken (the safe default)
     #   +#put+::    insert; overwrite any existing glyph with the same name
     #
     # Callers that need auto-renaming (insertion without giving up on a
-    # collision) call +UniqueGlyphName.in(target, base)+ first, then
-    # +#add+ the glyph under the returned name.
+    # collision) call +Stitcher::UniqueGlyphName.in(target, base)+ first,
+    # then +#add+ the glyph under the returned name.
+    #
+    # The error class itself lives at +Fontisan::Ufo::GlyphExistsError+
+    # (sibling, not nested) so the namespace stays flat.
     class Layer
       DEFAULT_NAME = "public.default"
-
-      # Raised by +#add+ when a glyph with the same name already exists.
-      # Surfaces what would otherwise be a silent overwrite so the
-      # caller can decide between +#put+ (intentional replace) and
-      # +UniqueGlyphName.in+ (auto-rename).
-      class GlyphExistsError < StandardError
-        attr_reader :name
-
-        def initialize(name)
-          @name = name
-          super("a glyph named #{name.inspect} already exists; use #put " \
-                "to overwrite or UniqueGlyphName.in to deconflict")
-        end
-      end
 
       attr_reader :name, :glyphs
 

--- a/lib/fontisan/ufo/layer.rb
+++ b/lib/fontisan/ufo/layer.rb
@@ -5,10 +5,40 @@ module Fontisan
     # A single layer in a UFO source. A Layer holds a set of glyphs
     # keyed by name. The default layer is `public.default` per UFO 3.
     #
-    # glyphs is mutated in place by Reader and Writer; the Layer does
-    # not own serialization concerns.
+    # == Naming contract
+    #
+    # Glyph names are the layer's primary key. Two distinct glyphs with
+    # the same name cannot coexist — adding the second would silently
+    # destroy the first, a class of bug that has historically cost real
+    # data (e.g. CJK Ext G cmap loss when CBDT placeholders collided
+    # with outline glyphs sharing "gid{N}" names).
+    #
+    # To make that contract unbreakable, +#add+ RAISES on conflict.
+    # Callers who want one of the other two semantics pick the method
+    # that names it:
+    #
+    #   +#add+::    insert; raise if the name is taken (the safe default)
+    #   +#put+::    insert; overwrite any existing glyph with the same name
+    #
+    # Callers that need auto-renaming (insertion without giving up on a
+    # collision) call +UniqueGlyphName.in(target, base)+ first, then
+    # +#add+ the glyph under the returned name.
     class Layer
       DEFAULT_NAME = "public.default"
+
+      # Raised by +#add+ when a glyph with the same name already exists.
+      # Surfaces what would otherwise be a silent overwrite so the
+      # caller can decide between +#put+ (intentional replace) and
+      # +UniqueGlyphName.in+ (auto-rename).
+      class GlyphExistsError < StandardError
+        attr_reader :name
+
+        def initialize(name)
+          @name = name
+          super("a glyph named #{name.inspect} already exists; use #put " \
+                "to overwrite or UniqueGlyphName.in to deconflict")
+        end
+      end
 
       attr_reader :name, :glyphs
 
@@ -21,7 +51,28 @@ module Fontisan
         @glyphs[glyph_name.to_s]
       end
 
+      # Insert +glyph+. Raises +GlyphExistsError+ if a glyph with the
+      # same name is already present — this is the contract that keeps
+      # the layer's key namespace trustworthy.
+      #
+      # @param glyph [Glyph]
+      # @return [Glyph] the same glyph
+      # @raise [GlyphExistsError] if +glyph.name+ is already taken
       def add(glyph)
+        name = glyph.name.to_s
+        raise GlyphExistsError, name if @glyphs.key?(name)
+
+        @glyphs[name] = glyph
+        glyph
+      end
+
+      # Insert +glyph+, replacing any existing glyph with the same
+      # name. Use this when the caller has positively decided that the
+      # previous glyph (if any) should be discarded.
+      #
+      # @param glyph [Glyph]
+      # @return [Glyph] the same glyph
+      def put(glyph)
         @glyphs[glyph.name.to_s] = glyph
         glyph
       end

--- a/lib/fontisan/version.rb
+++ b/lib/fontisan/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Fontisan
-  VERSION = "0.4.23"
+  VERSION = "0.4.22"
 end

--- a/lib/fontisan/version.rb
+++ b/lib/fontisan/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Fontisan
-  VERSION = "0.4.22"
+  VERSION = "0.4.23"
 end

--- a/spec/fontisan/stitcher/cbdt_placeholder_collision_spec.rb
+++ b/spec/fontisan/stitcher/cbdt_placeholder_collision_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string: true
+# frozen_string_literal: true
 
 require "spec_helper"
 require_relative "../../../lib/fontisan/stitcher"
@@ -10,81 +10,93 @@ require "tmpdir"
 # Before the Layer#add contract was tightened (raise-on-conflict +
 # UniqueGlyphName helper), CbdtPropagator#add_placeholder_glyphs named
 # its placeholders "gid{N}" — the SAME scheme Source#extract_truetype_glyph
-# uses for outline glyphs from TTF donors. When both an outline donor
-# and a CBDT donor contributed to the same target, Layer#add silently
-# hash-overwrote the outline glyph with the empty placeholder. The
-# outline's codepoints dropped out of the cmap; CJK Ext G in
-# Essenfont-Regular.ttc lost 3,917 of 4,939 codepoints this way.
+# uses for outline glyphs from TTF donors, AND the same scheme a caller
+# might use directly when constructing a UFO outline donor. When both
+# donors contributed a glyph with the same name, Layer#add silently
+# hash-overwrote the earlier one. The overwritten glyph's codepoints
+# dropped out of the cmap; CJK Ext G in Essenfont-Regular.ttc lost
+# 3,917 of 4,939 codepoints this way.
 #
-# This spec reproduces the failure mode minimally: an outline donor
-# whose U+30F4D sits at gid 4027, plus a CBDT source whose glyph
-# count is high enough that its placeholders cover "gid4027". Without
-# the fix, the placeholder overwrites the outline glyph and U+30F4D
-# disappears from the cmap.
-RSpec.describe Fontisan::Stitcher, "CBDT placeholder vs outline glyph naming" do
-  let(:ufo) { Fontisan::Ufo }
+# This spec reproduces the failure mode minimally. The outline donor
+# (UFO) carries a glyph NAMED "gid1" — matching the CBDT source's
+# placeholder at GID 1. The two donors cover DISJOINT codepoints so
+# the cmap-priority fix (PR #107 / outline-first ordering) does NOT
+# apply; the only path that keeps both glyphs in the target is
+# Layer#add raising on conflict + UniqueGlyphName allocating "gid1.1"
+# for the placeholder.
+#
+# Without the fix, the CBDT placeholder overwrites the outline glyph
+# and cp_a disappears from the cmap entirely.
+RSpec.describe Fontisan::Stitcher do
+  context "CBDT placeholder vs outline glyph naming" do
+    let(:ufo) { Fontisan::Ufo }
 
-  # Build a small UFO outline donor covering one codepoint, with the
-  # glyph at a known position. Naming is delegated to the compiler;
-  # all we need is a real outline glyph at GID 1 covering shared_cp.
-  def make_outline_source_with(name, cp, width: 500)
-    font = ufo::Font.new
-    font.info.units_per_em = 1000
-    font.glyphs[".notdef"] = ufo::Glyph.new(name: ".notdef")
+    # Build a UFO outline donor with one glyph named "gid1" (matching
+    # the CBDT source's placeholder naming scheme) at cp_a with advance
+    # 500.
+    def make_outline_donor_with_gid1_name(cp_a)
+      font = ufo::Font.new
+      font.info.units_per_em = 1000
+      font.glyphs[".notdef"] = ufo::Glyph.new(name: ".notdef")
 
-    g = ufo::Glyph.new(name: name)
-    g.width = width
-    g.add_unicode(cp)
-    g.add_contour(ufo::Contour.new([
-                                     ufo::Point.new(x: 0, y: 0, type: "line"),
-                                     ufo::Point.new(x: width, y: 0, type: "line"),
-                                     ufo::Point.new(x: width, y: 100, type: "line"),
-                                   ]))
-    font.glyphs[name] = g
-    font
-  end
+      g = ufo::Glyph.new(name: "gid1") # collides with CBDT placeholder name
+      g.width = 500
+      g.add_unicode(cp_a)
+      g.add_contour(ufo::Contour.new([
+                                       ufo::Point.new(x: 0, y: 0, type: "line"),
+                                       ufo::Point.new(x: 500, y: 0, type: "line"),
+                                       ufo::Point.new(x: 500, y: 100, type: "line"),
+                                     ]))
+      font.glyphs["gid1"] = g
+      font
+    end
 
-  it "outline glyph wins cmap mapping; CBDT placeholder lands at its own GID" do
-    shared_cp = 0x1F600
-    outline = make_outline_source_with("outline-emoji", shared_cp, width: 500)
+    it "outline glyph and CBDT placeholder both survive when they share a name" do
+      cp_a = 0x41    # 'A' — only in outline donor
+      cp_b = 0x1F600 # emoji — only in CBDT donor
 
-    cbdt_dir = Dir.mktmpdir
-    cbdt_path = File.join(cbdt_dir, "cbdt.ttf")
-    Fontisan::SpecHelpers::CbdtFixture.write_font(codepoints: [shared_cp], path: cbdt_path)
-    cbdt_font = Fontisan::FontLoader.load(cbdt_path)
+      outline = make_outline_donor_with_gid1_name(cp_a)
 
-    stitcher = described_class.new
-    stitcher.add_source(:outline, outline)
-    stitcher.add_source(:cbdt, cbdt_font)
-    stitcher.include_notdef(from: :outline, into: :main)
-    stitcher.include_codepoints([shared_cp], from: :outline, into: :main)
+      cbdt_dir = Dir.mktmpdir
+      cbdt_path = File.join(cbdt_dir, "cbdt.ttf")
+      Fontisan::SpecHelpers::CbdtFixture.write_font(codepoints: [cp_b],
+                                                    path: cbdt_path)
+      cbdt_font = Fontisan::FontLoader.load(cbdt_path)
 
-    Dir.mktmpdir do |dir|
-      path = File.join(dir, "out.ttf")
-      stitcher.write_to(path, format: :ttf, subfont: :main)
+      stitcher = described_class.new
+      stitcher.add_source(:outline, outline)
+      stitcher.add_source(:cbdt, cbdt_font)
+      stitcher.include_notdef(from: :outline, into: :main)
+      stitcher.include_codepoints([cp_a], from: :outline, into: :main)
 
-      loaded = Fontisan::FontLoader.load(path)
-      cmap = loaded.table("cmap").unicode_mappings
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out.ttf")
+        stitcher.write_to(path, format: :ttf, subfont: :main)
 
-      # The shared codepoint must remain in the cmap. Before the fix,
-      # the CBDT placeholder named "gid{N}" (where N matched the outline
-      # glyph's donor gid) overwrote the outline glyph and the cp was
-      # silently dropped.
-      expect(cmap).to include(shared_cp),
-                      "shared codepoint U+%06X dropped from cmap — CBDT placeholder " \
-                      "overwrote the outline glyph (regression)" % shared_cp
+        loaded = Fontisan::FontLoader.load(path)
+        cmap = loaded.table("cmap").unicode_mappings
 
-      # And it must map to the outline glyph (width 500), proving the
-      # outline won over the empty placeholder.
-      hmtx = loaded.table("hmtx")
-      hhea = loaded.table("hhea")
-      maxp_t = loaded.table("maxp")
-      hmtx.parse_with_context(hhea.number_of_h_metrics, maxp_t.num_glyphs)
-      gid = cmap[shared_cp]
-      metric = hmtx.metric_for(gid)
-      expect(metric[:advance_width]).to eq(500),
-                                        "shared codepoint mapped to CBDT placeholder (width 1000) " \
-                                        "instead of outline glyph (width 500) — overwrite regression"
+        # cp_a must remain in the cmap. Without the Layer#add raise-on-
+        # conflict contract + UniqueGlyphName deconfliction, the CBDT
+        # placeholder at "gid1" would overwrite the outline glyph at
+        # "gid1" and cp_a would silently disappear.
+        expect(cmap).to include(cp_a),
+                        "outline glyph's codepoint U+%04X dropped from cmap — " \
+                        "CBDT placeholder overwrote it via name collision (regression)" % cp_a
+
+        # And it must map to the outline glyph (width 500), proving the
+        # outline won — not to the CBDT placeholder (width 1000 from
+        # CbdtFixture's hmtx).
+        hmtx = loaded.table("hmtx")
+        hhea = loaded.table("hhea")
+        maxp_t = loaded.table("maxp")
+        hmtx.parse_with_context(hhea.number_of_h_metrics, maxp_t.num_glyphs)
+        gid = cmap[cp_a]
+        metric = hmtx.metric_for(gid)
+        expect(metric[:advance_width]).to eq(500),
+                                          "cp_a mapped to CBDT placeholder (width 1000) " \
+                                          "instead of outline glyph (width 500) — overwrite regression"
+      end
     end
   end
 end

--- a/spec/fontisan/stitcher/cbdt_placeholder_collision_spec.rb
+++ b/spec/fontisan/stitcher/cbdt_placeholder_collision_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string: true
+
+require "spec_helper"
+require_relative "../../../lib/fontisan/stitcher"
+require_relative "../../support/cbdt_fixture"
+require "tmpdir"
+
+# Regression coverage for the CBDT-placeholder-overwrites-outline bug.
+#
+# Before the Layer#add contract was tightened (raise-on-conflict +
+# UniqueGlyphName helper), CbdtPropagator#add_placeholder_glyphs named
+# its placeholders "gid{N}" — the SAME scheme Source#extract_truetype_glyph
+# uses for outline glyphs from TTF donors. When both an outline donor
+# and a CBDT donor contributed to the same target, Layer#add silently
+# hash-overwrote the outline glyph with the empty placeholder. The
+# outline's codepoints dropped out of the cmap; CJK Ext G in
+# Essenfont-Regular.ttc lost 3,917 of 4,939 codepoints this way.
+#
+# This spec reproduces the failure mode minimally: an outline donor
+# whose U+30F4D sits at gid 4027, plus a CBDT source whose glyph
+# count is high enough that its placeholders cover "gid4027". Without
+# the fix, the placeholder overwrites the outline glyph and U+30F4D
+# disappears from the cmap.
+RSpec.describe Fontisan::Stitcher, "CBDT placeholder vs outline glyph naming" do
+  let(:ufo) { Fontisan::Ufo }
+
+  # Build a small UFO outline donor covering one codepoint, with the
+  # glyph at a known position. Naming is delegated to the compiler;
+  # all we need is a real outline glyph at GID 1 covering shared_cp.
+  def make_outline_source_with(name, cp, width: 500)
+    font = ufo::Font.new
+    font.info.units_per_em = 1000
+    font.glyphs[".notdef"] = ufo::Glyph.new(name: ".notdef")
+
+    g = ufo::Glyph.new(name: name)
+    g.width = width
+    g.add_unicode(cp)
+    g.add_contour(ufo::Contour.new([
+                                     ufo::Point.new(x: 0, y: 0, type: "line"),
+                                     ufo::Point.new(x: width, y: 0, type: "line"),
+                                     ufo::Point.new(x: width, y: 100, type: "line"),
+                                   ]))
+    font.glyphs[name] = g
+    font
+  end
+
+  it "outline glyph wins cmap mapping; CBDT placeholder lands at its own GID" do
+    shared_cp = 0x1F600
+    outline = make_outline_source_with("outline-emoji", shared_cp, width: 500)
+
+    cbdt_dir = Dir.mktmpdir
+    cbdt_path = File.join(cbdt_dir, "cbdt.ttf")
+    Fontisan::SpecHelpers::CbdtFixture.write_font(codepoints: [shared_cp], path: cbdt_path)
+    cbdt_font = Fontisan::FontLoader.load(cbdt_path)
+
+    stitcher = described_class.new
+    stitcher.add_source(:outline, outline)
+    stitcher.add_source(:cbdt, cbdt_font)
+    stitcher.include_notdef(from: :outline, into: :main)
+    stitcher.include_codepoints([shared_cp], from: :outline, into: :main)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "out.ttf")
+      stitcher.write_to(path, format: :ttf, subfont: :main)
+
+      loaded = Fontisan::FontLoader.load(path)
+      cmap = loaded.table("cmap").unicode_mappings
+
+      # The shared codepoint must remain in the cmap. Before the fix,
+      # the CBDT placeholder named "gid{N}" (where N matched the outline
+      # glyph's donor gid) overwrote the outline glyph and the cp was
+      # silently dropped.
+      expect(cmap).to include(shared_cp),
+                      "shared codepoint U+%06X dropped from cmap — CBDT placeholder " \
+                      "overwrote the outline glyph (regression)" % shared_cp
+
+      # And it must map to the outline glyph (width 500), proving the
+      # outline won over the empty placeholder.
+      hmtx = loaded.table("hmtx")
+      hhea = loaded.table("hhea")
+      maxp_t = loaded.table("maxp")
+      hmtx.parse_with_context(hhea.number_of_h_metrics, maxp_t.num_glyphs)
+      gid = cmap[shared_cp]
+      metric = hmtx.metric_for(gid)
+      expect(metric[:advance_width]).to eq(500),
+                                        "shared codepoint mapped to CBDT placeholder (width 1000) " \
+                                        "instead of outline glyph (width 500) — overwrite regression"
+    end
+  end
+end

--- a/spec/fontisan/stitcher/outline_priority_spec.rb
+++ b/spec/fontisan/stitcher/outline_priority_spec.rb
@@ -156,11 +156,10 @@ RSpec.describe Fontisan::Stitcher do
       # Collection variant of the same regression: each subfont is
       # compiled independently, then packed via Collection::Builder.
       # Verifies the cmap survives the round-trip through the multi-face
-      # pipeline without losing the outline-first priority.
+      # pipeline without losing the outline-first priority, AND that the
+      # CBDT placeholder names ("gid{N}") don't overwrite outline glyphs
+      # sharing the same donor-gid naming scheme.
       it "write_collection preserves outline-first cmap priority across faces" do
-        skip "Stitcher currently raises on a CBDT source without at least one outline codepoint in each face — " \
-             "collection-mode coverage needs CbdtPropagator hardening tracked separately."
-
         shared_cp = 0x1F600
         outline = make_outline_source_with("outline-emoji", shared_cp, width: 500)
         cbdt_font = make_cbdt_source_with([shared_cp])

--- a/spec/fontisan/ufo/layer_spec.rb
+++ b/spec/fontisan/ufo/layer_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string: true
+
+require "spec_helper"
+require_relative "../../../lib/fontisan/ufo/layer"
+require_relative "../../../lib/fontisan/ufo/glyph"
+
+# Contract tests for the Layer naming invariants. The Layer is a
+# Hash-keyed collection and the key is the glyph name; that makes name
+# collisions data-loss events. The contract:
+#
+#   +#add+::  raises GlyphExistsError on collision (the safe default —
+#             never silently overwrites)
+#   +#put+::  explicit overwrite path for callers who have decided the
+#             previous glyph should be discarded
+#
+# Stitcher collaborators that need auto-renaming use
+# +Stitcher::UniqueGlyphName.in(target, base)+ to allocate a free name
+# before +#add+.
+RSpec.describe Fontisan::Ufo::Layer do
+  let(:glyph_a) { Fontisan::Ufo::Glyph.new(name: "A") }
+  let(:glyph_a_duplicate) { Fontisan::Ufo::Glyph.new(name: "A") }
+  let(:glyph_b) { Fontisan::Ufo::Glyph.new(name: "B") }
+
+  describe "#add" do
+    it "inserts the first glyph with a given name" do
+      layer = described_class.new
+      layer.add(glyph_a)
+      expect(layer.size).to eq(1)
+      expect(layer["A"]).to be(glyph_a)
+    end
+
+    it "raises GlyphExistsError when the name is already taken" do
+      layer = described_class.new
+      layer.add(glyph_a)
+
+      expect { layer.add(glyph_a_duplicate) }
+        .to raise_error(Fontisan::Ufo::Layer::GlyphExistsError, /"A"/)
+    end
+
+    it "preserves the original glyph when a second add raises" do
+      layer = described_class.new
+      layer.add(glyph_a)
+
+      expect { layer.add(glyph_a_duplicate) }.to raise_error(StandardError)
+      expect(layer["A"]).to be(glyph_a),
+                              "original glyph must NOT be replaced when add raises"
+    end
+
+    it "inserts glyphs with distinct names without raising" do
+      layer = described_class.new
+      layer.add(glyph_a)
+      layer.add(glyph_b)
+      expect(layer.size).to eq(2)
+    end
+  end
+
+  describe "#put" do
+    it "overwrites an existing glyph with the same name" do
+      layer = described_class.new
+      layer.add(glyph_a)
+      layer.put(glyph_a_duplicate)
+
+      expect(layer.size).to eq(1)
+      expect(layer["A"]).to be(glyph_a_duplicate)
+    end
+
+    it "inserts a glyph whose name is not yet present" do
+      layer = described_class.new
+      layer.put(glyph_a)
+      expect(layer["A"]).to be(glyph_a)
+    end
+  end
+
+  describe "GlyphExistsError" do
+    it "exposes the colliding name for programmatic handling" do
+      layer = described_class.new
+      layer.add(glyph_a)
+
+      begin
+        layer.add(glyph_a_duplicate)
+      rescue described_class::GlyphExistsError => e
+        expect(e.name).to eq("A")
+      end
+    end
+  end
+end

--- a/spec/fontisan/ufo/layer_spec.rb
+++ b/spec/fontisan/ufo/layer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Fontisan::Ufo::Layer do
       layer.add(glyph_a)
 
       expect { layer.add(glyph_a_duplicate) }
-        .to raise_error(Fontisan::Ufo::Layer::GlyphExistsError, /"A"/)
+        .to raise_error(Fontisan::Ufo::GlyphExistsError, /"A"/)
     end
 
     it "preserves the original glyph when a second add raises" do
@@ -43,7 +43,7 @@ RSpec.describe Fontisan::Ufo::Layer do
 
       expect { layer.add(glyph_a_duplicate) }.to raise_error(StandardError)
       expect(layer["A"]).to be(glyph_a),
-                              "original glyph must NOT be replaced when add raises"
+                            "original glyph must NOT be replaced when add raises"
     end
 
     it "inserts glyphs with distinct names without raising" do
@@ -78,7 +78,7 @@ RSpec.describe Fontisan::Ufo::Layer do
 
       begin
         layer.add(glyph_a_duplicate)
-      rescue described_class::GlyphExistsError => e
+      rescue Fontisan::Ufo::GlyphExistsError => e
         expect(e.name).to eq("A")
       end
     end


### PR DESCRIPTION
## Summary

Tightens the `Layer#add` contract so a glyph-name collision is a loud failure instead of silent data loss, and fixes `CbdtPropagator#add_placeholder_glyphs` to use the new contract safely.

- `Layer#add` raises `GlyphExistsError` on conflict (was: silently overwrote the existing glyph). New `Layer#put` is the explicit overwrite path.
- New `Stitcher::UniqueGlyphName` stateless helper allocates a non-colliding name in a target's glyph namespace. `GlyphCopier#unique_target_name` delegates to it; `CbdtPropagator` now uses it for both the UFO-source and TTF-source placeholder paths.
- Bumps to 0.4.23.

## Why

This was the actual root cause of the CJK Ext G cmap loss in `Essenfont-Regular.ttc` face 7 — the bug that the earlier `stitcher-cbdt-regression-coverage` PR (#107) was mistakenly thought to fix.

Of 4,939 Ext G codepoints in the FSung-3 donor, only 1,022 survived into the TTC. The lost 3,917 cps corresponded exactly to FSung-3 GIDs 110..4026 — the same GID range where NotoColorEmoji's CBDT placeholders (`"gid1"`..`"gid4026"`) collided with FSung-3's outline glyphs (also named `"gid{N}"` by `Source#extract_truetype_glyph`). `Layer#add` did `@glyphs[name] = glyph` under the hood; the placeholder hash-overwrote the outline glyph, and the cp→gid mapping for that codepoint was destroyed.

The earlier outline-first Stitcher fix (commit a8ce7dc, released in 0.4.20) handled the related but different "shared codepoint maps to which glyph" case via Cmap first-wins. It does NOT help when there's no codepoint sharing — NotoColorEmoji has 0 Ext G codepoints — but the placeholder glyph names still collide with outline glyph names because both donors happen to use the same gid-based naming scheme.

## How it works

Before:
```ruby
class Layer
  def add(glyph)
    @glyphs[glyph.name.to_s] = glyph  # silent overwrite
    glyph
  end
end
```

After:
```ruby
class Layer
  def add(glyph)
    name = glyph.name.to_s
    raise GlyphExistsError, name if @glyphs.key?(name)
    @glyphs[name] = glyph
    glyph
  end

  def put(glyph)         # explicit overwrite
    @glyphs[glyph.name.to_s] = glyph
    glyph
  end
end
```

Callers that need a glyph to land without clobbering anything (GlyphCopier, CbdtPropagator) ask `UniqueGlyphName.in(target, base)` for a free name first:

```ruby
name = UniqueGlyphName.in(target, "gid110")  # "gid110" or "gid110.1" etc.
target.layers.default_layer.add(Ufo::Glyph.new(name: name))
```

## Test plan

- [x] `bundle exec rspec spec/fontisan/ufo/layer_spec.rb` — new contract spec (insert/raise/preserve-original + put semantics)
- [x] `bundle exec rspec spec/fontisan/stitcher/cbdt_placeholder_collision_spec.rb` — end-to-end regression for the actual bug
- [x] `bundle exec rspec spec/fontisan/stitcher/outline_priority_spec.rb` — collection-mode test (previously skipped) now enabled and passing
- [x] `bundle exec rspec spec/fontisan/ufo/` — full UFO suite (264 examples, 0 failures)
- [x] `bundle exec rspec spec/fontisan/stitcher/` — full Stitcher suite (148 examples, 0 failures)
- [ ] End-to-end verification: rebuild `Essenfont-Regular.ttc` and confirm face 7 has all 4,939 Ext G codepoints (in progress)

## Notes

The Essenfont repo's `Gemfile.lock` still pins fontisan to 0.4.11 (the latest published on RubyGems at the time of writing). Once 0.4.23 ships to RubyGems, the Essenfont `Gemfile`'s `>= 0.4.20` floor will pick it up automatically. For immediate local verification, build with `FONTISAN_PATH=/path/to/fontisan bundle exec ruby scripts/build.rb`.
