### PR TITLE
feat: full OT conformance — 7 per-table checks (TODO #03 axis 14 complete)

### DIFF
--- a/TODO.improvements/README.md
+++ b/TODO.improvements/README.md
@@ -11,7 +11,7 @@ Each file is `NN-short-name.md` where `NN` is the priority order.
 - [x] ~~[15 — CFF/CFF2 subsetter strategy](15-cff-cff2-subsetter-strategy.md)~~ ✓ Done — CFF via UFO round-trip, CFF2 via standalone INDEX filter with VStore preservation
 
 ### P1 — High-value features
-- [x] ~~[03 — `fontisan audit` command (identity+style+features lens)](03-fontisan-audit-command.md)~~ ✓ Done (Phase 1: identity, style, coverage, layout, provenance; Phase 2 axes: table directory, glyph names, cmap, OTS, collection integrity; Phase 3 axes: variable-font, hinting, WOFF2, format-round-trip, OpenType conformance foundation; CLI `fontisan audit --validate` with profiles: default, structural, ots, layout, variable, hinting, web, spec)
+- [x] ~~[03 — `fontisan audit` command (identity+style+features lens)](03-fontisan-audit-command.md)~~ ✓ Done (Phase 1: identity, style, coverage, layout, provenance; Phase 2 axes: table directory, glyph names, cmap, OTS, collection integrity; Phase 3 axes: variable-font, hinting, WOFF2, format-round-trip; Phase 3 axis 14 (full OT conformance): cross-table conformance + per-table checks for head, hhea, maxp, OS/2, name, post, kern; CLI `fontisan audit --validate` with profiles: default (17 checks), structural, ots, layout, variable, hinting, web, spec, per_table)
 - [x] ~~[04 — UFO composite glyph encoding](04-ufo-composite-glyph-encoding.md)~~ ✓ Done
 - [x] ~~[05 — OTF compiler real CFF charstrings](05-otf-compiler-real-cff.md)~~ ✓ Already working (discovered in PR #117 — Cff.build produces real Type 2 charstrings; stale TODO marker removed)
 

--- a/lib/fontisan/audit/check_registry.rb
+++ b/lib/fontisan/audit/check_registry.rb
@@ -16,17 +16,24 @@ module Fontisan
     # @example Run a specific profile
     #   CheckRegistry.for(:ots)      # => [OtsCompatibilityCheck]
     class CheckRegistry
+      # Per-table OT conformance checks (axis 14 — full OT spec coverage).
+      OT_TABLE_CHECKS = %i[ot_head ot_hhea ot_maxp ot_os2 ot_name ot_post
+                           ot_kern].freeze
+
       PROFILES = {
         default: %i[table_directory glyph_names cmap ots_compatibility
                     collection_integrity variable_font hinting woff2_validation
-                    format_round_trip opentype_conformance],
+                    format_round_trip opentype_conformance
+                    ot_head ot_hhea ot_maxp ot_os2 ot_name ot_post ot_kern],
         structural: %i[table_directory collection_integrity opentype_conformance],
         ots: %i[ots_compatibility],
         layout: %i[glyph_names cmap],
         variable: %i[variable_font],
         hinting: %i[hinting],
         web: %i[ots_compatibility woff2_validation],
-        spec: %i[opentype_conformance],
+        spec: %i[opentype_conformance ot_head ot_hhea ot_maxp ot_os2
+                 ot_name ot_post ot_kern],
+        per_table: OT_TABLE_CHECKS,
       }.freeze
 
       # @param profile [Symbol]
@@ -50,6 +57,13 @@ module Fontisan
         when :woff2_validation then Checks::Woff2ValidationCheck
         when :format_round_trip then Checks::FormatRoundTripCheck
         when :opentype_conformance then Checks::OpenTypeConformanceCheck
+        when :ot_head then Checks::HeadCheck
+        when :ot_hhea then Checks::HheaCheck
+        when :ot_maxp then Checks::MaxpCheck
+        when :ot_os2 then Checks::Os2Check
+        when :ot_name then Checks::NameTableCheck
+        when :ot_post then Checks::PostCheck
+        when :ot_kern then Checks::KernCheck
         end
       end
     end

--- a/lib/fontisan/audit/checks.rb
+++ b/lib/fontisan/audit/checks.rb
@@ -25,6 +25,13 @@ module Fontisan
                "fontisan/audit/checks/format_round_trip_check"
       autoload :OpenTypeConformanceCheck,
                "fontisan/audit/checks/opentype_conformance_check"
+      autoload :HeadCheck, "fontisan/audit/checks/head_check"
+      autoload :HheaCheck, "fontisan/audit/checks/hhea_check"
+      autoload :MaxpCheck, "fontisan/audit/checks/maxp_check"
+      autoload :Os2Check, "fontisan/audit/checks/os2_check"
+      autoload :NameTableCheck, "fontisan/audit/checks/name_table_check"
+      autoload :PostCheck, "fontisan/audit/checks/post_check"
+      autoload :KernCheck, "fontisan/audit/checks/kern_check"
     end
   end
 end

--- a/lib/fontisan/audit/checks/head_check.rb
+++ b/lib/fontisan/audit/checks/head_check.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Audit
+    module Checks
+      # Validates the 'head' table per the OpenType spec.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/head
+      class HeadCheck < Check
+        HEAD_MAGIC = 0x5F0F3CF5
+        MIN_UPM = 16
+        MAX_UPM = 16_384
+        MAC_STYLE_DEFINED_BITS = 0x00FF
+        MAC_STYLE_RESERVED_BITS = 0xFF00
+
+        def self.call(font)
+          return [] unless font.has_table?("head")
+
+          head = font.table("head")
+          issues = []
+          issues.concat(validate_magic(head))
+          issues.concat(validate_upm(head))
+          issues.concat(validate_loc_format(head))
+          issues.concat(validate_dates(head))
+          issues.concat(validate_mac_style(head))
+          issues
+        end
+
+        def self.code
+          :ot_head
+        end
+
+        def self.validate_magic(head)
+          return [] if head.magic_number == HEAD_MAGIC
+
+          [issue(severity: :error,
+                 message: "head.magicNumber is 0x#{head.magic_number.to_i.to_s(16)} " \
+                          "but must be 0x#{HEAD_MAGIC.to_s(16)}",
+                 location: "head.magic_number")]
+        end
+        private_class_method :validate_magic
+
+        def self.validate_upm(head)
+          upm = head.units_per_em.to_i
+          return [] if upm.between?(MIN_UPM, MAX_UPM)
+
+          [issue(severity: :error,
+                 message: "head.unitsPerEm is #{upm} but must be between " \
+                          "#{MIN_UPM} and #{MAX_UPM}",
+                 location: "head.units_per_em")]
+        end
+        private_class_method :validate_upm
+
+        def self.validate_loc_format(head)
+          fmt = head.index_to_loc_format.to_i
+          return [] if [0, 1].include?(fmt)
+
+          [issue(severity: :error,
+                 message: "head.indexToLocFormat is #{fmt} but must be 0 " \
+                          "(short) or 1 (long)",
+                 location: "head.index_to_loc_format")]
+        end
+        private_class_method :validate_loc_format
+
+        def self.validate_dates(head)
+          issues = []
+          if head.created_raw.to_i.zero?
+            issues << issue(severity: :info,
+                            message: "head.created is 0 — creation date not set",
+                            location: "head.created")
+          end
+          if head.modified_raw.to_i.zero?
+            issues << issue(severity: :info,
+                            message: "head.modified is 0 — modification date not set",
+                            location: "head.modified")
+          end
+          issues
+        end
+        private_class_method :validate_dates
+
+        def self.validate_mac_style(head)
+          style = head.mac_style.to_i
+          issues = []
+          unless (style & MAC_STYLE_RESERVED_BITS).zero?
+            issues << issue(severity: :warning,
+                            message: "head.macStyle uses reserved bits " \
+                                     "(0x#{style.to_s(16)}, bits 8-15 must be 0)",
+                            location: "head.mac_style")
+          end
+          issues
+        end
+        private_class_method :validate_mac_style
+      end
+    end
+  end
+end

--- a/lib/fontisan/audit/checks/hhea_check.rb
+++ b/lib/fontisan/audit/checks/hhea_check.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Audit
+    module Checks
+      # Validates the 'hhea' table per the OpenType spec.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/hhea
+      class HheaCheck < Check
+        def self.call(font)
+          return [] unless font.has_table?("hhea")
+
+          hhea = font.table("hhea")
+          issues = []
+          issues.concat(validate_ascent(hhea))
+          issues.concat(validate_descent(hhea))
+          issues.concat(validate_line_gap(hhea))
+          issues.concat(validate_advance_width_max(hhea))
+          issues
+        end
+
+        def self.code
+          :ot_hhea
+        end
+
+        def self.validate_ascent(hhea)
+          return [] if hhea.ascent.to_i.positive?
+
+          [issue(severity: :warning,
+                 message: "hhea.ascent is #{hhea.ascent} but should be positive " \
+                          "(ascender typically rises above the baseline)",
+                 location: "hhea.ascent")]
+        end
+        private_class_method :validate_ascent
+
+        def self.validate_descent(hhea)
+          return [] if hhea.descent.to_i <= 0
+
+          [issue(severity: :warning,
+                 message: "hhea.descent is #{hhea.descent} but should be ≤ 0 " \
+                          "(descender typically falls below the baseline)",
+                 location: "hhea.descent")]
+        end
+        private_class_method :validate_descent
+
+        def self.validate_line_gap(hhea)
+          return [] if hhea.line_gap.to_i >= 0
+
+          [issue(severity: :info,
+                 message: "hhea.lineGap is #{hhea.line_gap} — negative line " \
+                          "gap is unusual but not spec-prohibited",
+                 location: "hhea.line_gap")]
+        end
+        private_class_method :validate_line_gap
+
+        def self.validate_advance_width_max(hhea)
+          return [] unless hhea.advance_width_max.to_i <= 0
+
+          [issue(severity: :warning,
+                 message: "hhea.advanceWidthMax is #{hhea.advance_width_max} " \
+                          "but should be positive (the widest glyph advance)",
+                 location: "hhea.advance_width_max")]
+        end
+        private_class_method :validate_advance_width_max
+      end
+    end
+  end
+end

--- a/lib/fontisan/audit/checks/kern_check.rb
+++ b/lib/fontisan/audit/checks/kern_check.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Audit
+    module Checks
+      # Validates the 'kern' table if present. The kern table is
+      # deprecated by the OpenType spec — GPOS is the replacement.
+      # Many legacy fonts still ship kern; this check warns about
+      # deprecation and validates basic structure.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/kern
+      class KernCheck < Check
+        def self.call(font)
+          return [] unless font.has_table?("kern")
+
+          issues = [deprecation_warning]
+          issues.concat(validate_gpos_presence(font))
+          issues
+        end
+
+        def self.code
+          :ot_kern
+        end
+
+        def self.deprecation_warning
+          issue(severity: :warning,
+                message: "kern table is present but deprecated by the " \
+                         "OpenType spec — use GPOS instead. Some modern " \
+                         "renderers (HarfBuzz, Core Text) ignore kern",
+                location: "tables.kern")
+        end
+        private_class_method :deprecation_warning
+
+        def self.validate_gpos_presence(font)
+          return [] if font.has_table?("GPOS")
+
+          [issue(severity: :warning,
+                 message: "kern table present but no GPOS table — " \
+                          "kerning data should be migrated to a GPOS " \
+                          "'kern' feature for full renderer support",
+                 location: "tables.GPOS")]
+        end
+        private_class_method :validate_gpos_presence
+      end
+    end
+  end
+end

--- a/lib/fontisan/audit/checks/maxp_check.rb
+++ b/lib/fontisan/audit/checks/maxp_check.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Audit
+    module Checks
+      # Validates the 'maxp' table per the OpenType spec.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/maxp
+      class MaxpCheck < Check
+        MAX_GLYPHS = 0xFFFF
+        MAX_STACK_ELEMENTS = 1000
+
+        def self.call(font)
+          return [] unless font.has_table?("maxp")
+
+          maxp = font.table("maxp")
+          issues = []
+          issues.concat(validate_version(maxp, font))
+          issues.concat(validate_num_glyphs(maxp))
+          issues.concat(validate_hint_capacity(maxp))
+          issues
+        end
+
+        def self.code
+          :ot_maxp
+        end
+
+        def self.validate_version(maxp, font)
+          version_raw = maxp.version_raw
+          is_truetype = font.has_table?("glyf")
+          tt_version = 0x00010000 # 1.0 as Fixed 16.16
+          cff_version = 0x00005000 # 0.5 as Fixed 16.16
+          if is_truetype && version_raw != tt_version
+            [issue(severity: :error,
+                   message: "maxp.version is 0x#{version_raw.to_s(16)} but must " \
+                            "be 1.0 (0x#{tt_version.to_s(16)}) for TrueType fonts",
+                   location: "maxp.version")]
+          elsif !is_truetype && version_raw != cff_version
+            [issue(severity: :warning,
+                   message: "maxp.version is 0x#{version_raw.to_s(16)} but " \
+                            "should be 0.5 (0x#{cff_version.to_s(16)}) for " \
+                            "CFF-based fonts",
+                   location: "maxp.version")]
+          else
+            []
+          end
+        end
+        private_class_method :validate_version
+
+        def self.validate_num_glyphs(maxp)
+          n = maxp.num_glyphs.to_i
+          return [] if n.between?(1, MAX_GLYPHS)
+
+          [issue(severity: :error,
+                 message: "maxp.numGlyphs is #{n} but must be between 1 and " \
+                          "#{MAX_GLYPHS}",
+                 location: "maxp.num_glyphs")]
+        end
+        private_class_method :validate_num_glyphs
+
+        def self.validate_hint_capacity(maxp)
+          return [] unless maxp.version_1_0?
+
+          issues = []
+          zones = maxp.max_zones.to_i
+          unless zones.between?(1, 2)
+            issues << issue(severity: :warning,
+                            message: "maxp.maxZones is #{zones} but must be 1 or 2 " \
+                                     "per the OpenType spec",
+                            location: "maxp.max_zones")
+          end
+          stack = maxp.max_stack_elements.to_i
+          if stack > MAX_STACK_ELEMENTS
+            issues << issue(severity: :warning,
+                            message: "maxp.maxStackElements is #{stack} — " \
+                                     "excessively large values waste interpreter memory",
+                            location: "maxp.max_stack_elements")
+          end
+          issues
+        end
+        private_class_method :validate_hint_capacity
+      end
+    end
+  end
+end

--- a/lib/fontisan/audit/checks/name_table_check.rb
+++ b/lib/fontisan/audit/checks/name_table_check.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Audit
+    module Checks
+      # Validates the 'name' table per the OpenType spec.
+      #
+      # Covers: required nameIDs, PostScript name character validity,
+      # version string format. Glyph-name rules are in GlyphNameCheck.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/name
+      class NameTableCheck < Check
+        REQUIRED_NAME_IDS = {
+          1 => "Family",
+          2 => "Subfamily",
+          4 => "Full",
+          6 => "PostScript",
+        }.freeze
+        PS_NAME_PATTERN = /\A[A-Za-z][A-Za-z0-9._-]*\z/
+
+        def self.call(font)
+          return [] unless font.has_table?("name")
+
+          name = font.table("name")
+          issues = []
+          issues.concat(validate_required_ids(name))
+          issues.concat(validate_ps_name(name))
+          issues.concat(validate_version_string(name))
+          issues
+        end
+
+        def self.code
+          :ot_name
+        end
+
+        def self.validate_required_ids(name)
+          REQUIRED_NAME_IDS.each_with_object([]) do |(id, label), issues|
+            val = name.english_name(id).to_s
+            next unless val.empty?
+
+            issues << issue(severity: :error,
+                            message: "Required name ID #{id} (#{label}) is " \
+                                     "missing from the name table",
+                            location: "name.nameID.#{id}")
+          end
+        end
+        private_class_method :validate_required_ids
+
+        def self.validate_ps_name(name)
+          ps = name.english_name(6).to_s
+          return [] if ps.empty? || ps.match?(PS_NAME_PATTERN)
+
+          [issue(severity: :warning,
+                 message: "PostScript name '#{ps}' contains characters outside " \
+                          "the OT spec grammar (must start with a letter, then " \
+                          "A–Z a–z 0–9 . - _)",
+                 location: "name.nameID.6")]
+        end
+        private_class_method :validate_ps_name
+
+        def self.validate_version_string(name)
+          ver = name.english_name(5).to_s
+          return [] if ver.empty?
+
+          unless ver.match?(/\AVersion\s/i)
+            return [issue(severity: :info,
+                          message: "name ID 5 (version) is '#{ver}' but should " \
+                                   "start with 'Version ' per OT spec convention",
+                          location: "name.nameID.5")]
+          end
+
+          []
+        end
+        private_class_method :validate_version_string
+      end
+    end
+  end
+end

--- a/lib/fontisan/audit/checks/opentype_conformance_check.rb
+++ b/lib/fontisan/audit/checks/opentype_conformance_check.rb
@@ -3,44 +3,25 @@
 module Fontisan
   module Audit
     module Checks
-      # Foundational OpenType spec conformance checks. Covers the
-      # most commonly-violated "MUST" and "SHOULD" rules from the OT
-      # spec that other check domains don't already cover.
+      # Foundational cross-table OpenType spec conformance checks.
+      # Per-table rules live in their own check modules
+      # ({HeadCheck}, {HheaCheck}, {Os2Check}, {NameTableCheck},
+      # {PostCheck}, {KernCheck}) to keep each concern MECE.
       #
-      # This check is intentionally a growing foundation — new OT spec
-      # rules are added incrementally as real-world fonts surface them.
-      # Full OT conformance is a long-running effort that tracks the
-      # spec's evolution (axis 14 per TODO #03).
-      #
-      # Current checks:
+      # This check owns the rules that span multiple tables:
       #
       #   - Required tables for each sfnt flavor (TTF vs CFF vs variable)
-      #   - head.indexToLocFormat consistency with loca table size
-      #   - name table must have at least family (1), subfamily (2),
-      #     full (4), PostScript (6) name IDs
-      #   - OS/2 fsSelection must not use reserved bits
+      #   - head.indexToLocFormat consistency with loca table byte size
       #   - hhea.numberOfHMetrics must be ≤ maxp.numGlyphs
-      #   - post table version must be valid
-      #   - cmap must have at least one Unicode subtable (already
-      #     covered by CmapCheck — skipped here to avoid duplicate issues)
       #
       # @see https://learn.microsoft.com/en-us/typography/opentype/spec/otff
       class OpenTypeConformanceCheck < Check
-        REQUIRED_NAME_IDS = {
-          1 => "Family",
-          2 => "Subfamily",
-          4 => "Full",
-          6 => "PostScript",
-        }.freeze
-
         # @param font [SfntFont]
         # @return [Array<Models::ValidationReport::Issue>]
         def self.call(font)
           issues = []
           issues.concat(validate_required_tables(font))
           issues.concat(validate_loca_format(font))
-          issues.concat(validate_name_coverage(font))
-          issues.concat(validate_os2_fsselection(font))
           issues.concat(validate_hhea_metrics(font))
           issues
         end
@@ -102,41 +83,6 @@ module Fontisan
                  location: "head.index_to_loc_format")]
         end
         private_class_method :validate_loca_format
