### PR TITLE
feat: CFF2 subsetter + variable CFF2 blend operators (TODO #06, #15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ REQ-*.md
 /spec/fixtures/fonts/SourceSans3/
 /spec/fixtures/fonts/TwemojiMozilla/
 /spec/fixtures/fonts/TwitterColorEmoji/
+/spec/fixtures/fonts/long_loca/
 /spec/fixtures/fonts/tamsyn/
 /spec/fixtures/fonts/type1/urw/urw-base35-fonts/
 /spec/fixtures/fonts/unifontex/
@@ -50,3 +51,6 @@ REQ-*.md
 CLAUDE.md
 
 .rubocop-remote*
+
+# Transient browser-based font verification scripts
+/scripts/test-*.mjs

--- a/TODO.improvements/README.md
+++ b/TODO.improvements/README.md
@@ -8,7 +8,7 @@ Each file is `NN-short-name.md` where `NN` is the priority order.
 ### P0 — Correctness gaps (open bugs / silent failures)
 - [x] ~~[01 — CBDT/CBLC GID-stable propagation](01-cbdt-cblc-gid-stable-propagation.md)~~ ✓ Done (PR #115)
 - [x] ~~[02 — Collection-mode outline-priority regression](02-collection-outline-priority.md)~~ ✓ Already fixed
-- [15 — CFF/CFF2 subsetter strategy](15-cff-cff2-subsetter-strategy.md) — Head crash fixed, profiles updated; CFF→UFO extraction done (TODO #10b); blocked on TODO #05 for full round-trip (PR #108 unskipped the test; now passing with TODO 01)
+- [x] ~~[15 — CFF/CFF2 subsetter strategy](15-cff-cff2-subsetter-strategy.md)~~ ✓ Done — CFF via UFO round-trip, CFF2 via standalone INDEX filter with VStore preservation
 
 ### P1 — High-value features
 - [03 — `fontisan audit` command (identity+style+features lens)](03-fontisan-audit-command.md)
@@ -18,7 +18,7 @@ Each file is `NN-short-name.md` where `NN` is the priority order.
 ### P2 — Specialist feature parity
 - [x] ~~[07 — CPAL v1 header fields](07-cpal-v1-header-fields.md)~~ ✓ Done (v0.4.25)
 - [x] ~~[08 — CFF standard string table](08-cff-standard-string-table.md)~~ ✓ Done (full 391 SIDs per Adobe TN 5176)
-- [06 — CFF2 blend/vsindex operators](06-cff2-blend-vsindex-operators.md)
+- [x] ~~[06 — CFF2 blend/vsindex operators](06-cff2-blend-vsindex-operators.md)~~ ✓ Done — `Cff2.build_variable` emits blend operators in charstrings; `VariableOtf` passes masters through; VStore embedded with regions
 - [09 — Type 1 seac expansion](09-type1-seac-expansion.md)
 - [10 — UFO image set + feature writers](10-ufo-image-set-feature-writers.md)
 - [x] ~~[11 — kern groups.plist support](11-kern-groups-plist.md)~~ ✓ Done (Groups model in PR #116 + GPOS group resolution in this PR)

--- a/lib/fontisan/subset/table_strategy.rb
+++ b/lib/fontisan/subset/table_strategy.rb
@@ -17,6 +17,7 @@ module Fontisan
       autoload :Cblc, "fontisan/subset/table_strategy/cblc"
       autoload :Cbdt, "fontisan/subset/table_strategy/cbdt"
       autoload :Cff, "fontisan/subset/table_strategy/cff"
+      autoload :Cff2, "fontisan/subset/table_strategy/cff2"
       autoload :Cmap, "fontisan/subset/table_strategy/cmap"
       autoload :ColorBitmapPlacement,
                "fontisan/subset/table_strategy/color_bitmap_placement"
@@ -57,6 +58,7 @@ module Fontisan
         "head" => :Head,
         "OS/2" => :Os2,
         "CFF " => :Cff,
+        "CFF2" => :Cff2,
         "CBDT" => :Cbdt,
         "CBLC" => :Cblc,
       }.freeze

--- a/lib/fontisan/subset/table_strategy/cff2.rb
+++ b/lib/fontisan/subset/table_strategy/cff2.rb
@@ -1,0 +1,392 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Fontisan
+  module Subset
+    module TableStrategy
+      # CFF2 (Compact Font Format 2) subsetter strategy.
+      #
+      # Subsets CFF2 tables by filtering the CharStrings INDEX and FDSelect
+      # to the subset glyphs, then rebuilding the table with patched offsets.
+      # The Variable Store (ItemVariationStore) is preserved unchanged —
+      # its `vsindex` references in charstrings remain valid because
+      # charstrings are carried as opaque bytes.
+      #
+      # Unlike the CFF1 subsetter (which routes through UFO), CFF2 uses a
+      # standalone binary filter because CFF2 charstrings carry blend/vsindex
+      # operators for variation that the UFO round-trip would strip.
+      #
+      # Layout of the rebuilt table:
+      #
+      #   Header (5 bytes)
+      #   Top DICT               (offsets patched to new positions)
+      #   Global Subr INDEX      (preserved as-is)
+      #   [Variable Store]       (preserved as-is, if present)
+      #   [FDArray INDEX]        (Private DICT offsets patched)
+      #   [Private DICTs]        (preserved as-is, relocated after FDArray)
+      #   [FDSelect]             (filtered to subset glyphs, if present)
+      #   CharStrings INDEX      (filtered to subset glyphs)
+      #
+      # Private DICT offsets in Font DICTs always use the 5-byte integer
+      # encoding (operator 29 + int32). This makes the FDArray byte size
+      # independent of the offset values, breaking the layout chicken-and-egg.
+      #
+      # See TODO #15 for the full design rationale.
+      class Cff2
+        # CFF2 Top DICT operator codes (per Adobe TN 5177 §8.1).
+        OP_CHARSTRINGS = 17
+        OP_VSTORE = 24
+        OP_FDARRAY = [12, 36].freeze
+        OP_FDSELECT = [12, 37].freeze
+        OP_PRIVATE = 18
+
+        MAX_TOPDICT_ITERATIONS = 16
+
+        # @param context [SubsetContext]
+        # @param tag [String] "CFF2"
+        # @param table [Object] parsed CFF2 table (unused — we read raw bytes)
+        # @return [String] subset CFF2 table bytes
+        def self.call(context:, tag:, table:)
+          raw = raw_bytes_from_font(context.font) || raw_bytes_from_table(table)
+          return raw unless raw && !raw.empty?
+
+          new(raw, context.mapping).subset
+        end
+
+        def self.raw_bytes_from_font(font)
+          t = font.table("CFF2") if font.respond_to?(:table)
+          t&.raw_data
+        end
+        private_class_method :raw_bytes_from_font
+
+        def self.raw_bytes_from_table(table)
+          table&.raw_data if table.respond_to?(:raw_data)
+        end
+        private_class_method :raw_bytes_from_table
+
+        # ------------------------------------------------------------------
+
+        def initialize(raw_data, mapping)
+          @raw = raw_data
+          @mapping = mapping
+          @reader = Tables::Cff2::TableReader.new(raw_data)
+          @reader.read_top_dict
+        end
+
+        # Build the subset CFF2 table.
+        #
+        # @return [String]
+        def subset
+          sections = gather_sections
+          retained_gids = @mapping.old_ids.sort
+
+          filtered = build_filtered_sections(sections, retained_gids)
+          layout = converge_layout(sections, filtered)
+          write_table(layout, filtered)
+        end
+
+        # ------------------------------------------------------------------
+        # Source section gathering
+        # ------------------------------------------------------------------
+
+        def gather_sections
+          td = @reader.top_dict
+          hdr = @reader.header
+          gsubr_off = hdr[:header_size] + hdr[:top_dict_length]
+
+          {
+            header_size: hdr[:header_size],
+            charstrings: read_index(td[OP_CHARSTRINGS]),
+            gsubr: read_index(gsubr_off),
+            fdarray: td[OP_FDARRAY] ? read_index(td[OP_FDARRAY]) : nil,
+            fdselect_offset: td[OP_FDSELECT],
+            vstore_offset: td[OP_VSTORE],
+          }
+        end
+
+        def read_index(offset)
+          Tables::Cff2::Index.read(@raw, offset)
+        end
+
+        # ------------------------------------------------------------------
+        # Section filtering
+        # ------------------------------------------------------------------
+
+        # Build all filtered/rebuilt section bytes.
+        def build_filtered_sections(sections, retained_gids)
+          {
+            charstrings_bytes: filter_charstrings(sections[:charstrings], retained_gids),
+            fdselect_bytes: filter_fdselect(sections, retained_gids),
+            fdarray_entries: sections[:fdarray] ? parse_fdarray_entries(sections[:fdarray]) : [],
+          }
+        end
+
+        # Build a new CharStrings INDEX containing only the retained glyphs.
+        def filter_charstrings(source_cs, retained_gids)
+          items = retained_gids.map do |gid|
+            item = source_cs[gid]
+            item.nil? || item.empty? ? "\x0e".b : item
+          end
+          Tables::Cff2::IndexBuilder.build(items)
+        end
+
+        # Rebuild FDSelect to cover only retained glyphs in their new order.
+        def filter_fdselect(sections, retained_gids)
+          return nil unless sections[:fdselect_offset]
+
+          assignments = Tables::Cff2::FdSelect.read(
+            @raw, sections[:fdselect_offset], sections[:charstrings].count
+          )
+          new_assigns = retained_gids.map { |gid| assignments[gid] || 0 }
+          Tables::Cff2::FdSelect.build(new_assigns)
+        end
+
+        # Parse each Font DICT in the FDArray, extract Private DICT bytes,
+        # and prepare entries for relocation.
+        def parse_fdarray_entries(source_fdarray)
+          source_fdarray.to_a.map do |fd_bytes|
+            parsed = @reader.parse_dict(fd_bytes)
+            priv = parsed[OP_PRIVATE]
+            entry = { parsed: parsed, priv_bytes: nil, priv_size: nil }
+            next entry unless priv.is_a?(Array) && priv.size == 2
+
+            size, offset = priv
+            entry[:priv_bytes] = @raw.byteslice(offset, size)
+            entry[:priv_size] = size
+            entry
+          end
+        end
+
+        # Build the FDArray INDEX bytes with the given Private DICT offsets.
+        # Private offsets always use 5-byte int32 encoding for deterministic
+        # sizing across layout iterations.
+        def build_fdarray_bytes(entries, priv_offsets)
+          rebuilt = entries.each_with_index.map do |entry, idx|
+            parsed = entry[:parsed].dup
+            if entry[:priv_size]
+              parsed[OP_PRIVATE] = [entry[:priv_size], priv_offsets[idx] || 0]
+            end
+            encode_font_dict(parsed)
+          end
+          Tables::Cff2::IndexBuilder.build(rebuilt)
+        end
+
+        # ------------------------------------------------------------------
+        # Layout convergence
+        # ------------------------------------------------------------------
+
+        # Iterate Top DICT encoding to stability, then produce the final
+        # layout with FDArray patched with concrete Private DICT offsets.
+        def converge_layout(sections, filtered)
+          top_dict_size = @reader.header[:top_dict_length]
+          placeholder_offsets = Array.new(filtered[:fdarray_entries].size, 0)
+          fdarray_placeholder = if filtered[:fdarray_entries].any?
+                                  build_fdarray_bytes(filtered[:fdarray_entries],
+                                                      placeholder_offsets)
+                                end
+          priv_bytes = filtered[:fdarray_entries].map { |e| e[:priv_bytes] }.compact
+
+          prev_size = nil
+          layout = nil
+          MAX_TOPDICT_ITERATIONS.times do
+            layout = layout_offsets(sections, top_dict_size, filtered,
+                                    fdarray_placeholder, priv_bytes)
+            new_td = build_top_dict_bytes(layout)
+            top_dict_size = new_td.bytesize
+            break if top_dict_size == prev_size
+
+            prev_size = top_dict_size
+          end
+
+          finalize_layout(layout, sections, top_dict_size, filtered,
+                          fdarray_placeholder, priv_bytes)
+        end
+
+        # Assign byte offsets to every section.
+        def layout_offsets(sections, top_dict_size, filtered, fdarray_bytes, priv_bytes)
+          pos = sections[:header_size] + top_dict_size
+          layout = { top_dict_size: top_dict_size }
+
+          layout[:global_subrs_offset] = pos
+          layout[:global_subrs_bytes] = index_bytes(sections[:gsubr])
+          pos += layout[:global_subrs_bytes].bytesize
+
+          if sections[:vstore_offset]
+            layout[:vstore_offset] = pos
+            layout[:vstore_bytes] = vstore_bytes(sections[:vstore_offset])
+            pos += layout[:vstore_bytes].bytesize
+          end
+
+          if fdarray_bytes
+            layout[:fdarray_offset] = pos
+            layout[:fdarray_bytes] = fdarray_bytes
+            pos += fdarray_bytes.bytesize
+
+            priv_offsets = priv_bytes.map do |pb|
+              off = pos
+              pos += pb.bytesize
+              off
+            end
+            layout[:private_dict_offsets] = priv_offsets
+            layout[:private_dicts] = priv_bytes
+          end
+
+          if filtered[:fdselect_bytes]
+            layout[:fdselect_offset] = pos
+            layout[:fdselect_bytes] = filtered[:fdselect_bytes]
+            pos += layout[:fdselect_bytes].bytesize
+          end
+
+          layout[:charstrings_offset] = pos
+          layout[:charstrings_bytes] = filtered[:charstrings_bytes]
+          layout
+        end
+
+        # Build the Top DICT bytes with updated section offsets.
+        def build_top_dict_bytes(layout)
+          td = @reader.top_dict.dup
+          td[OP_CHARSTRINGS] = layout[:charstrings_offset]
+          td[OP_VSTORE] = layout[:vstore_offset] if layout[:vstore_offset]
+          td[OP_FDARRAY] = layout[:fdarray_offset] if layout[:fdarray_offset]
+          td[OP_FDSELECT] = layout[:fdselect_offset] if layout[:fdselect_offset]
+          encode_dict(td)
+        end
+
+        # Produce the final layout: stabilized Top DICT bytes, header,
+        # and FDArray rebuilt with concrete Private DICT offsets.
+        def finalize_layout(layout, sections, top_dict_size, filtered,
+                            fdarray_placeholder, priv_bytes)
+          final = layout.dup
+          final[:top_dict_bytes] = build_top_dict_bytes(layout)
+          final[:header_bytes] = Tables::Cff2::Header.build(
+            top_dict_size: top_dict_size,
+          )
+          if filtered[:fdarray_entries].any?
+            final[:fdarray_bytes] = build_fdarray_bytes(
+              filtered[:fdarray_entries], final[:private_dict_offsets] || []
+            )
+          end
+          final
+        end
+
+        # ------------------------------------------------------------------
+        # Table serialization
+        # ------------------------------------------------------------------
+
+        def write_table(layout, filtered)
+          io = StringIO.new(+"")
+          io << layout[:header_bytes]
+          io << layout[:top_dict_bytes]
+          io << layout[:global_subrs_bytes]
+          io << layout[:vstore_bytes] if layout[:vstore_bytes]
+          io << layout[:fdarray_bytes] if layout[:fdarray_bytes]
+          (layout[:private_dicts] || []).each { |pd| io << pd }
+          io << layout[:fdselect_bytes] if layout[:fdselect_bytes]
+          io << layout[:charstrings_bytes]
+          io.string
+        end
+
+        # ------------------------------------------------------------------
+        # Binary helpers
+        # ------------------------------------------------------------------
+
+        # Extract the raw bytes of a parsed INDEX from the source table.
+        def index_bytes(index)
+          @raw.byteslice(index.start_offset, index.total_size)
+        end
+
+        # Extract VStore bytes by computing its byte extent.
+        def vstore_bytes(vstore_offset)
+          size = vstore_extent(vstore_offset)
+          @raw.byteslice(vstore_offset, size)
+        end
+
+        # Compute the byte size of an ItemVariationStore.
+        def vstore_extent(vs_off)
+          io = StringIO.new(@raw)
+          io.seek(vs_off)
+          _format = read_u16(io)
+          region_list_off = read_u32(io)
+          data_count = read_u16(io)
+          data_offsets = Array.new(data_count) { read_u32(io) }
+
+          extents = []
+          extents << region_list_end(vs_off + region_list_off) if region_list_off.positive?
+          data_offsets.each do |rel_off|
+            extents << item_variation_data_end(vs_off + rel_off) if rel_off.positive?
+          end
+          end_off = extents.max || (8 + (data_count * 4))
+          end_off - vs_off
+        end
+
+        def region_list_end(abs_off)
+          io = StringIO.new(@raw)
+          io.seek(abs_off)
+          axis_count = read_u16(io)
+          region_count = read_u16(io)
+          abs_off + 4 + (region_count * axis_count * 6)
+        end
+
+        def item_variation_data_end(abs_off)
+          io = StringIO.new(@raw)
+          io.seek(abs_off)
+          item_count = read_u16(io)
+          short_delta_count = read_u16(io)
+          region_index_count = read_u16(io)
+          long_count = region_index_count - short_delta_count
+          delta_set_size = (short_delta_count * 2) + (long_count * 1)
+          abs_off + 6 + (region_index_count * 2) + (item_count * delta_set_size)
+        end
+
+        def read_u16(io)
+          io.read(2).unpack1("n")
+        end
+
+        def read_u32(io)
+          io.read(4).unpack1("N")
+        end
+
+        # ------------------------------------------------------------------
+        # DICT encoding
+        # ------------------------------------------------------------------
+
+        # Encode a DICT hash to binary using the CFF2 DictEncoder.
+        def encode_dict(dict)
+          io = +""
+          dict.each do |operator, operands|
+            vals = Array(operands)
+            vals.each do |v|
+              io << Tables::Cff2::DictEncoder.encode_integer(v.to_i)
+            end
+            io << Tables::Cff2::DictEncoder.encode_operator(operator)
+          end
+          io
+        end
+
+        # Encode a Font DICT. The Private operator (18) always uses 5-byte
+        # integer encoding for BOTH operands so the Font DICT byte size
+        # is deterministic across layout iterations.
+        def encode_font_dict(parsed)
+          io = +""
+          parsed.each do |operator, operands|
+            vals = Array(operands)
+            if operator == OP_PRIVATE && vals.size == 2
+              io << encode_int32(vals[0].to_i)
+              io << encode_int32(vals[1].to_i)
+            else
+              vals.each { |v| io << Tables::Cff2::DictEncoder.encode_integer(v.to_i) }
+            end
+            io << Tables::Cff2::DictEncoder.encode_operator(operator)
+          end
+          io
+        end
+
+        # 5-byte integer encoding: byte 29 (marker) + 4-byte big-endian.
+        def encode_int32(value)
+          [29, value].pack("CN")
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/subset/table_strategy/cff2.rb
+++ b/lib/fontisan/subset/table_strategy/cff2.rb
@@ -335,7 +335,7 @@ module Fontisan
           short_delta_count = read_u16(io)
           region_index_count = read_u16(io)
           long_count = region_index_count - short_delta_count
-          delta_set_size = (short_delta_count * 2) + (long_count * 1)
+          delta_set_size = (short_delta_count * 2) + long_count
           abs_off + 6 + (region_index_count * 2) + (item_count * delta_set_size)
         end
 

--- a/lib/fontisan/tables/cff/cff2_charstring_builder.rb
+++ b/lib/fontisan/tables/cff/cff2_charstring_builder.rb
@@ -73,8 +73,11 @@ width: nil)
           @num_regions = num_regions
           @has_blend = false
 
-          outline.commands.each_with_index do |cmd, i|
-            master_cmds = master_outlines.map { |mo| mo.commands[i] }
+          commands = outline.to_cff_commands
+          master_commands = master_outlines.map(&:to_cff_commands)
+
+          commands.each_with_index do |cmd, i|
+            master_cmds = master_commands.map { |mc| mc[i] }
             encode_variable_command(cmd, master_cmds)
           end
 

--- a/lib/fontisan/tables/cff2.rb
+++ b/lib/fontisan/tables/cff2.rb
@@ -26,6 +26,7 @@ module Fontisan
       autoload :CharstringParser, "fontisan/tables/cff2/charstring_parser"
       autoload :FdSelect, "fontisan/tables/cff2/fd_select"
       autoload :Header, "fontisan/tables/cff2/header"
+      autoload :Index, "fontisan/tables/cff2/index"
       autoload :IndexBuilder, "fontisan/tables/cff2/index_builder"
       autoload :DictEncoder, "fontisan/tables/cff2/dict_encoder"
       autoload :OperandStack, "fontisan/tables/cff2/operand_stack"

--- a/lib/fontisan/tables/cff2/fd_select.rb
+++ b/lib/fontisan/tables/cff2/fd_select.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "stringio"
+
 module Fontisan
   module Tables
     class Cff2
@@ -17,10 +19,81 @@ module Fontisan
       #
       # @see https://learn.microsoft.com/en-us/typography/opentype/spec/cff2
       class FdSelect
+        # Read an FDSelect subtable and return the flat FD-index array
+        # (one entry per glyph).
+        #
+        # @param raw_data [String] full CFF2 table bytes
+        # @param offset [Integer] byte offset of the FDSelect
+        # @param num_glyphs [Integer] glyph count (from maxp)
+        # @return [Array<Integer>] FD index per glyph
+        def self.read(raw_data, offset, num_glyphs)
+          io = StringIO.new(raw_data)
+          io.seek(offset)
+          format = io.read(1).unpack1("C")
+
+          case format
+          when 0 then read_format0(io, num_glyphs)
+          when 3 then read_format3(io, num_glyphs)
+          when 4 then read_format4(io, num_glyphs)
+          else
+            raise CorruptedTableError, "unsupported FDSelect format: #{format}"
+          end
+        end
+
+        # Format 0: uint8 fd_index[numGlyphs]
+        def self.read_format0(io, num_glyphs)
+          io.read(num_glyphs).unpack("C*")
+        end
+        private_class_method :read_format0
+
+        # Format 3: uint16 numRanges, Range3[], uint16 sentinel
+        def self.read_format3(io, num_glyphs)
+          num_ranges = io.read(2).unpack1("n")
+          assignments = Array.new(num_glyphs, 0)
+          ranges = Array.new(num_ranges) do
+            first = io.read(2).unpack1("n")
+            fd = io.read(1).unpack1("C")
+            [first, fd]
+          end
+          sentinel = io.read(2).unpack1("n")
+
+          ranges.each_cons(2) do |(first, fd), (next_first, _)|
+            assignments.fill(fd, first, next_first - first)
+          end
+          if ranges.any?
+            last_first, last_fd = ranges.last
+            assignments.fill(last_fd, last_first, sentinel - last_first)
+          end
+          assignments
+        end
+        private_class_method :read_format3
+
+        # Format 4: uint32 numRanges, Range4[], uint32 sentinel
+        def self.read_format4(io, num_glyphs)
+          num_ranges = io.read(4).unpack1("N")
+          assignments = Array.new(num_glyphs, 0)
+          ranges = Array.new(num_ranges) do
+            first = io.read(4).unpack1("N")
+            fd = io.read(2).unpack1("n")
+            [first, fd]
+          end
+          sentinel = io.read(4).unpack1("N")
+
+          ranges.each_cons(2) do |(first, fd), (next_first, _)|
+            assignments.fill(fd, first, next_first - first)
+          end
+          if ranges.any?
+            last_first, last_fd = ranges.last
+            assignments.fill(last_fd, last_first, sentinel - last_first)
+          end
+          assignments
+        end
+        private_class_method :read_format4
+
         # @param assignments [Array<Integer>] FD index per glyph (length = numGlyphs)
         # @return [String] FDSelect bytes in the most compact format
         def self.build(assignments)
-          return 0.to_s if assignments.empty?
+          return [0].pack("C").to_s + "".b if assignments.empty?
 
           format0_bytes(assignments)
         end

--- a/lib/fontisan/tables/cff2/index.rb
+++ b/lib/fontisan/tables/cff2/index.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Fontisan
+  module Tables
+    class Cff2
+      # Reads a CFF2 INDEX structure.
+      #
+      # A CFF2 INDEX uses a 4-byte count (Card32) instead of the
+      # 2-byte count (Card16) used by CFF1. Otherwise the layout is
+      # the same: count, offSize, offset array (1-based), then data.
+      #
+      # An empty INDEX is just the 4-byte count field (= 0).
+      #
+      # @example
+      #   idx = Cff2::Index.read(raw_cff2_bytes, charstrings_offset)
+      #   idx[0]  # first item
+      #   idx.count
+      #   idx.total_size
+      class Index
+        include Enumerable
+
+        attr_reader :count, :off_size, :offsets, :data, :start_offset
+
+        # Read a CFF2 INDEX at +offset+ within +raw_data+.
+        #
+        # @param raw_data [String] full CFF2 table bytes
+        # @param offset [Integer] byte offset of the INDEX
+        def self.read(raw_data, offset)
+          io = StringIO.new(raw_data)
+          io.seek(offset)
+          new(io, offset)
+        end
+
+        # Build an INDEX from a list of data items.
+        # Delegates to {IndexBuilder}.
+        #
+        # @param items [Array<String>]
+        # @return [String] binary INDEX bytes
+        def self.build(items)
+          IndexBuilder.build(items)
+        end
+
+        # @param io [IO, StringIO] positioned at the INDEX start
+        # @param start_offset [Integer] byte offset (for diagnostics)
+        def initialize(io, start_offset = 0)
+          @io = io
+          @start_offset = start_offset
+          parse!
+        end
+
+        # Fetch the item at +index+ (0-based).
+        #
+        # @return [String, nil] binary data, or nil if out of range
+        def [](index)
+          return nil if index.negative? || index >= count
+          return "".b if count.zero?
+
+          start_pos = offsets[index] - 1
+          end_pos = offsets[index + 1] - 1
+          data[start_pos, end_pos - start_pos]
+        end
+
+        # Iterate over all items.
+        def each
+          return enum_for(:each) unless block_given?
+
+          count.times { |i| yield self[i] }
+        end
+
+        # All items as an array.
+        def to_a
+          Array.new(count) { |i| self[i] }
+        end
+
+        def empty?
+          count.zero?
+        end
+
+        # Total size of the INDEX in bytes (count + offSize + offsets + data).
+        def total_size
+          return 4 if count.zero?
+
+          4 + 1 + ((count + 1) * off_size) + data.bytesize
+        end
+
+        private
+
+        def parse!
+          @count = read_uint32
+
+          if @count.zero?
+            @off_size = 0
+            @offsets = []
+            @data = "".b
+            return
+          end
+
+          @off_size = read_uint8
+          raise CorruptedTableError, "invalid CFF2 offSize: #{@off_size}" unless (1..4).cover?(@off_size)
+
+          @offsets = Array.new(@count + 1) { read_offset(@off_size) }
+          validate_offsets!
+
+          data_size = @offsets.last - 1
+          @data = read_bytes(data_size)
+        end
+
+        def read_uint32
+          read_bytes(4).unpack1("N")
+        end
+
+        def read_uint8
+          read_bytes(1).unpack1("C")
+        end
+
+        def read_offset(size)
+          bytes = read_bytes(size)
+          case size
+          when 1 then bytes.unpack1("C")
+          when 2 then bytes.unpack1("n")
+          when 3 then bytes.unpack("C3").inject(0) { |s, b| (s << 8) | b }
+          when 4 then bytes.unpack1("N")
+          end
+        end
+
+        def read_bytes(n)
+          return "".b if n.zero?
+
+          bytes = @io.read(n)
+          if bytes.nil? || bytes.bytesize < n
+            raise CorruptedTableError,
+                  "unexpected EOF in CFF2 INDEX at offset #{@start_offset}"
+          end
+
+          bytes
+        end
+
+        def validate_offsets!
+          unless @offsets.first == 1
+            raise CorruptedTableError,
+                  "CFF2 INDEX first offset must be 1, got #{@offsets.first}"
+          end
+
+          @offsets.each_cons(2) do |prev, curr|
+            next unless curr < prev
+
+            raise CorruptedTableError, "CFF2 INDEX offsets not ascending"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontisan/tables/cff2/table_reader.rb
+++ b/lib/fontisan/tables/cff2/table_reader.rb
@@ -235,25 +235,7 @@ module Fontisan
           Cff::Index.new(@io, start_offset: offset)
         end
 
-        private
-
-        # Read bytes safely with EOF checking
-        #
-        # @param bytes [Integer] Number of bytes to read
-        # @param description [String] Description for error messages
-        # @return [String] Binary data
-        # @raise [EOFError] If not enough bytes available
-        def read_safely(bytes, description)
-          data = @io.read(bytes)
-          if data.nil? || data.bytesize < bytes
-            raise EOFError,
-                  "Unexpected EOF while reading #{description}"
-          end
-
-          data
-        end
-
-        # Parse DICT structure
+        # Parse a DICT structure (public: reused by the CFF2 subsetter).
         #
         # @param data [String] DICT binary data
         # @return [Hash] Parsed operators and values
@@ -281,20 +263,37 @@ module Fontisan
           dict
         end
 
+        private
+
+        # Read bytes safely with EOF checking
+        #
+        # @param bytes [Integer] Number of bytes to read
+        # @param description [String] Description for error messages
+        # @return [String] Binary data
+        # @raise [EOFError] If not enough bytes available
+        def read_safely(bytes, description)
+          data = @io.read(bytes)
+          if data.nil? || data.bytesize < bytes
+            raise EOFError,
+                  "Unexpected EOF while reading #{description}"
+          end
+
+          data
+        end
+
         # Check if byte is an operator
         #
-        # CFF2 extends the operator range to include operator 24 (vstore)
+        # CFF/CFF2 DICT operator bytes are 0-21 (with 12 as the two-byte
+        # escape prefix) and 24 (vstore, CFF2-specific). Number encoding
+        # prefixes (28, 29, 30) and ranges (32-254) are NOT operators.
         #
         # @param byte [Integer] Byte value
         # @return [Boolean] True if operator
         def operator_byte?(byte)
-          # Standard DICT operators (0-21, excluding number markers)
-          return true if byte <= 21 && ![12, 28, 29, 30, 31].include?(byte)
+          return false if (28..30).cover?(byte) # number prefixes
+          return false if (32..254).cover?(byte) # number ranges
 
-          # CFF2-specific operators
-          return true if byte == VSTORE_OPERATOR
-
-          false
+          true # 0-27 (incl. 12 escape), 31, 255 — treat as operator
         end
 
         # Read DICT operator

--- a/lib/fontisan/ufo/compile/cff2.rb
+++ b/lib/fontisan/ufo/compile/cff2.rb
@@ -33,40 +33,141 @@ module Fontisan
 
         # @param font [Fontisan::Ufo::Font]
         # @param glyphs [Array<Fontisan::Ufo::Glyph>] in gid order
+        # @param masters [Array<Hash>, nil] variation masters for variable
+        #   CFF2. Each hash: { font:, axes: }. When present, charstrings
+        #   emit blend operators and a VariationStore is embedded.
+        # @param axis_count [Integer, nil] number of variation axes
         # @param variation_store [String, nil] ItemVariationStore bytes
         #   for variable CFF2 fonts. When present, embedded between the
         #   GlobalSubr INDEX and CharStrings INDEX, and referenced from
         #   the Top DICT via operator 24.
         # @return [String] CFF2 table bytes
-        def self.build(_font, glyphs:, variation_store: nil)
+        def self.build(font, glyphs:, masters: nil, axis_count: nil,
+                       variation_store: nil)
+          if masters&.any?
+            build_variable(font, glyphs, masters, axis_count)
+          else
+            build_static(font, glyphs, variation_store:)
+          end
+        end
+
+        # Build a static CFF2 table (no variation data).
+        def self.build_static(font, glyphs, variation_store:)
           charstrings = glyphs.map { |g| charstring_for(g) }
           global_subr_index = empty_global_subr_index
           font_dict = build_font_dict(private_size: 0, private_offset: 0)
           font_dict_index = Tables::Cff2::IndexBuilder.build([font_dict])
           vs_bytes = variation_store&.b
 
-          # Fixed-point iteration: encode Top DICT, compute offsets, repeat.
-          top_dict = encode_top_dict(
-            charstrings_offset: 0, font_dict_index_offset: 0,
-            variation_store_offset: vs_bytes ? 0 : nil
+          layout = converge_layout(
+            charstrings:, global_subr_index:, font_dict_index:,
+            variation_store: vs_bytes
           )
-          layout = compute_layout(top_dict:, charstrings:, global_subr_index:,
-                                  font_dict_index:, variation_store: vs_bytes)
+          assemble(layout:)
+        end
 
-          10.times do
-            top_dict = encode_top_dict(
-              charstrings_offset: layout[:charstrings_offset],
-              font_dict_index_offset: layout[:font_dict_index_offset],
-              variation_store_offset: layout[:variation_store_offset],
-            )
-            next_layout = compute_layout(top_dict:, charstrings:, global_subr_index:,
-                                         font_dict_index:, variation_store: vs_bytes)
-            break if same_offsets?(layout, next_layout)
+        # Build a variable CFF2 table with blend operators and a VStore.
+        #
+        # Each glyph gets a variable charstring with blend operators when
+        # master outlines are available for it. Glyphs without masters fall
+        # back to static charstrings. The VStore contains one region per
+        # master, each peaking at the master's axis location.
+        def self.build_variable(font, glyphs, masters, axis_count)
+          num_regions = masters.size
+          vstore = build_variation_store(masters, axis_count)
 
-            layout = next_layout
+          master_glyph_sets = masters.map do |m|
+            { font: m[:font], by_name: m[:font].glyphs }
           end
 
+          charstrings = glyphs.map.with_index do |glyph, _idx|
+            master_outlines = master_glyph_sets.filter_map do |mg|
+              mg[:by_name][glyph.name]&.to_outline
+            end
+
+            if master_outlines.size == num_regions && glyph.contours.any?
+              Tables::Cff::Cff2CharStringBuilder.build_variable(
+                glyph.to_outline,
+                master_outlines: master_outlines,
+                num_regions: num_regions,
+                width: glyph.width.to_i,
+              )
+            else
+              charstring_for(glyph)
+            end
+          end
+
+          global_subr_index = empty_global_subr_index
+          font_dict = build_font_dict(private_size: 0, private_offset: 0)
+          font_dict_index = Tables::Cff2::IndexBuilder.build([font_dict])
+
+          layout = converge_layout(
+            charstrings:, global_subr_index:, font_dict_index:,
+            variation_store: vstore
+          )
           assemble(layout:)
+        end
+
+        # Build the ItemVariationStore for CFF2: one region per master,
+        # each peaking at the master's axis location.
+        def self.build_variation_store(masters, axis_count)
+          ac = axis_count || masters.first&.dig(:axes)&.size || 1
+          regions = masters.each_with_index.map do |_master, midx|
+            Array.new(ac) do |aidx|
+              if aidx == midx
+                { start: -1.0, peak: 1.0, end: 1.0 }
+              else
+                { start: -1.0, peak: 0.0, end: 1.0 }
+              end
+            end
+          end
+
+          region_list = serialize_region_list(regions, ac)
+          # One ItemVariationData with all regions referenced but zero items.
+          # The actual deltas live in charstrings (pushed via blend operands).
+          var_data = serialize_empty_variation_data(regions.size)
+
+          header_size = 8
+          offsets_array_size = 4
+          region_list_offset = header_size + offsets_array_size
+          var_data_offset = region_list_offset + region_list.bytesize
+
+          store = +""
+          store << [1].pack("n")
+          store << [region_list_offset].pack("N")
+          store << [1].pack("n")
+          store << [var_data_offset].pack("N")
+          store << region_list
+          store << var_data
+          store
+        end
+
+        def self.serialize_region_list(regions, axis_count)
+          io = +""
+          io << [axis_count].pack("n")
+          io << [regions.size].pack("n")
+          regions.each do |region|
+            region.each do |coords|
+              io << [f2dot14(coords[:start]), f2dot14(coords[:peak]),
+                     f2dot14(coords[:end])].pack("nnn")
+            end
+          end
+          io
+        end
+
+        # Serialize an ItemVariationData with all regions referenced but
+        # zero items. CFF2 charstrings push their own deltas via blend.
+        def self.serialize_empty_variation_data(region_count)
+          io = +""
+          io << [0].pack("n")               # itemCount = 0
+          io << [region_count].pack("n")    # shortDeltaCount
+          io << [region_count].pack("n")    # regionIndexCount
+          region_count.times { |i| io << [i].pack("n") }
+          io
+        end
+
+        def self.f2dot14(value)
+          (value.to_f * 16384).to_i.clamp(-16384, 16384)
         end
 
         # ---------- charstring per-glyph ----------
@@ -148,6 +249,43 @@ module Fontisan
           }
         end
 
+        # Iteratively encode the Top DICT and recompute offsets until the
+        # layout stabilizes. After convergence, performs one final
+        # encode + compute pass so +layout[:top_dict]+ carries the
+        # converged offsets (not the stale initial placeholder).
+        def self.converge_layout(charstrings:, global_subr_index:,
+                                 font_dict_index:, variation_store: nil)
+          has_vs = !variation_store.nil?
+          top_dict = encode_top_dict(
+            charstrings_offset: 0, font_dict_index_offset: 0,
+            variation_store_offset: has_vs ? 0 : nil
+          )
+          layout = compute_layout(top_dict:, charstrings:, global_subr_index:,
+                                  font_dict_index:, variation_store:)
+
+          10.times do
+            top_dict = encode_top_dict(
+              charstrings_offset: layout[:charstrings_offset],
+              font_dict_index_offset: layout[:font_dict_index_offset],
+              variation_store_offset: layout[:variation_store_offset],
+            )
+            next_layout = compute_layout(top_dict:, charstrings:, global_subr_index:,
+                                         font_dict_index:, variation_store:)
+            break if same_offsets?(layout, next_layout)
+
+            layout = next_layout
+          end
+
+          # Final encode ensures layout[:top_dict] matches converged offsets
+          final_td = encode_top_dict(
+            charstrings_offset: layout[:charstrings_offset],
+            font_dict_index_offset: layout[:font_dict_index_offset],
+            variation_store_offset: layout[:variation_store_offset],
+          )
+          compute_layout(top_dict: final_td, charstrings:, global_subr_index:,
+                         font_dict_index:, variation_store:)
+        end
+
         def self.same_offsets?(a, b)
           a[:charstrings_offset] == b[:charstrings_offset] &&
             a[:font_dict_index_offset] == b[:font_dict_index_offset] &&
@@ -173,8 +311,12 @@ module Fontisan
 
         private_class_method :charstring_for, :empty_charstring,
                              :encode_top_dict, :build_font_dict,
-                             :compute_layout, :same_offsets?,
-                             :empty_global_subr_index, :assemble
+                             :compute_layout, :converge_layout,
+                             :same_offsets?,
+                             :empty_global_subr_index, :assemble,
+                             :build_static, :build_variable,
+                             :build_variation_store, :serialize_region_list,
+                             :serialize_empty_variation_data, :f2dot14
       end
     end
   end

--- a/lib/fontisan/ufo/compile/variable_otf.rb
+++ b/lib/fontisan/ufo/compile/variable_otf.rb
@@ -9,15 +9,12 @@ module Fontisan
       #
       # The orchestrator assembles a default-master UFO plus variation
       # masters into a variable OpenType font with:
-      #   - CFF2 outlines (static — blend/vsindex operators are TODO 07/18)
+      #   - CFF2 outlines with blend operators for each varying coordinate
+      #   - ItemVariationStore embedded in the CFF2 table (regions only;
+      #     deltas live in charstring blend operands)
       #   - fvar (axes + instances)
       #   - STAT (style attributes)
       #   - avar (axis remapping, when maps are provided)
-      #
-      # NOTE: the CFF2 table currently contains static outlines (no
-      # VariationStore, no blend operators). Full variable CFF2 requires
-      # TODO 07 (blend/vsindex) and TODO 18 (blend integration) to be
-      # wired into the charstring builder.
       #
       # @see https://learn.microsoft.com/en-us/typography/opentype/spec/cff2
       class VariableOtf
@@ -59,7 +56,7 @@ module Fontisan
             "post" => Post.build(@default),
             "hmtx" => Hmtx.build(@default, glyphs: glyphs),
             "cmap" => Cmap.build(@default, glyphs: glyphs),
-            "CFF2" => Cff2.build(@default, glyphs: glyphs),
+            "CFF2" => build_cff2(glyphs),
             "fvar" => Fvar.build(@default, axes: @axes, instances: @instances),
             "STAT" => Stat.build(axes: @axes),
           }
@@ -68,6 +65,18 @@ module Fontisan
           tables["avar"] = avar_bytes if avar_bytes
 
           tables
+        end
+
+        private
+
+        # Build the CFF2 table. When masters are supplied, variable
+        # charstrings with blend operators are emitted; otherwise a static
+        # CFF2 table is produced.
+        def build_cff2(glyphs)
+          masters = @masters.map { |mf| { font: mf, axes: @axes } }
+          Cff2.build(@default, glyphs: glyphs,
+                     masters: masters.any? ? masters : nil,
+                     axis_count: @axes.size)
         end
       end
     end

--- a/spec/fontisan/subset/table_strategy/cff2_spec.rb
+++ b/spec/fontisan/subset/table_strategy/cff2_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Build a minimal synthetic CFF2 binary for testing the subsetter.
+# The CFF2 has:
+#   - Header (5 bytes)
+#   - Top DICT (pointers to CharStrings, FDArray, FDSelect, VStore)
+#   - Global Subr INDEX (empty)
+#   - Variable Store (minimal)
+#   - FDArray INDEX (one Font DICT with one Private DICT)
+#   - FDSelect (format 0)
+#   - CharStrings INDEX (N glyphs, each a minimal "endchar" charstring)
+module Cff2SpecHelper
+  OP_CHARSTRINGS = 17
+  OP_VSTORE = 24
+  OP_FDARRAY = [12, 36].freeze
+  OP_FDSELECT = [12, 37].freeze
+  OP_PRIVATE = 18
+
+  class << self
+    def encode_int(value)
+      Fontisan::Tables::Cff2::DictEncoder.encode_integer(value)
+    end
+
+    def encode_op(op)
+      Fontisan::Tables::Cff2::DictEncoder.encode_operator(op)
+    end
+
+    def encode_dict(entries)
+      io = +""
+      entries.each do |op, vals|
+        Array(vals).each { |v| io << encode_int(v) }
+        io << encode_op(op)
+      end
+      io
+    end
+
+    def build_empty_index
+      [0].pack("N") # count = 0
+    end
+
+    def build_index(items)
+      Fontisan::Tables::Cff2::IndexBuilder.build(items)
+    end
+
+    # Build a minimal ItemVariationStore with 1 region, 1 data entry.
+    def build_vstore
+      io = +""
+      io << [1].pack("n")          # format
+      io << [8 + 4].pack("N")      # variationRegionListOffset (after header + 1 offset)
+      io << [1].pack("n")          # itemVariationDataCount
+      io << [8 + 4 + 16].pack("N") # itemVariationDataOffsets[0]
+
+      # VariationRegionList
+      io << [1].pack("n")  # axisCount
+      io << [1].pack("n")  # regionCount
+      # Region: 3 × F2DOT14 for 1 axis
+      io << [0, 0x4000, 0x4000].pack("nnn") # start=0, peak=1.0, end=1.0
+
+      # ItemVariationData
+      io << [1].pack("n")  # itemCount
+      io << [1].pack("n")  # shortDeltaCount
+      io << [1].pack("n")  # regionIndexCount
+      io << [0].pack("n")  # regionIndex[0] = 0
+      io << [100].pack("s>") # deltaSets[0] = +100 (int16)
+      io
+    end
+
+    # Build a CFF2 table with N glyphs, each with a minimal charstring.
+    def build_cff2(num_glyphs:)
+      endchar = "\x0e".b # Type 2 endchar
+
+      charstrings = build_index(Array.new(num_glyphs) { endchar })
+      gsubr = build_empty_index
+      vstore = build_vstore
+      priv_dict = encode_dict([]) # empty Private DICT
+      font_dict = encode_dict([[OP_PRIVATE, [priv_dict.bytesize, 0]]])
+      fdarray = build_index([font_dict])
+      fdselect = ([0] + Array.new(num_glyphs) { 0 }).pack("C*") # format 0, all FD=0
+
+      # Layout: Header(5) | TopDICT | GSubr | VStore | FDArray | PrivDict | FDSelect | CharStrings
+      # Top DICT offsets need to be computed. Start with estimate.
+      td_entries = {}
+      td_size_guess = 30
+
+      10.times do
+        pos = 5 + td_size_guess
+        offsets = {
+          gsubr: pos,
+          vstore: pos + gsubr.bytesize,
+          fdarray: pos + gsubr.bytesize + vstore.bytesize,
+          priv: pos + gsubr.bytesize + vstore.bytesize + fdarray.bytesize,
+          fdselect: pos + gsubr.bytesize + vstore.bytesize + fdarray.bytesize + priv_dict.bytesize,
+          charstrings: pos + gsubr.bytesize + vstore.bytesize + fdarray.bytesize + priv_dict.bytesize + fdselect.bytesize,
+        }
+
+        td_entries = {
+          OP_CHARSTRINGS => offsets[:charstrings],
+          OP_VSTORE => offsets[:vstore],
+          OP_FDARRAY => offsets[:fdarray],
+          OP_FDSELECT => offsets[:fdselect],
+        }
+        # Update Font DICT's Private offset
+        font_dict = encode_dict([[OP_PRIVATE, [priv_dict.bytesize, offsets[:priv]]]])
+        fdarray = build_index([font_dict])
+        # Recompute fdselect/charstrings offsets since fdarray size may change
+        offsets[:fdselect] = offsets[:fdarray] + fdarray.bytesize
+        offsets[:charstrings] = offsets[:fdselect] + fdselect.bytesize
+        td_entries[OP_FDSELECT] = offsets[:fdselect]
+        td_entries[OP_CHARSTRINGS] = offsets[:charstrings]
+
+        td = encode_dict(td_entries)
+        break if td.bytesize == td_size_guess
+
+        td_size_guess = td.bytesize
+      end
+
+      header = Fontisan::Tables::Cff2::Header.build(top_dict_size: td_size_guess)
+      encode_dict(td_entries)
+
+      # Rebuild font_dict with correct offset
+      priv_offset = 5 + td_size_guess + gsubr.bytesize + vstore.bytesize + fdarray.bytesize
+      font_dict = encode_dict([[OP_PRIVATE, [priv_dict.bytesize, priv_offset]]])
+      fdarray = build_index([font_dict])
+      fdselect_offset = priv_offset + priv_dict.bytesize
+      charstrings_offset = fdselect_offset + fdselect.bytesize
+      td_entries[OP_CHARSTRINGS] = charstrings_offset
+      td_entries[OP_FDSELECT] = fdselect_offset
+      td = encode_dict(td_entries)
+
+      io = +""
+      io << header
+      io << td
+      io << gsubr
+      io << vstore
+      io << fdarray
+      io << priv_dict
+      io << fdselect
+      io << charstrings
+      io
+    end
+  end
+end
+
+RSpec.describe Fontisan::Subset::TableStrategy::Cff2 do
+  let(:cff2_bytes) { Cff2SpecHelper.build_cff2(num_glyphs: 10) }
+  let(:font) do
+    # Minimal stub font object that returns the CFF2 table bytes.
+    Struct.new(:table_obj).new(
+      Struct.new(:raw_data).new(cff2_bytes),
+    )
+  end
+
+  before do
+    allow(font).to receive(:table).with("CFF2").and_return(font.table_obj)
+    allow(font).to receive(:respond_to).with(:table).and_return(true)
+  end
+
+  describe ".call" do
+    it "produces valid CFF2 output with fewer charstrings" do
+      mapping = Fontisan::Subset::GlyphMapping.new([0, 1, 2])
+      context = Fontisan::Subset::SubsetContext.new(
+        font: font, mapping: mapping, options: nil, state: nil,
+      )
+
+      result = described_class.call(context: context, tag: "CFF2", table: font.table_obj)
+      expect(result).not_to be_empty
+
+      reader = Fontisan::Tables::Cff2::TableReader.new(result)
+      reader.read_top_dict
+
+      cs_offset = reader.top_dict[Cff2SpecHelper::OP_CHARSTRINGS]
+      cs_index = Fontisan::Tables::Cff2::Index.read(result, cs_offset)
+      expect(cs_index.count).to eq(3)
+    end
+
+    it "preserves the Variable Store" do
+      mapping = Fontisan::Subset::GlyphMapping.new([0, 1])
+      context = Fontisan::Subset::SubsetContext.new(
+        font: font, mapping: mapping, options: nil, state: nil,
+      )
+
+      result = described_class.call(context: context, tag: "CFF2", table: font.table_obj)
+
+      reader = Fontisan::Tables::Cff2::TableReader.new(result)
+      reader.read_top_dict
+      expect(reader.top_dict[Cff2SpecHelper::OP_VSTORE]).to be_positive
+    end
+
+    it "preserves the FDSelect with correct glyph count" do
+      mapping = Fontisan::Subset::GlyphMapping.new([0, 1, 2])
+      context = Fontisan::Subset::SubsetContext.new(
+        font: font, mapping: mapping, options: nil, state: nil,
+      )
+
+      result = described_class.call(context: context, tag: "CFF2", table: font.table_obj)
+
+      reader = Fontisan::Tables::Cff2::TableReader.new(result)
+      reader.read_top_dict
+      fds_offset = reader.top_dict[Cff2SpecHelper::OP_FDSELECT]
+      expect(fds_offset).to be_positive
+
+      assignments = Fontisan::Tables::Cff2::FdSelect.read(
+        result, fds_offset, 3
+      )
+      expect(assignments.size).to eq(3)
+    end
+
+    it "returns the raw bytes when the source is empty" do
+      empty_font = Struct.new(:table_obj).new(nil)
+      allow(empty_font).to receive(:respond_to).with(:table).and_return(true)
+      allow(empty_font).to receive(:table).with("CFF2").and_return(nil)
+
+      mapping = Fontisan::Subset::GlyphMapping.new([0])
+      context = Fontisan::Subset::SubsetContext.new(
+        font: empty_font, mapping: mapping, options: nil, state: nil,
+      )
+
+      result = described_class.call(context: context, tag: "CFF2", table: nil)
+      expect(result).to be_nil
+    end
+  end
+end

--- a/spec/fontisan/subset/table_strategy_spec.rb
+++ b/spec/fontisan/subset/table_strategy_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Fontisan::Subset::TableStrategy do
       expect(described_class.for("OS/2")).to eq(described_class::Os2)
       expect(described_class.for("CBDT")).to eq(described_class::Cbdt)
       expect(described_class.for("CBLC")).to eq(described_class::Cblc)
+      expect(described_class.for("CFF2")).to eq(described_class::Cff2)
     end
 
     it "falls back to PassThrough for unknown tags" do

--- a/spec/fontisan/ufo/compile/cff2_spec.rb
+++ b/spec/fontisan/ufo/compile/cff2_spec.rb
@@ -57,6 +57,64 @@ RSpec.describe "CFF2 table builder and Otf2Compiler" do
     end
   end
 
+  describe "variable CFF2 build (TODO #06)" do
+    let(:master_font) do
+      f = Fontisan::Ufo::Font.new
+      f.info.family_name = "Test"
+      f.info.units_per_em = 1000
+      f.glyphs[".notdef"] = Fontisan::Ufo::Glyph.new(name: ".notdef")
+
+      a = Fontisan::Ufo::Glyph.new(name: "A")
+      a.add_unicode(0x41)
+      a.width = 600
+      a.add_contour(Fontisan::Ufo::Contour.new([
+                                                 Fontisan::Ufo::Point.new(x: 120, y: 0, type: "line"),
+                                                 Fontisan::Ufo::Point.new(x: 120, y: 120, type: "offcurve"),
+                                                 Fontisan::Ufo::Point.new(x: 520, y: 120, type: "offcurve"),
+                                                 Fontisan::Ufo::Point.new(x: 520, y: 0, type: "curve"),
+                                               ]))
+      f.glyphs["A"] = a
+      f
+    end
+
+    let(:axes) do
+      [{ tag: "wght", min: 400, default: 400, max: 700, name_id: 256 }]
+    end
+
+    let(:builder) { Fontisan::Ufo::Compile::Cff2 }
+
+    it "embeds a VariationStore when masters are supplied" do
+      bytes = builder.build(
+        font, glyphs: font.glyphs.values,
+        masters: [{ font: master_font, axes: axes }], axis_count: 1
+      )
+      reader = Fontisan::Tables::Cff2::TableReader.new(bytes)
+      reader.read_top_dict
+      expect(reader.top_dict[24]).to be_positive # vstore offset
+    end
+
+    it "emits blend operators in charstrings for varying coordinates" do
+      bytes = builder.build(
+        font, glyphs: font.glyphs.values,
+        masters: [{ font: master_font, axes: axes }], axis_count: 1
+      )
+      reader = Fontisan::Tables::Cff2::TableReader.new(bytes)
+      reader.read_top_dict
+      cs_offset = reader.top_dict[17]
+      cs_index = Fontisan::Tables::Cff2::Index.read(bytes, cs_offset)
+      # GID 1 is "A" — it has varying contours, so should contain blend
+      a_charstring = cs_index[1]
+      expect(a_charstring).to include(23.chr) # blend operator = byte 23
+    end
+
+    it "produces a static CFF2 when masters is nil" do
+      static = builder.build(font, glyphs: font.glyphs.values)
+      reader = Fontisan::Tables::Cff2::TableReader.new(static)
+      reader.read_top_dict
+      expect(reader.top_dict[24]).to be_nil # no vstore
+    end
+  end
+
   describe "Otf2Compiler end-to-end" do
     it "compiles a UFO font to OTF (CFF2) and reopens it" do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
## Summary

Completes two TODO.improvements items:

- **TODO #15 — CFF2 subsetter**: New `Subset::TableStrategy::Cff2` filters CharStrings INDEX and FDSelect to subset glyphs, preserves the Variable Store as opaque bytes (vsindex references stay valid), and rebuilds with patched offsets. Uses fixed 5-byte int32 encoding for Private DICT offsets so FDArray byte size is deterministic without iteration.

- **TODO #06 — CFF2 blend operators**: `Compile::Cff2.build` now accepts `masters:` and emits per-glyph variable charstrings with `blend` operators via `Cff2CharStringBuilder.build_variable`. `VariableOtf` passes masters through. The VStore contains region definitions only; charstrings push their own delta operands to `blend`.

## Supporting fixes

- **`operator_byte?` bug** in `Tables::Cff2::TableReader`: byte 12 (the two-byte operator escape prefix) was incorrectly excluded from the operator set, silently dropping `[12,36]` (FDArray) and `[12,37]` (FDSelect) operators from every parsed CFF2 Top DICT. Fixed.
- **`Cff2CharStringBuilder#encode_variable_outline`**: was using raw outline commands (`cx1/cy1/...` keys) instead of CFF-converted commands (`x1/y1/...`), causing a nil error on every cubic contour. Fixed by calling `to_cff_commands`.
- **Layout convergence**: the CFF2 builder's fixed-point loop kept a stale `top_dict` after `same_offsets?` returned true. Extracted `converge_layout` with a final encode pass.

## Test plan

- [x] `bundle exec rspec spec/fontisan/tables/cff2/ spec/fontisan/ufo/compile/ spec/fontisan/subset/` -- 436 examples, 0 failures
- [x] `bundle exec rubocop` -- no offenses on changed files
- [x] New spec `spec/fontisan/subset/table_strategy/cff2_spec.rb` verifies CharStrings filter, VStore preservation, FDSelect retention
- [x] New spec block in `spec/fontisan/ufo/compile/cff2_spec.rb` verifies variable build emits VStore + blend operators
