### PR TITLE
tasks/fixture_downloader: retry 429, honor Retry-After, scope GITHUB_TOKEN to GitHub hosts

### DIFF
--- a/lib/fontisan/tasks/fixture_downloader.rb
+++ b/lib/fontisan/tasks/fixture_downloader.rb
@@ -12,12 +12,21 @@ module Fontisan
   module Tasks
     # Downloads a single fixture file with retry on transient network
     # failures. Used by `rake fixtures:download` so a single CDN blip
-    # (5xx, connection reset, OpenTimeout) doesn't sink a fresh
-    # checkout. Permanent failures (404, malformed URL) surface
-    # immediately.
+    # (5xx, connection reset, OpenTimeout, GitHub 429) doesn't sink a
+    # fresh checkout. Permanent failures (404, 403) surface immediately.
     #
     # The downloader is a focused class, not a procedural Rakefile
     # patch, so the retry logic is unit-testable in isolation.
+    #
+    # == Authentication
+    #
+    # GitHub anonymous downloads are rate-limited to ~60 req/hour per IP.
+    # CI runners share egress IPs, so parallel matrix jobs hit that
+    # ceiling quickly and start receiving 429 Too Many Requests. To
+    # avoid that, when the +GITHUB_TOKEN+ environment variable is set
+    # (GitHub Actions auto-injects it for every workflow run), the
+    # downloader sends it as a Bearer token. Authenticated requests get
+    # 15,000 req/hour.
     #
     # @example
     #   Fontisan::Tasks::FixtureDownloader.new(
@@ -36,12 +45,21 @@ module Fontisan
         IOError,
       ].freeze
 
-      # 5xx HTTP responses are transient server errors worth retrying.
-      # 4xx are permanent (404, 403) and must fail fast.
-      RETRIABLE_HTTP_STATUSES = (500..599)
+      # HTTP statuses worth retrying after a backoff. 5xx are
+      # transient server errors; 429 is a transient rate-limit (always
+      # retriable — server is explicitly telling the client to slow
+      # down, not to go away permanently).
+      RETRIABLE_HTTP_STATUSES = ((500..599).to_a + [429]).freeze
+
+      # Status code returned when the client has been rate-limited.
+      HTTP_TOO_MANY_REQUESTS = 429
 
       DEFAULT_MAX_RETRIES = 3
       DEFAULT_BASE_BACKOFF = 0.5 # seconds; doubles per attempt
+      # Ceiling for the +Retry-After+ header value so a misbehaving
+      # server can't stall CI for hours. 60s is well above GitHub's
+      # typical 1-5s secondary-limit backoff.
+      MAX_RETRY_AFTER_SECONDS = 60
 
       # Error raised after exhausting all retries. Carries the last
       # underlying exception so callers can log the root cause.
@@ -55,7 +73,8 @@ module Fontisan
         end
       end
 
-      attr_reader :url, :destination, :max_retries, :base_backoff, :sleep_method
+      attr_reader :url, :destination, :max_retries, :base_backoff,
+                  :sleep_method, :github_token
 
       # @param url [String] source URL.
       # @param destination [String] path to write bytes to. Parent dir
@@ -63,16 +82,22 @@ module Fontisan
       # @param max_retries [Integer] total attempts including the
       #   first. 3 means: try, retry, retry.
       # @param base_backoff [Float] seconds to sleep before the first
-      #   retry. Doubles per attempt.
+      #   retry. Doubles per attempt (overridden by Retry-After on 429).
       # @param sleep_method [#call] injectable sleep (for tests).
       #   Defaults to Kernel.sleep.
+      # @param github_token [String, nil] Bearer token for GitHub auth.
+      #   Defaults to +ENV["GITHUB_TOKEN"]+ so CI auto-authenticates;
+      #   pass +nil+ explicitly to force anonymous download in tests.
       def initialize(url:, destination:, max_retries: DEFAULT_MAX_RETRIES,
-                     base_backoff: DEFAULT_BASE_BACKOFF, sleep_method: method(:sleep))
+                     base_backoff: DEFAULT_BASE_BACKOFF,
+                     sleep_method: method(:sleep),
+                     github_token: ENV["GITHUB_TOKEN"])
         @url = url
         @destination = destination
         @max_retries = max_retries
         @base_backoff = base_backoff
         @sleep_method = sleep_method
+        @github_token = github_token
       end
 
       # Performs the download. Returns the destination path on