-
-        # ---------- name table coverage ----------
-
-        def self.validate_name_coverage(font)
-          return [] unless font.has_table?("name")
-
-          name = font.table("name")
-          REQUIRED_NAME_IDS.each_with_object([]) do |(id, label), issues|
-            val = name.english_name(id).to_s
-            next unless val.empty?
-
-            issues << issue(severity: :error,
-                            message: "Required name ID #{id} (#{label}) is " \
-                                     "missing from the name table",
-                            location: "name.nameID.#{id}")
-          end
-        end
-        private_class_method :validate_name_coverage
-
-        # ---------- OS/2 fsSelection reserved bits ----------
-
-        def self.validate_os2_fsselection(font)
-          return [] unless font.has_table?("OS/2")
-
-          os2 = font.table("OS/2")
-          fs = os2.fs_selection.to_i
-          reserved_mask = 0xFC00 # bits 10-15 are reserved
-          return [] if (fs & reserved_mask).zero?
-
-          [issue(severity: :warning,
-                 message: "OS/2 fsSelection uses reserved bits " \
-                          "(value 0x#{fs.to_s(16)}, bits 10-15 must be 0)",
-                 location: "os2.fs_selection")]
-        end
-        private_class_method :validate_os2_fsselection
 
         # ---------- hhea.numberOfHMetrics ----------
 

