### PR TITLE
docs: document recent features (CBDT subset retention, Layer contract, Stitcher outline-first)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -322,6 +322,7 @@ export default defineConfig({
             { text: "ConversionOptions", link: "/api/conversion-options" },
             { text: "SfntFont", link: "/api/sfnt-font" },
             { text: "Type1Font", link: "/api/type1-font" },
+            { text: "Ufo::Layer", link: "/api/layer" },
           ],
         },
         {

--- a/docs/STITCHER_GUIDE.adoc
+++ b/docs/STITCHER_GUIDE.adoc
@@ -364,12 +364,56 @@ stitcher.write_to("out.ttf", format: :ttf, subfont: :main)
 # → out.ttf has glyf + CBDT + CBLC, emoji renders correctly
 ----
 
-Constraints:
+=== Outline-first cmap priority
+
+When a codepoint is covered by BOTH an outline donor and the CBDT
+donor, the cmap maps it to the outline glyph — never to the CBDT
+placeholder. The Cmap compiler follows first-wins semantics, and
+`GlyphCopier` runs before `CbdtPropagator` so the outline GID is
+registered first. This was the fix for the Emoticons cmap-loss bug
+where shared codepoints silently dropped out of the cmap.
+
+=== Placeholder name deconfliction
+
+CBDT placeholders are named after the source's glyph IDs
+(`"gid1"`, `"gid2"`, …), which is the SAME naming scheme
+`Source#extract_truetype_glyph` uses for outline glyphs from TTF
+donors. Without protection, a placeholder at `"gid110"` would
+silently overwrite an outline glyph at `"gid110"` from a different
+donor via `Layer#add` — the original cmap-loss vector for the
+Essenfont CJK Ext G regression.
+
+The Stitcher resolves this with two pieces:
+
+* `Ufo::Layer#add` RAISES `Ufo::GlyphExistsError` on name conflict.
+  Silent overwrites are no longer possible. Callers that want to
+  replace an existing glyph use the explicit `Ufo::Layer#put`.
+* `Stitcher::UniqueGlyphName.in(target, base)` allocates a
+  non-colliding name (`"gid110"`, then `"gid110.1"`, `"gid110.2"`,
+  …). `GlyphCopier` and `CbdtPropagator` both call it before every
+  `Layer#add`, so each glyph lands at its own GID slot without
+  touching the others.
+
+=== Limitations
 
 * Only ONE CBDT source per Stitcher. Multiple CBDT sources raise
   `Fontisan::MultipleCbdtSourcesError`.
-* The CBDT source is processed first (GIDs 0..N-1) so the CBLC's GID
-  references remain valid in the output.
+* **GID stability for overlapping codepoint ranges.** The raw-bytes
+  CBDT/CBLC propagation (`CbdtPropagator#propagate_tables_into`)
+  copies the source's CBLC verbatim. CBLC indexes glyphs by SOURCE
+  GID. After placeholder renaming (`"gid110"` → `"gid110.1"`), the
+  compiled GID no longer matches the source GID, so CBLC's source-
+  GID-indexed bitmaps can dangle. This is masked in the typical
+  Essenfont case (CBDT donor NotoColorEmoji and outline donors
+  cover disjoint codepoint ranges) but would produce wrong bitmaps
+  for any stitch where CBDT and outline sources share codepoint
+  ranges. A proper fix requires a CBLC rebuild pass that walks the
+  compiled cmap to remap source GIDs to compiled GIDs — tracked as
+  follow-up.
+* **Collection-mode single-face coverage.** Each face is compiled
+  independently; `CbdtPropagator` currently requires at least one
+  outline codepoint per face. Collection-mode coverage of the
+  outline-first cmap-priority invariant is tracked as follow-up.
 
 == CLI
 

--- a/docs/api/layer.md
+++ b/docs/api/layer.md
@@ -1,0 +1,89 @@
+---
+title: Ufo::Layer
+---
+
+# `Ufo::Layer`
+
+A single layer in a UFO source. A `Layer` holds a set of glyphs keyed by name. The default layer is `public.default` per UFO 3.
+
+```ruby
+layer = Fontisan::Ufo::Layer.new                       # => "public.default"
+layer.add(Fontisan::Ufo::Glyph.new(name: "A"))
+layer["A"]                                             # => the glyph
+layer.size                                             # => 1
+```
+
+## Naming contract
+
+Glyph names are the layer's primary key. Two distinct glyphs with the same name cannot coexist — adding the second would silently destroy the first, a class of bug that has historically cost real data (e.g. the CJK Ext G cmap loss when CBDT placeholders collided with outline glyphs sharing `"gid{N}"` names).
+
+To make that contract unbreakable, the API exposes two methods with named semantics:
+
+| Method | Behavior on conflict |
+|--------|----------------------|
+| `Layer#add(glyph)` | **Raises** `Ufo::GlyphExistsError` (the safe default) |
+| `Layer#put(glyph)` | Overwrites the existing glyph (explicit replace) |
+
+Callers that need auto-renaming — insert without giving up on a collision — call `Stitcher::UniqueGlyphName.in(target, base)` first to allocate a free name, then `Layer#add` the glyph under that name.
+
+## API
+
+### `Layer.new(name = "public.default")`
+
+Initialize an empty layer.
+
+### `#add(glyph) -> Glyph`
+
+Insert `glyph`. Raises `Ufo::GlyphExistsError` if a glyph with the same name is already present.
+
+```ruby
+layer = Fontisan::Ufo::Layer.new
+layer.add(Fontisan::Ufo::Glyph.new(name: "A"))
+
+layer.add(Fontisan::Ufo::Glyph.new(name: "A"))
+# => raises Fontisan::Ufo::GlyphExistsError: a glyph named "A" already exists
+```
+
+The original glyph is preserved when the second `add` raises — the layer is never partially mutated.
+
+### `#put(glyph) -> Glyph`
+
+Insert `glyph`, replacing any existing glyph with the same name. Use this when the caller has positively decided the previous glyph (if any) should be discarded.
+
+```ruby
+layer.put(Fontisan::Ufo::Glyph.new(name: "A"))  # overwrites the prior "A"
+```
+
+### `#[](glyph_name) -> Glyph, nil`
+
+Look up a glyph by name.
+
+### `#each { |glyph| ... }`
+
+Iterate over glyphs (no ordering guarantee).
+
+### `#size -> Integer`
+
+Number of glyphs in the layer.
+
+## `Ufo::GlyphExistsError`
+
+Raised by `Layer#add` on a name conflict. Carries the colliding name so callers can branch programmatically:
+
+```ruby
+begin
+  layer.add(glyph)
+rescue Fontisan::Ufo::GlyphExistsError => e
+  puts "name #{e.name.inspect} already taken"
+  # Decide: layer.put(glyph) to overwrite, or
+  # unique = Fontisan::Stitcher::UniqueGlyphName.in(target, e.name)
+  # layer.add(glyph.dup_as(name: unique))
+end
+```
+
+The error class is a sibling of `Layer` (not nested inside it) so the namespace stays flat — both `Ufo::Layer` and `Ufo::GlyphExistsError` live directly under `Fontisan::Ufo`.
+
+## See also
+
+- `docs/STITCHER_GUIDE.adoc` — `UniqueGlyphName`, `GlyphCopier`, and `CbdtPropagator` all build on the Layer naming contract.
+- `docs/UFO_COMPILATION.adoc` — how layers feed the TTF/OTF/CFF2 compilers.

--- a/docs/cli/subset.md
+++ b/docs/cli/subset.md
@@ -18,8 +18,23 @@ fontisan subset <font> [options]
 |--------|-------------|
 | `--chars TEXT` | Characters to include |
 | `--file FILE` | File containing characters |
+| `--unicodes RANGE` | Unicode ranges (`"U+0000-007F"`) |
+| `--glyphs LIST` | Glyph names/IDs |
 | `--output FILE` | Output file path |
-| `--format FORMAT` | Output format |
+| `--format FORMAT` | Output format (`ttf`, `woff`, `woff2`, …) |
+| `--profile PROFILE` | Subsetting profile (default: `pdf`) |
+| `--retain-gids` | Preserve original glyph IDs |
+
+## Profiles
+
+| Profile | Tables included | Use case |
+|---------|-----------------|----------|
+| `pdf` | core + glyf/loca | PDF embedding (smallest) |
+| `web` | core + glyf/loca + GSUB/GPOS + **CBDT/CBLC** | Web fonts that retain color-emoji bitmaps |
+| `minimal` | core only | Smallest valid font |
+| `full` | every standard table | Lossless re-export |
+
+The `web` profile is the one to reach for when the subset must still render color emoji in a browser: it preserves the CBDT (bitmap data) and CBLC (bitmap location) tables, and the paired subsetter rewrites them to keep only the bitmaps for the retained glyphs.
 
 ## Examples
 
@@ -27,13 +42,17 @@ fontisan subset <font> [options]
 # Subset to specific characters
 fontisan subset font.ttf --chars "ABCDEF" --output subset.ttf
 
-# Subset from file
-fontisan subset font.ttf --file chars.txt --output subset.ttf
+# Web subset that retains color-emoji bitmaps
+fontisan subset NotoColorEmoji.ttf \
+  --chars "😀😁😂🤣😊" \
+  --profile web \
+  --format woff2 \
+  --output emoji.woff2
 
-# Subset and convert format
-fontisan subset font.ttf --chars "Hello" --format woff2
+# PDF embedding profile (drops CBDT/CBLC, smaller output)
+fontisan subset font.ttf --chars "ABC" --profile pdf --output pdf-subset.ttf
 ```
 
 ## Detailed Documentation
 
-For comprehensive documentation including unicode ranges and advanced subsetting, see the [subset command guide](/guide/cli/subset).
+For comprehensive documentation including unicode ranges, profile selection, and CBDT/CBLC behavior, see the [subset command guide](/guide/cli/subset).

--- a/docs/guide/cli/subset.md
+++ b/docs/guide/cli/subset.md
@@ -28,6 +28,7 @@ fontisan subset FONT [options]
 | `--glyphs LIST` | Glyph names/IDs |
 | `--output PATH` | Output file |
 | `--output-format FORMAT` | Output format |
+| `--profile PROFILE` | Subsetting profile (`pdf`, `web`, `minimal`, `full`; default `pdf`) |
 | `--retain-gids` | Retain glyph IDs |
 
 ## Examples
@@ -85,6 +86,36 @@ fontisan subset font.ttf --chars "ABC" --output-format woff2 --output subset.wof
 ```
 
 ## Subsetting Strategies
+
+### Profile selection
+
+The `--profile` option controls which font tables the subset retains. The right choice depends on what the subset is for:
+
+| Profile | When to use | Notable tables dropped |
+|---------|-------------|------------------------|
+| `pdf` (default) | PDF embedding, smallest valid output | GSUB, GPOS, CBDT, CBLC |
+| `web` | Browser/web font, **retains color-emoji bitmaps** | nothing that browsers need |
+| `minimal` | Absolute smallest core that still renders | glyf/loca, CBDT/CBLC, GSUB/GPOS |
+| `full` | Lossless re-export | (none) |
+
+```bash
+# Web subset that keeps color-emoji bitmaps so 😀 renders in color
+fontisan subset NotoColorEmoji.ttf \
+  --chars "😀😁😂🤣😊" \
+  --profile web \
+  --output-format woff2 \
+  --output emoji.woff2
+
+# PDF embedding — drops color bitmaps for size
+fontisan subset NotoColorEmoji.ttf \
+  --chars "😀" \
+  --profile pdf \
+  --output emoji-pdf.ttf
+```
+
+#### Web profile and CBDT/CBLC
+
+The `web` profile is the only built-in profile that retains CBDT (Color Bitmap Data) and CBLC (Color Bitmap Location) tables. The subsetter walks CBLC to find each retained glyph's bitmap block, rewrites CBDT to keep only those blocks, and rebuilds CBLC's IndexSubTableArray to point at the new offsets. Glyph IDs are remapped through the subset's `GlyphMapping`, so the output CBLC references subset GIDs, not source GIDs.
 
 ### Web Font Optimization
 

--- a/docs/guide/color-fonts/bitmaps.md
+++ b/docs/guide/color-fonts/bitmaps.md
@@ -144,6 +144,23 @@ fontisan convert bitmap-font.ttf --to ttf --output bitmap-font.ttf
 fontisan convert bitmap-font.ttf --to ttf --no-bitmaps --output outline-only.ttf
 ```
 
+### Subsetting color-emoji fonts
+
+The `web` subsetting profile retains CBDT and CBLC tables and rewrites them to keep only the bitmaps for retained glyphs. Use it when subsetting a color-emoji source for browser delivery:
+
+```bash
+# Keep only 😀 + 😁 bitmaps; output WOFF2 for web
+fontisan subset NotoColorEmoji.ttf \
+  --chars "😀😁" \
+  --profile web \
+  --output-format woff2 \
+  --output emoji-subset.woff2
+```
+
+Other profiles (`pdf`, `minimal`, `full`) drop CBDT/CBLC — pick them when the subset doesn't need color-emoji rendering (e.g. PDF embedding where the subsetter is just selecting glyphs for outlines).
+
+See the [subset CLI docs](/cli/subset) and `docs/STITCHER_GUIDE.adoc` (CBDT/CBLC passthrough section) for the full story, including the GID-stability caveat when CBDT and outline donors cover overlapping codepoint ranges in stitch mode.
+
 ## Comparison
 
 | Feature | sbix | CBDT/CBLC |


### PR DESCRIPTION
## Summary

Documentation updates for recent user-visible features that landed in PRs #106 and #108 and supporting commits but were not yet documented. This PR contains no code changes.

## What's new in docs

| Doc | Change |
|-----|--------|
| `docs/cli/subset.md` | Add `--profile` option to the table; document that the **`web` profile retains CBDT/CBLC** tables (the headline feature from PR #106) so web subsets of color-emoji fonts render in color |
| `docs/guide/cli/subset.md` | Same `--profile` addition + a "Profile selection" subsection with a comparison table (`pdf` / `web` / `minimal` / `full`) and examples for the color-emoji web subset and the PDF embedding paths |
| `docs/STITCHER_GUIDE.adoc` | Rewrite the CBDT/CBLC passthrough section. The old text claimed the CBDT source was "processed first (GIDs 0..N-1)" — that stopped being true when `CbdtPropagator` started adding placeholders AFTER outline glyphs. New section covers: outline-first cmap priority (commit `a8ce7dc`), the `Layer#add` raise-on-conflict contract + `UniqueGlyphName` deconfliction (PR #108), and the known GID-stability limitation when CBDT and outline donors cover overlapping codepoint ranges |
| `docs/api/layer.md` (new) | Full reference for `Ufo::Layer`: `add` / `put` / `[]` / `each` / `size`, the `Ufo::GlyphExistsError` sibling class, and how to choose between raise-on-conflict, explicit overwrite, and `UniqueGlyphName` auto-rename. Sidebar entry added to `docs/.vitepress/config.ts`. |
| `docs/guide/color-fonts/bitmaps.md` | New "Subsetting color-emoji fonts" subsection pointing at the web profile and cross-referencing the Stitcher CBDT section |

## Incomplete features (not addressed here, tracked separately)

Surveyed while writing this PR. Listing here so reviewers know what's still pending:

- **`fontisan audit` command** — proposed in `docs/history/PROPOSAL.font-audit.md`, no implementation yet.
- **GID-stable CBDT propagation** — `CbdtPropagator#propagate_tables_into` copies raw bytes; CBLC is not rebuilt after compile. Documented as a known limitation in `docs/STITCHER_GUIDE.adoc`. Proper fix requires a CBLC rebuild pass that walks the compiled cmap to remap source GIDs.
- **Collection-mode outline-priority regression** — pending spec at `spec/fontisan/stitcher/outline_priority_spec.rb:160` (now unskipped for single-face, but collection variant still needs `CbdtPropagator` hardening).
- **CPAL v1 header fields** — `lib/fontisan/tables/cpal.rb:106,184`.
- **CFF standard string table** — `lib/fontisan/tables/cff.rb:418`.
- **Type 1 seac expansion** — `lib/fontisan/type1/charstring_converter.rb:161` and `ttf_to_type1_converter.rb:256`.
- **CFF2 blend/vsindex operators** — TODOs 07/18 referenced in `lib/fontisan/ufo/compile/variable_otf.rb`.
- **UFO image set / feature writers** — TODOs 02 and 08.
- **OTF compiler CFF construction** — TODO 10 at `lib/fontisan/ufo/compile/otf_compiler.rb` (currently emits a placeholder CFF table).

## Test plan

- [x] `npx vitepress build` — succeeds, no dead links.
- [x] Manual review of each rendered page.
- [ ] Reviewer spot-check of the Stitcher guide's GID-stability limitation wording (it's the most nuanced new content).