@@ -82,19 +107,19 @@ module Fontisan
       # @raise [Error]
       def call
         attempts = 0
-        nil
 
         begin
           attempts += 1
           fetch_to_destination
           destination
         rescue StandardError => e
-          e
           raise if permanent_failure?(e)
-          raise Error.new(url: url, attempts: attempts, last_error: e) if attempts >= max_retries
+          if attempts >= max_retries
+            raise Error.new(url: url, attempts: attempts,
+                            last_error: e)
+          end
 
-          backoff = base_backoff * (2**(attempts - 1))
-          sleep_method.call(backoff)
+          sleep_method.call(backoff_seconds(e, attempts))
           retry
         end
       end
@@ -128,22 +153,47 @@ module Fontisan
       # message]` array. We re-raise non-retriable 4xx as
       # `permanent-failure`-tagged exceptions so the retry loop exits.
       def open_uri_options
-        {
+        options = {
           "User-Agent" => "fontisan-fixtures/1.0",
           redirect: true,
           open_timeout: 30,
           read_timeout: 120,
         }
+        options["Authorization"] = "Bearer #{github_token}" if github_token
+        options
       end
 
       def permanent_failure?(error)
         case error
         when OpenURI::HTTPError
           status = parse_http_status(error)
-          status && !RETRIABLE_HTTP_STATUSES.cover?(status)
+          status && !RETRIABLE_HTTP_STATUSES.include?(status)
         else
           RETRIABLE_ERRORS.none? { |klass| error.is_a?(klass) }
         end
+      end
+
+      # Seconds to wait before the next attempt. Honors the server's
+      # +Retry-After+ header on 429 responses (capped); otherwise uses
+      # exponential backoff from +base_backoff+.
+      def backoff_seconds(error, attempts)
+        retry_after = parse_retry_after(error)
+        return retry_after if retry_after
+
+        base_backoff * (2**(attempts - 1))
+      end
+
+      def parse_retry_after(error)
+        return unless error.is_a?(OpenURI::HTTPError)
+        return unless parse_http_status(error) == HTTP_TOO_MANY_REQUESTS
+
+        header_value = error.io&.meta&.[]("retry-after")
+        return unless header_value
+
+        seconds = Integer(header_value, exception: false)
+        return unless seconds&.positive?
+
+        [seconds, MAX_RETRY_AFTER_SECONDS].min
       end
 
       def parse_http_status(error)

--- a/lib/fontisan/tasks/fixture_downloader.rb
+++ b/lib/fontisan/tasks/fixture_downloader.rb
@@ -61,6 +61,17 @@ module Fontisan
       # typical 1-5s secondary-limit backoff.
       MAX_RETRY_AFTER_SECONDS = 60
 
+      # Hosts that legitimately accept the GITHUB_TOKEN as Bearer auth.
+      # Anything else (raw.githubusercontent.com subdomain variants,
+      # third-party CDNs, mirror sites) is treated as untrusted. Used
+      # by +send_auth?+ as the credential-leak guard.
+      GITHUB_HOSTS = %w[
+        github.com
+        codeload.github.com
+        objects.githubusercontent.com
+        api.github.com
+      ].freeze
+
       # Error raised after exhausting all retries. Carries the last
       # underlying exception so callers can log the root cause.
       class Error < StandardError
@@ -129,18 +140,18 @@ module Fontisan
       def fetch_to_destination
         FileUtils.mkdir_p(File.dirname(destination))
 
-        # IO.copy_stream avoids loading the whole response into memory
-        # and is more Windows-compatible than remote.read + File.binwrite.
+        # Parse once, reuse: a second URI.parse(url) call inside
+        # open_uri_options would be wasteful and breaks test stubs
+        # that return a single fixed URI instance.
+        #
         # URLs come from FixtureFonts config (version-controlled), not
         # user input — same trust model as the previous inline URI.open
-        # call in the Rakefile.
-        #
-        # Parsing with URI.parse first satisfies CodeQL's "open with
-        # non-constant value" check: any string that isn't a valid URI
-        # raises URI::InvalidURIError before OpenURI can dispatch on
-        # it. The parsed URI's .open is OpenURI's standard entry.
+        # call in the Rakefile. Parsing first satisfies CodeQL's "open
+        # with non-constant value" check: any string that isn't a valid
+        # URI raises URI::InvalidURIError before OpenURI dispatches.
         # rubocop:disable Security/Open
-        URI.parse(url).open(open_uri_options) do |remote|
+        parsed = URI.parse(url)
+        parsed.open(open_uri_options(parsed)) do |remote|
           File.open(destination, "wb") do |file|
             IO.copy_stream(remote, file)
           end
@@ -152,15 +163,31 @@ module Fontisan
       # errors as `OpenURI::HTTPError` whose `io.status` is the `[code,
       # message]` array. We re-raise non-retriable 4xx as
       # `permanent-failure`-tagged exceptions so the retry loop exits.
-      def open_uri_options
+      #
+      # The Authorization header is gated on +send_auth?+ so a token
+      # captured from ENV never leaks to a non-GitHub host (e.g. if a
+      # future fixture URL points at a third-party CDN). codeload and
+      # objects.githubusercontent are included because github.com
+      # release-asset URLs redirect there.
+      def open_uri_options(parsed)
         options = {
           "User-Agent" => "fontisan-fixtures/1.0",
           redirect: true,
           open_timeout: 30,
           read_timeout: 120,
         }
-        options["Authorization"] = "Bearer #{github_token}" if github_token
+        options["Authorization"] = "Bearer #{github_token}" if send_auth?(parsed)
         options
+      end
+
+      # True only when +github_token+ is configured AND the URL targets
+      # a GitHub-owned host. The host check is the credential-leak
+      # guard: an attacker who controls a different host can't trick
+      # the downloader into forwarding the CI token.
+      def send_auth?(parsed)
+        return false unless github_token
+
+        GITHUB_HOSTS.include?(parsed.host.to_s)
       end
 
       def permanent_failure?(error)

--- a/spec/fontisan/tasks/fixture_downloader_spec.rb
+++ b/spec/fontisan/tasks/fixture_downloader_spec.rb
@@ -7,10 +7,10 @@ require "stringio"
 require "open-uri"
 
 # Lightweight stand-in for the Net::HTTP response object that
-# OpenURI::HTTPError wraps. OpenURI only needs .status -> [code,
-# message]; a Struct satisfies that without doubles, and behaves
-# identically when our code reads it.
-HttpStatusIo = Struct.new(:status)
+# OpenURI::HTTPError wraps. OpenURI needs .status -> [code, message]
+# and our retry-after parser reads .meta["retry-after"]; a Struct
+# satisfies both without doubles.
+HttpStatusIo = Struct.new(:status, :meta)
 
 RSpec.describe Fontisan::Tasks::FixtureDownloader do
   let(:destination) { File.join(Dir.tmpdir, "fontisan-spec-#{Process.pid}-#{rand(10_000)}.dat") }
@@ -29,8 +29,9 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
     File.delete(destination) if File.exist?(destination)
   end
 
-  def http_error(code, message)
-    OpenURI::HTTPError.new("#{code} #{message}", HttpStatusIo.new([code.to_s, message]))
+  def http_error(code, message, meta: {})
+    OpenURI::HTTPError.new("#{code} #{message}",
+                           HttpStatusIo.new([code.to_s, message], meta))
   end
 
   describe "#call" do
@@ -125,7 +126,7 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
       expect(sleeps).to eq([1.0, 2.0, 4.0])
     end
 
-    it "fails fast on 4xx without retrying" do
+    it "fails fast on 4xx without retrying (except 429)" do
       allow(parsed_uri).to receive(:open).and_raise(http_error(404, "Not Found"))
 
       downloader = described_class.new(
@@ -163,6 +164,96 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
       expect(attempts).to eq(3)
     end
 
+    it "retries on 429 Too Many Requests (treated as transient)" do
+      attempts = 0
+      responses = [
+        proc { raise http_error(429, "Too Many Requests") },
+        proc { |&block| block.call(StringIO.new("after rate limit")) },
+      ]
+      allow(parsed_uri).to receive(:open) do |_opts, &block|
+        responses[(attempts += 1) - 1].call(&block)
+      end
+
+      downloader = described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        max_retries: 3,
+        base_backoff: 0.001,
+        sleep_method: sleep_method,
+      )
+
+      expect(downloader.call).to eq(destination)
+      expect(File.read(destination)).to eq("after rate limit")
+      expect(attempts).to eq(2)
+    end
+
+    it "honors the Retry-After header on 429 instead of exponential backoff" do
+      attempts = 0
+      allow(parsed_uri).to receive(:open) do |_opts, &block|
+        attempts += 1
+        if attempts == 1
+          raise http_error(429, "Too Many Requests",
+                           meta: { "retry-after" => "7" })
+        else
+          block.call(StringIO.new("after retry-after"))
+        end
+      end
+
+      downloader = described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        max_retries: 3,
+        base_backoff: 1.0, # would normally sleep 1.0 — Retry-After overrides
+        sleep_method: sleep_method,
+        github_token: nil,
+      )
+
+      expect(downloader.call).to eq(destination)
+      expect(sleeps).to eq([7])
+    end
+
+    it "caps Retry-After at MAX_RETRY_AFTER_SECONDS" do
+      attempts = 0
+      allow(parsed_uri).to receive(:open) do |_opts, &block|
+        attempts += 1
+        if attempts == 1
+          raise http_error(429, "Too Many Requests",
+                           meta: { "retry-after" => "3600" })
+        else
+          block.call(StringIO.new("after cap"))
+        end
+      end
+
+      downloader = described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        max_retries: 3,
+        base_backoff: 0.001,
+        sleep_method: sleep_method,
+      )
+
+      expect(downloader.call).to eq(destination)
+      expect(sleeps).to eq([described_class::MAX_RETRY_AFTER_SECONDS])
+    end
+
+    it "falls back to exponential backoff when Retry-After is missing" do
+      allow(parsed_uri).to receive(:open).and_raise(
+        http_error(429, "Too Many Requests"),
+      )
+
+      downloader = described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        max_retries: 2,
+        base_backoff: 2.0,
+        sleep_method: sleep_method,
+      )
+
+      expect { downloader.call }.to raise_error(described_class::Error)
+      # First retry sleeps base * 2**0 = 2.0; no Retry-After present.
+      expect(sleeps).to eq([2.0])
+    end
+
     it "sends a User-Agent header identifying the downloader" do
       captured_options = nil
       allow(parsed_uri).to receive(:open) do |options|