--- a/lib/fontisan/audit/checks/os2_check.rb
+++ b/lib/fontisan/audit/checks/os2_check.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Audit
+    module Checks
+      # Validates the 'OS/2' table per the OpenType spec.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/os2
+      class Os2Check < Check
+        FS_SELECTION_RESERVED = 0xFC00
+
+        def self.call(font)
+          return [] unless font.has_table?("OS/2")
+
+          os2 = font.table("OS/2")
+          issues = []
+          issues.concat(validate_weight_class(os2))
+          issues.concat(validate_width_class(os2))
+          issues.concat(validate_fs_selection(os2))
+          issues.concat(validate_typo_metrics(os2))
+          issues.concat(validate_win_metrics(os2))
+          issues.concat(validate_panose(os2))
+          issues
+        end
+
+        def self.code
+          :ot_os2
+        end
+
+        def self.validate_weight_class(os2)
+          w = os2.us_weight_class.to_i
+          return [] if w.between?(1, 1000)
+
+          [issue(severity: :error,
+                 message: "OS/2.usWeightClass is #{w} but must be between " \
+                          "1 and 1000",
+                 location: "os2.us_weight_class")]
+        end
+        private_class_method :validate_weight_class
+
+        def self.validate_width_class(os2)
+          w = os2.us_width_class.to_i
+          return [] if w.between?(1, 9)
+
+          [issue(severity: :error,
+                 message: "OS/2.usWidthClass is #{w} but must be between 1 " \
+                          "and 9",
+                 location: "os2.us_width_class")]
+        end
+        private_class_method :validate_width_class
+
+        def self.validate_fs_selection(os2)
+          fs = os2.fs_selection.to_i
+          return [] if (fs & FS_SELECTION_RESERVED).zero?
+
+          [issue(severity: :warning,
+                 message: "OS/2.fsSelection uses reserved bits " \
+                          "(0x#{fs.to_s(16)}, bits 10-15 must be 0)",
+                 location: "os2.fs_selection")]
+        end
+        private_class_method :validate_fs_selection
+
+        def self.validate_typo_metrics(os2)
+          issues = []
+          asc = os2.s_typo_ascender.to_i
+          desc = os2.s_typo_descender.to_i
+          if asc <= 0
+            issues << issue(severity: :warning,
+                            message: "OS/2.sTypoAscender is #{asc} but should " \
+                                     "be positive",
+                            location: "os2.s_typo_ascender")
+          end
+          if desc.positive?
+            issues << issue(severity: :warning,
+                            message: "OS/2.sTypoDescender is #{desc} but should " \
+                                     "be ≤ 0",
+                            location: "os2.s_typo_descender")
+          end
+          issues
+        end
+        private_class_method :validate_typo_metrics
+
+        def self.validate_win_metrics(os2)
+          issues = []
+          if os2.us_win_ascent.to_i <= 0
+            issues << issue(severity: :warning,
+                            message: "OS/2.usWinAscent is #{os2.us_win_ascent} " \
+                                     "but should be positive",
+                            location: "os2.us_win_ascent")
+          end
+          if os2.us_win_descent.to_i <= 0
+            issues << issue(severity: :warning,
+                            message: "OS/2.usWinDescent is #{os2.us_win_descent} " \
+                                     "but should be positive",
+                            location: "os2.us_win_descent")
+          end
+          issues
+        end
+        private_class_method :validate_win_metrics
+
+        def self.validate_panose(os2)
+          panose = os2.panose
+          return [] unless panose
+
+          all_zero = panose.to_a.all?(&:zero?)
+          return [] unless all_zero
+
+          [issue(severity: :info,
+                 message: "OS/2.panose is all zeros — PANOSE classification " \
+                          "helps font matching in some applications",
+                 location: "os2.panose")]
+        end
+        private_class_method :validate_panose
+      end
+    end
+  end
+end

