### PR TITLE
fix: implement variable font instance WOFF2 output (bug-fix #06)

### DIFF
--- a/TODO.bug-fixes/06-instance-woff2-output.md
+++ b/TODO.bug-fixes/06-instance-woff2-output.md
@@ -1,0 +1,24 @@
+# 06 — Variable font instance WOFF2 output
+
+## Priority
+P1
+
+## Problem
+`Variation::InstanceWriter` raises `Fontisan::Error` for WOFF2 output
+instead of writing the file. Variable font instances can be written
+to TTF, OTF, and WOFF but not WOFF2.
+
+## Goal
+Wire the existing WOFF2 encoder into the instance writer so
+`write(format: :woff2)` produces a valid WOFF2 file.
+
+## Approach
+The instance writer already calls `write_sfnt` for TTF/OTF and
+`write_woff` for WOFF. Add a `write_woff2` method that:
+1. Writes the SFNT tables to a temp TTF
+2. Loads the temp TTF
+3. Encodes to WOFF2 via `Converters::FormatConverter`
+
+## Acceptance criteria
+- `instance_writer.write(format: :woff2)` produces a valid WOFF2 file
+- The WOFF2 file decodes back to the correct instance tables

--- a/TODO.bug-fixes/README.md
+++ b/TODO.bug-fixes/README.md
@@ -6,12 +6,13 @@ Each file is `NN-short-name.md` where `NN` is the priority order.
 ## Priorities
 
 ### P0 — Correctness bugs (wrong data for specific font types)
-- [01 — CFF Expert charset placeholder](01-cff-expert-charsets.md)
-- [02 — CFF2 subroutine call stubs](02-cff2-subroutine-stubs.md)
+- [x] ~~[01 — CFF Expert charset placeholder](01-cff-expert-charsets.md)~~ ✓ Done (v0.4.40)
+- [x] ~~[02 — CFF2 subroutine call stubs](02-cff2-subroutine-stubs.md)~~ ✓ Done (v0.4.40)
 
 ### P1 — Feature gaps (non-functional code paths)
-- [03 — Variation subsetter placeholders](03-variation-subsetter-placeholders.md)
-- [04 — UFO image compile round-trip](04-ufo-image-compile-roundtrip.md)
+- [x] ~~[03 — Variation subsetter placeholders](03-variation-subsetter-placeholders.md)~~ ✓ Done (v0.4.40)
+- [x] ~~[04 — UFO image compile round-trip](04-ufo-image-compile-roundtrip.md)~~ ✓ Done (v0.4.40)
+- [06 — Variable font instance WOFF2 output](06-instance-woff2-output.md)
 
 ### P2 — Documentation cleanup
-- [05 — Stale CFF comment](05-stale-cff-comment.md)
+- [x] ~~[05 — Stale CFF comment](05-stale-cff-comment.md)~~ ✓ Done (v0.4.40)

--- a/lib/fontisan/variation/instance_writer.rb
+++ b/lib/fontisan/variation/instance_writer.rb
@@ -105,8 +105,7 @@ module Fontisan
         when :woff
           write_woff(output_tables, output_path, source_format)
         when :woff2
-          raise Fontisan::Error,
-                "WOFF2 output not yet implemented (planned for Phase 6)"
+          write_woff2(output_tables, output_path, source_format)
         end
       end
 
@@ -322,6 +321,29 @@ module Fontisan
       rescue StandardError => e
         raise Fontisan::Error,
               "Failed to write WOFF output: #{e.message}"
+      end
+
+      # Write WOFF2 format
+      #
+      # @param tables [Hash<String, String>] Output tables
+      # @param output_path [String] Output file path
+      # @param source_format [Symbol] Source format (for flavor detection)
+      # @return [Integer] Number of bytes written
+      def write_woff2(tables, output_path, source_format)
+        require "tmpdir"
+        sfnt_version = sfnt_version_for_format(source_format)
+
+        Dir.mktmpdir("fontisan-woff2-") do |dir|
+          temp_ttf = File.join(dir, "instance.ttf")
+          FontWriter.write_to_file(tables, temp_ttf, sfnt_version: sfnt_version)
+
+          font = FontLoader.load(temp_ttf)
+          woff2_data = Converters::Woff2Encoder.new.convert(font)
+          File.binwrite(output_path, woff2_data)
+        end
+      rescue StandardError => e
+        raise Fontisan::Error,
+              "Failed to write WOFF2 output: #{e.message}"
       end
 
       # Get SFNT version for output format

--- a/spec/fontisan/variation/instance_writer_spec.rb
+++ b/spec/fontisan/variation/instance_writer_spec.rb
@@ -231,13 +231,14 @@ RSpec.describe Fontisan::Variation::InstanceWriter do
   end
 
   describe "WOFF2 output" do
-    it "raises error for WOFF2 (not yet implemented)" do
-      writer = described_class.new(minimal_tables)
+    it "writes a valid WOFF2 file from real font tables" do
+      real_font = Fontisan::FontLoader.load("spec/fixtures/fonttools/TestTTF.ttf")
+      tables = real_font.table_data.transform_values { |t| t.is_a?(String) ? t : t.to_binary_s }
+      writer = described_class.new(tables)
       Tempfile.create(["test", ".woff2"]) do |file|
-        expect { writer.write(file.path) }.to raise_error(
-          Fontisan::Error,
-          /WOFF2 output not yet implemented/,
-        )
+        writer.write(file.path)
+        expect(File.exist?(file.path)).to be(true)
+        expect(File.size(file.path)).to be_positive
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes the last remaining functional gap in fontisan: variable font instance WOFF2 output.

**Problem:** `Variation::InstanceWriter` raised `Fontisan::Error("WOFF2 output not yet implemented")` for WOFF2 format, while TTF, OTF, and WOFF all worked.

**Fix:** Added `write_woff2` method that:
1. Writes SFNT tables to a temp TTF file via `FontWriter`
2. Loads the temp TTF as a real font via `FontLoader` (needed because the temp font stub doesn't support Woff2Encoder's internal table access)
3. Encodes to WOFF2 via `Converters::Woff2Encoder`

Also marks all 5 previous bug-fixes as done in TODO.bug-fixes/README.

## Test plan
- [x] Updated spec verifies WOFF2 output from real font tables
- [x] 31 instance writer specs pass, 0 failures
- [x] Rubocop clean on changed files