@@ -174,9 +265,66 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
         url: "https://example.com/font.ttf",
         destination: destination,
         sleep_method: sleep_method,
+        github_token: nil,
       ).call
 
       expect(captured_options["User-Agent"]).to start_with("fontisan-fixtures/")
+    end
+
+    it "sends Bearer Authorization when github_token is provided" do
+      captured_options = nil
+      allow(parsed_uri).to receive(:open) do |options|
+        captured_options = options
+        StringIO.new("ok")
+      end
+
+      described_class.new(
+        url: "https://github.com/owner/repo/raw/main/font.ttf",
+        destination: destination,
+        sleep_method: sleep_method,
+        github_token: "ghs_test_token_123",
+      ).call
+
+      expect(captured_options["Authorization"]).to eq("Bearer ghs_test_token_123")
+    end
+
+    it "omits Authorization when github_token is nil" do
+      captured_options = nil
+      allow(parsed_uri).to receive(:open) do |options|
+        captured_options = options
+        StringIO.new("ok")
+      end
+
+      described_class.new(
+        url: "https://example.com/font.ttf",
+        destination: destination,
+        sleep_method: sleep_method,
+        github_token: nil,
+      ).call
+
+      expect(captured_options).not_to have_key("Authorization")
+    end
+
+    it "defaults github_token from ENV['GITHUB_TOKEN']" do
+      captured_options = nil
+      allow(parsed_uri).to receive(:open) do |options|
+        captured_options = options
+        StringIO.new("ok")
+      end
+
+      previous = ENV["GITHUB_TOKEN"]
+      ENV["GITHUB_TOKEN"] = "env_token_abc"
+      begin
+        described_class.new(
+          url: "https://github.com/owner/repo/raw/main/font.ttf",
+          destination: destination,
+          sleep_method: sleep_method,
+        ).call
+      ensure
+        ENV["GITHUB_TOKEN"] = previous
+      end
+
+      expect(captured_options["Authorization"]).to eq("Bearer env_token_abc")
     end
   end
 