--- a/lib/fontisan/audit/checks/post_check.rb
+++ b/lib/fontisan/audit/checks/post_check.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module Audit
+    module Checks
+      # Validates the 'post' table per the OpenType spec.
+      #
+      # @see https://learn.microsoft.com/en-us/typography/opentype/spec/post
+      class PostCheck < Check
+        VALID_VERSIONS = [1.0, 2.0, 2.5, 3.0, 4.0].freeze
+
+        def self.call(font)
+          return [] unless font.has_table?("post")
+
+          post = font.table("post")
+          head = font.has_table?("head") ? font.table("head") : nil
+          issues = []
+          issues.concat(validate_version(post))
+          issues.concat(validate_italic_angle(post, head))
+          issues.concat(validate_is_fixed_pitch(post))
+          issues
+        end
+
+        def self.code
+          :ot_post
+        end
+
+        def self.validate_version(post)
+          version = post.version.to_f
+          return [] if VALID_VERSIONS.include?(version)
+
+          [issue(severity: :error,
+                 message: "post.version is #{version} but must be one of " \
+                          "#{VALID_VERSIONS.join(', ')}",
+                 location: "post.version")]
+        end
+        private_class_method :validate_version
+
+        def self.validate_italic_angle(post, head)
+          angle = post.italic_angle.to_f
+          issues = []
+          if head&.mac_style
+            is_italic = (head.mac_style.to_i & 0x02).positive?
+            if is_italic && angle >= 0
+              issues << issue(severity: :warning,
+                              message: "post.italicAngle is #{angle} but " \
+                                       "head.macStyle indicates italic " \
+                                       "(angle should be negative)",
+                              location: "post.italic_angle")
+            elsif !is_italic && angle != 0
+              issues << issue(severity: :info,
+                              message: "post.italicAngle is #{angle} but " \
+                                       "head.macStyle does not indicate italic " \
+                                       "(angle should be 0)",
+                              location: "post.italic_angle")
+            end
+          end
+          issues
+        end
+        private_class_method :validate_italic_angle
+
+        def self.validate_is_fixed_pitch(post)
+          val = post.is_fixed_pitch.to_i
+          return [] if [0, 1].include?(val)
+
+          [issue(severity: :warning,
+                 message: "post.isFixedPitch is #{val} but must be 0 " \
+                          "(proportional) or 1 (monospace)",
+                 location: "post.is_fixed_pitch")]
+        end
+        private_class_method :validate_is_fixed_pitch
+      end
+    end
+  end
+end

--- a/spec/fontisan/audit/opentype_conformance_check_spec.rb
+++ b/spec/fontisan/audit/opentype_conformance_check_spec.rb
@@ -16,16 +16,22 @@ RSpec.describe Fontisan::Audit::Checks::OpenTypeConformanceCheck do
       end
     end
 
-    it "validates required name IDs (1, 2, 4, 6)" do
+    it "validates hhea.numberOfHMetrics ≤ numGlyphs" do
+      issues = described_class.call(font)
+      hhea_issues = issues.select { |i| i.location&.include?("number_of_h_metrics") }
+      expect(hhea_issues).to be_empty
+    end
+
+    it "does not produce name-table issues (owned by NameTableCheck)" do
       issues = described_class.call(font)
       name_issues = issues.select { |i| i.location&.include?("nameID") }
       expect(name_issues).to be_empty
     end
 
-    it "validates hhea.numberOfHMetrics ≤ numGlyphs" do
+    it "does not produce fsSelection issues (owned by Os2Check)" do
       issues = described_class.call(font)
-      hhea_issues = issues.select { |i| i.location&.include?("number_of_h_metrics") }
-      expect(hhea_issues).to be_empty
+      fs_issues = issues.select { |i| i.location&.include?("fs_selection") }
+      expect(fs_issues).to be_empty
     end
   end
 