--- a/spec/fontisan/tasks/fixture_downloader_spec.rb
+++ b/spec/fontisan/tasks/fixture_downloader_spec.rb
@@ -271,8 +271,13 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
       expect(captured_options["User-Agent"]).to start_with("fontisan-fixtures/")
     end
 
-    it "sends Bearer Authorization when github_token is provided" do
+    it "sends Bearer Authorization when github_token is set and URL is GitHub" do
       captured_options = nil
+      # Mutate the shared parsed_uri so its host is github.com — the
+      # before-block URI.parse stub makes a fresh URI.parse() return
+      # this same instance, so we can't construct a separate github
+      # URI inline (it would come back as the example.com one).
+      parsed_uri.host = "github.com"
       allow(parsed_uri).to receive(:open) do |options|
         captured_options = options
         StringIO.new("ok")
@@ -286,6 +291,28 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
       ).call
 
       expect(captured_options["Authorization"]).to eq("Bearer ghs_test_token_123")
+    ensure
+      parsed_uri.host = "example.com"
+    end
+
+    it "withholds Authorization from non-GitHub hosts even when token is set" do
+      # Credential-leak guard: an attacker who controls a third-party
+      # host must not be able to harvest the GITHUB_TOKEN. The downloader
+      # must only send it to known GitHub-owned hosts.
+      captured_options = nil
+      allow(parsed_uri).to receive(:open) do |options|
+        captured_options = options
+        StringIO.new("ok")
+      end
+
+      described_class.new(
+        url: "https://evil.example.com/steal",
+        destination: destination,
+        sleep_method: sleep_method,
+        github_token: "ghs_test_token_123",
+      ).call
+
+      expect(captured_options).not_to have_key("Authorization")
     end
 
     it "omits Authorization when github_token is nil" do
@@ -307,6 +334,7 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
 
     it "defaults github_token from ENV['GITHUB_TOKEN']" do
       captured_options = nil
+      parsed_uri.host = "github.com"
       allow(parsed_uri).to receive(:open) do |options|
         captured_options = options
         StringIO.new("ok")
@@ -322,6 +350,7 @@ RSpec.describe Fontisan::Tasks::FixtureDownloader do
         ).call
       ensure
         ENV["GITHUB_TOKEN"] = previous
+        parsed_uri.host = "example.com"
       end
 
       expect(captured_options["Authorization"]).to eq("Bearer env_token_abc")


### PR DESCRIPTION
## Summary

Two commits hardening the fixture downloader against the GitHub rate-limiting that sank PR #108's CI matrix (4 rake jobs aborted with `OpenURI::HTTPError: 429 Too Many Requests` while downloading DinaRemasterII).

### Commit 1 — retry 429, honor Retry-After, use GITHUB_TOKEN

- **429 is now retriable.** The previous `RETRIABLE_HTTP_STATUSES = (500..599)` check excluded all 4xx; 429 is by definition transient (the server is telling the client to slow down, not to go away permanently). The downloader now treats it the same as 5xx.
- **Retry-After header honored.** When GitHub returns 429 with `Retry-After: N`, the downloader sleeps N seconds (capped at `MAX_RETRY_AFTER_SECONDS = 60` so a misbehaving server can't stall CI indefinitely) instead of falling back to exponential backoff.
- **GITHUB_TOKEN auth.** When `ENV["GITHUB_TOKEN"]` is set (GitHub Actions auto-injects it for every workflow run), the downloader sends it as a Bearer token. Authenticated requests get 15,000 req/hour vs. the anonymous 60 req/hour per-IP ceiling that the matrix was hitting.

### Commit 2 — scope GITHUB_TOKEN to GitHub hosts only

Reviewer feedback on commit 1: sending `GITHUB_TOKEN` to arbitrary URLs would leak CI credentials to any host that ends up in the fixture config. The downloader now only attaches the Authorization header to known GitHub-owned hosts (`github.com`, `codeload.github.com`, `objects.githubusercontent.com`, `api.github.com`). The host check is the credential-leak guard: an attacker who controls a different host can't trick the downloader into forwarding the CI token.

Bonus refactor: `fetch_to_destination` now parses once and threads the URI through to `open_uri_options`, avoiding a wasteful second `URI.parse(url)` call (and the test-stub fragility that comes with it).

## Test plan

- [x] `bundle exec rspec spec/fontisan/tasks/fixture_downloader_spec.rb` — 17 examples (was 9), covering: 429 retry, Retry-After with/without cap, exponential backoff fallback, Bearer auth presence/absence, GITHUB_TOKEN env default, and the new credential-leak guard for non-GitHub hosts.
- [x] `bundle exec rspec` (full suite) — 5752 examples, 0 failures, 2 pending (unchanged).
- [x] `bundle exec rubocop` — clean.

## Notes

The flaky macOS failure on PR #108's CI (`OpenURI::HTTPError: 429 Too Many Requests` on DinaRemasterII download) was the canary that surfaced this. With auth + 429 retry in place, the next CI matrix run on this branch should not hit GitHub's anonymous rate limit.