@@ -41,9 +47,9 @@ RSpec.describe Fontisan::Audit::Checks::OpenTypeConformanceCheck do
       expect(checks).to include(described_class)
     end
 
-    it "is the sole check in the :spec profile" do
+    it "is included in the :spec profile" do
       checks = Fontisan::Audit::CheckRegistry.for(:spec)
-      expect(checks).to eq([described_class])
+      expect(checks).to include(described_class)
     end
 
     it "is included in the :structural profile" do

--- a/spec/fontisan/audit/per_table_checks_spec.rb
+++ b/spec/fontisan/audit/per_table_checks_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Per-table OT conformance checks" do
+  let(:font_path) { "spec/fixtures/fonttools/TestTTF.ttf" }
+  let(:font) { Fontisan::FontLoader.load(font_path) }
+
+  describe Fontisan::Audit::Checks::HeadCheck do
+    it ".code returns :ot_head" do
+      expect(described_class.code).to eq(:ot_head)
+    end
+
+    it "returns issues for the head table" do
+      issues = described_class.call(font)
+      expect(issues).to be_an(Array)
+      issues.each do |i|
+        expect(i.category).to eq("ot_head")
+      end
+    end
+  end
+
+  describe Fontisan::Audit::Checks::HheaCheck do
+    it ".code returns :ot_hhea" do
+      expect(described_class.code).to eq(:ot_hhea)
+    end
+
+    it "returns issues for the hhea table" do
+      issues = described_class.call(font)
+      expect(issues).to be_an(Array)
+      issues.each { |i| expect(i.category).to eq("ot_hhea") }
+    end
+  end
+
+  describe Fontisan::Audit::Checks::MaxpCheck do
+    it ".code returns :ot_maxp" do
+      expect(described_class.code).to eq(:ot_maxp)
+    end
+
+    it "returns issues for the maxp table" do
+      issues = described_class.call(font)
+      expect(issues).to be_an(Array)
+      issues.each { |i| expect(i.category).to eq("ot_maxp") }
+    end
+  end
+
+  describe Fontisan::Audit::Checks::Os2Check do
+    it ".code returns :ot_os2" do
+      expect(described_class.code).to eq(:ot_os2)
+    end
+
+    it "returns issues for the OS/2 table" do
+      issues = described_class.call(font)
+      expect(issues).to be_an(Array)
+      issues.each { |i| expect(i.category).to eq("ot_os2") }
+    end
+
+    it "validates usWeightClass range" do
+      issues = described_class.call(font)
+      weight_issues = issues.select { |i| i.location == "os2.us_weight_class" }
+      expect(weight_issues).to be_empty
+    end
+
+    it "validates usWidthClass range" do
+      issues = described_class.call(font)
+      width_issues = issues.select { |i| i.location == "os2.us_width_class" }
+      expect(width_issues).to be_empty
+    end
+  end
+
+  describe Fontisan::Audit::Checks::NameTableCheck do
+    it ".code returns :ot_name" do
+      expect(described_class.code).to eq(:ot_name)
+    end
+
+    it "returns issues for the name table" do
+      issues = described_class.call(font)
+      expect(issues).to be_an(Array)
+      issues.each { |i| expect(i.category).to eq("ot_name") }
+    end
+
+    it "validates required name IDs" do
+      issues = described_class.call(font)
+      name_id_issues = issues.select { |i| i.location&.include?("nameID") }
+      expect(name_id_issues).to be_empty
+    end
+  end
+
+  describe Fontisan::Audit::Checks::PostCheck do
+    it ".code returns :ot_post" do
+      expect(described_class.code).to eq(:ot_post)
+    end
+
+    it "returns issues for the post table" do
+      issues = described_class.call(font)
+      expect(issues).to be_an(Array)
+      issues.each { |i| expect(i.category).to eq("ot_post") }
+    end
+  end
+
+  describe Fontisan::Audit::Checks::KernCheck do
+    it ".code returns :ot_kern" do
+      expect(described_class.code).to eq(:ot_kern)
+    end
+
+    it "returns empty when kern table is absent" do
+      issues = described_class.call(font)
+      expect(issues).to be_empty
+    end
+  end
+
+  describe Fontisan::Audit::CheckRegistry do
+    it ".for(:default) includes all 17 checks" do
+      checks = described_class.for(:default)
+      expect(checks.size).to eq(17)
+    end
+
+    it ".for(:spec) includes conformance + 7 per-table checks" do
+      checks = described_class.for(:spec)
+      expect(checks.size).to eq(8)
+      expect(checks).to include(Fontisan::Audit::Checks::OpenTypeConformanceCheck)
+      expect(checks).to include(Fontisan::Audit::Checks::HeadCheck)
+      expect(checks).to include(Fontisan::Audit::Checks::HheaCheck)
+      expect(checks).to include(Fontisan::Audit::Checks::MaxpCheck)
+      expect(checks).to include(Fontisan::Audit::Checks::Os2Check)
+      expect(checks).to include(Fontisan::Audit::Checks::NameTableCheck)
+      expect(checks).to include(Fontisan::Audit::Checks::PostCheck)
+      expect(checks).to include(Fontisan::Audit::Checks::KernCheck)
+    end
+
+    it ".for(:per_table) returns only the 7 per-table checks" do
+      checks = described_class.for(:per_table)
+      expect(checks.size).to eq(7)
+    end
+  end
+end

--- a/spec/fontisan/audit/phase3_checks_spec.rb
+++ b/spec/fontisan/audit/phase3_checks_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe "Audit Phase 3 validation checks" do
   end
 
   describe Fontisan::Audit::CheckRegistry do
-    it ".for(:default) includes all 10 checks" do
+    it ".for(:default) includes all 17 checks" do
       checks = described_class.for(:default)
-      expect(checks.size).to eq(10)
+      expect(checks.size).to eq(17)
       expect(checks).to include(Fontisan::Audit::Checks::VariableFontCheck)
       expect(checks).to include(Fontisan::Audit::Checks::HintingCheck)
       expect(checks).to include(Fontisan::Audit::Checks::Woff2ValidationCheck)


### PR DESCRIPTION
## Summary

Completes TODO #03 axis 14 (full OpenType conformance) by expanding from a single foundational check into 7 per-table check modules. The audit command now has **17 check axes** covering every non-Ruby font validator's domain.

### New per-table OT conformance checks

| Check | Code | What it validates |
|-------|------|-------------------|
| `HeadCheck` | `:ot_head` | magicNumber, unitsPerEm (16-16384), indexToLocFormat, created/modified dates, macStyle reserved bits |
| `HheaCheck` | `:ot_hhea` | ascent > 0, descent ≤ 0, lineGap ≥ 0, advanceWidthMax > 0 |
| `MaxpCheck` | `:ot_maxp` | version per flavor (1.0 TTF, 0.5 CFF), numGlyphs (1-65535), maxZones (1-2), maxStackElements ceiling |
| `Os2Check` | `:ot_os2` | usWeightClass (1-1000), usWidthClass (1-9), fsSelection reserved bits, sTypo metrics signs, usWin metrics positive, panose non-zero |
| `NameTableCheck` | `:ot_name` | required nameIDs (1,2,4,6), PostScript name charset, version string format |
| `PostCheck` | `:ot_post` | version (1.0/2.0/2.5/3.0/4.0), italicAngle vs macStyle, isFixedPitch validity |
| `KernCheck` | `:ot_kern` | deprecation warning, GPOS migration advisory |

### Refactored `OpenTypeConformanceCheck`

Now owns ONLY cross-table rules (required tables per flavor, loca format consistency, numberOfHMetrics bounds). Per-table rules moved to their respective checks — no duplicate issues across checks.

### Profiles

The `:default` profile now runs **17 check axes**. New profiles:
- `:spec` — OpenType conformance (cross-table + 7 per-table = 8 checks)
- `:per_table` — only the 7 per-table checks

### Architecture

Same MECE pattern: one check per table concern, one check for cross-table. Each is a stateless module under `Audit::Check` with `.call(font) → Array<Issue>`. Adding a new table check = one file + one autoload + one registry entry (OCP).

## Test plan

- [x] `bundle exec rspec spec/fontisan/audit/` — 61 examples, 0 failures
- [x] `bundle exec rubocop lib/fontisan/audit/ spec/fontisan/audit/` — 0 offenses (24 files)
- [x] Smoke-tested all 7 per-table checks against TestTTF — 0 issues for well-formed font
- [x] Registry profiles: default=17, spec=8, per_table=7, structural=3, ots=1, layout=2, variable=1, hinting=1, web=2
