### PR TITLE
fix: SvgToGlyf scales SVG coordinates to em-square using actual bounds

### DIFF
--- a/lib/fontisan/svg_to_glyf/assembler.rb
+++ b/lib/fontisan/svg_to_glyf/assembler.rb
@@ -7,7 +7,9 @@ module Fontisan
     #   path data + transforms
     #     → Path::Parser.parse → [Command]
     #     → Path::ContourBuilder.build → [Ufo::Contour]
-    #     → apply final transform (normalization · group transform)
+    #     → measure actual bounds (Path::Bounds)
+    #     → normalize using max(viewBox, actual bounds)
+    #     → apply final transform (normalizer · group transform)
     #     → round to Integer
     #     → Ufo::Glyph
     #
@@ -34,9 +36,12 @@ module Fontisan
       def build_from_path_data(path_data, codepoint: nil, name: nil,
                                viewbox: nil, transform: nil)
         viewbox ||= { width: @upm, height: @upm }
-        final = normalizer_for(**viewbox).final_transform(transform || Geometry::AffineTransform.identity)
-        contours = build_contours(path_data, final)
-        assemble_glyph(name || glyph_name_for(codepoint), contours, codepoint)
+        commands = Path::Parser.parse(path_data)
+        contours = Path::ContourBuilder.new.build(commands)
+        norm_dims = normalization_dimensions(contours, **viewbox)
+        final = normalizer_for(**norm_dims).final_transform(transform || Geometry::AffineTransform.identity)
+        transformed = contours.map { |c| transform_contour(c, final) }
+        assemble_glyph(name || glyph_name_for(codepoint), transformed, codepoint)
       end
 
       # Build a glyph from an SVG file.
@@ -74,17 +79,32 @@ module Fontisan
       private
 
       def build_from_doc_path(data, group_transform, doc, codepoint)
-        final = normalizer_for(width: doc.viewbox_width,
-                               height: doc.viewbox_height)
-          .final_transform(group_transform)
-        contours = build_contours(data, final)
-        assemble_glyph(glyph_name_for(codepoint), contours, codepoint)
+        commands = Path::Parser.parse(data)
+        contours = Path::ContourBuilder.new.build(commands)
+        norm_dims = normalization_dimensions(
+          contours,
+          width: doc.viewbox_width,
+          height: doc.viewbox_height,
+        )
+        final = normalizer_for(**norm_dims).final_transform(group_transform)
+        transformed = contours.map { |c| transform_contour(c, final) }
+        assemble_glyph(glyph_name_for(codepoint), transformed, codepoint)
       end
 
-      def build_contours(path_data, final_transform)
-        commands = Path::Parser.parse(path_data)
-        contours = Path::ContourBuilder.new.build(commands)
-        contours.map { |c| transform_contour(c, final_transform) }
+      # Compute the normalization dimensions from both the declared
+      # viewBox and the actual contour bounds. Uses the max of each
+      # so coordinates outside the viewBox are scaled correctly.
+      #
+      # @param contours [Array<Ufo::Contour>]
+      # @param width [Float] declared viewBox width
+      # @param height [Float] declared viewBox height
+      # @return [Hash{Symbol=>Float}] :width, :height for the Normalizer
+      def normalization_dimensions(contours, width:, height:)
+        bounds = Path::Bounds.measure(contours)
+        {
+          width: [bounds.max_x, width.to_f].max,
+          height: [bounds.max_y, height.to_f].max,
+        }
       end
 
       def transform_contour(contour, transform)

--- a/lib/fontisan/svg_to_glyf/path.rb
+++ b/lib/fontisan/svg_to_glyf/path.rb
@@ -9,6 +9,7 @@ module Fontisan
       autoload :Parser, "fontisan/svg_to_glyf/path/parser"
       autoload :State, "fontisan/svg_to_glyf/path/state"
       autoload :ContourBuilder, "fontisan/svg_to_glyf/path/contour_builder"
+      autoload :Bounds, "fontisan/svg_to_glyf/path/bounds"
     end
   end
 end

--- a/lib/fontisan/svg_to_glyf/path/bounds.rb
+++ b/lib/fontisan/svg_to_glyf/path/bounds.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SvgToGlyf
+    module Path
+      # Measures the bounding box of an array of Ufo::Contour objects.
+      #
+      # SvgToGlyf's Normalizer scales coordinates using the SVG viewBox
+      # dimensions. But SVG path data can have coordinates outside the
+      # viewBox (valid SVG — they're just visually clipped). Without
+      # measuring the actual contour bounds, those coordinates pass
+      # through at the wrong scale, producing glyphs 2-11x too large.
+      #
+      # Bounds solves this by computing the real coordinate range from
+      # the built contours. The Assembler uses Bounds to determine the
+      # correct normalization dimensions.
+      #
+      class Bounds
+        attr_reader :min_x, :min_y, :max_x, :max_y
+
+        def initialize(min_x:, min_y:, max_x:, max_y:)
+          @min_x = min_x.to_f
+          @min_y = min_y.to_f
+          @max_x = max_x.to_f
+          @max_y = max_y.to_f
+        end
+
+        # @param contours [Array<Fontisan::Ufo::Contour>]
+        # @return [Bounds]
+        def self.measure(contours)
+          points = contours.flat_map(&:points)
+          return empty if points.empty?
+
+          xs = points.map(&:x)
+          ys = points.map(&:y)
+          new(min_x: xs.min, min_y: ys.min, max_x: xs.max, max_y: ys.max)
+        end
+
+        # @return [Bounds] a zero-extent bounds at the origin
+        def self.empty
+          new(min_x: 0, min_y: 0, max_x: 0, max_y: 0)
+        end
+
+        def width
+          max_x - min_x
+        end
+
+        def height
+          max_y - min_y
+        end
+
+        def empty?
+          width.zero? && height.zero?
+        end
+      end
+    end
+  end
+end

--- a/spec/fontisan/svg_to_glyf/bounds_spec.rb
+++ b/spec/fontisan/svg_to_glyf/bounds_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Fontisan::SvgToGlyf::Path::Bounds do
+  describe ".measure" do
+    it "computes the bounding box of contour points" do
+      contours = [
+        Fontisan::Ufo::Contour.new([
+                                     Fontisan::Ufo::Point.new(x: 100, y: 200, type: "line"),
+                                     Fontisan::Ufo::Point.new(x: 300, y: 400, type: "line"),
+                                   ]),
+        Fontisan::Ufo::Contour.new([
+                                     Fontisan::Ufo::Point.new(x: 50, y: 600, type: "line"),
+                                     Fontisan::Ufo::Point.new(x: 500, y: 50, type: "line"),
+                                   ]),
+      ]
+
+      bounds = described_class.measure(contours)
+      expect(bounds.min_x).to eq(50)
+      expect(bounds.min_y).to eq(50)
+      expect(bounds.max_x).to eq(500)
+      expect(bounds.max_y).to eq(600)
+    end
+
+    it "returns empty bounds for no contours" do
+      bounds = described_class.measure([])
+      expect(bounds).to be_empty
+    end
+
+    it "returns empty bounds for contours with no points" do
+      contours = [Fontisan::Ufo::Contour.new([])]
+      bounds = described_class.measure(contours)
+      expect(bounds).to be_empty
+    end
+
+    it "handles negative coordinates" do
+      contours = [
+        Fontisan::Ufo::Contour.new([
+                                     Fontisan::Ufo::Point.new(x: -100, y: -200, type: "line"),
+                                     Fontisan::Ufo::Point.new(x: 300, y: -50, type: "line"),
+                                   ]),
+      ]
+
+      bounds = described_class.measure(contours)
+      expect(bounds.min_x).to eq(-100)
+      expect(bounds.min_y).to eq(-200)
+      expect(bounds.max_x).to eq(300)
+      expect(bounds.max_y).to eq(-50)
+    end
+  end
+
+  describe "#width and #height" do
+    it "computes width and height from the bounding box" do
+      bounds = described_class.new(min_x: 10, min_y: 20, max_x: 110, max_y: 270)
+      expect(bounds.width).to eq(100)
+      expect(bounds.height).to eq(250)
+    end
+  end
+
+  describe "#empty?" do
+    it "is true for zero-extent bounds" do
+      expect(described_class.empty).to be_empty
+    end
+
+    it "is false for non-zero bounds" do
+      bounds = described_class.new(min_x: 0, min_y: 0, max_x: 1, max_y: 1)
+      expect(bounds).not_to be_empty
+    end
+  end
+
+  describe ".empty" do
+    it "returns bounds at the origin with zero extent" do
+      bounds = described_class.empty
+      expect(bounds.min_x).to eq(0)
+      expect(bounds.min_y).to eq(0)
+      expect(bounds.max_x).to eq(0)
+      expect(bounds.max_y).to eq(0)
+    end
+  end
+end

--- a/spec/fontisan/svg_to_glyf/integration_spec.rb
+++ b/spec/fontisan/svg_to_glyf/integration_spec.rb
@@ -75,6 +75,33 @@ RSpec.describe "SvgToGlyf integration" do
         expect(types).to include("offcurve")
         expect(types).to include("curve")
       end
+
+      it "scales coordinates exceeding the viewBox to fit the em-square" do
+        glyph = described_class.convert(
+          "M 0 0 L 5000 0 L 5000 5000 L 0 5000 Z",
+          upm: 1000,
+          codepoint: 0x41,
+          viewbox: { width: 1000, height: 1000 },
+        )
+        pts = glyph.contours.first.points
+        all_x = pts.map(&:x)
+        all_y = pts.map(&:y)
+        expect(all_x.max).to be <= 1000
+        expect(all_y.max).to be <= 1000
+        expect(all_x.min).to be >= 0
+        expect(all_y.min).to be >= 0
+      end
+
+      it "preserves coordinates when they are within the viewBox" do
+        glyph = described_class.convert(
+          "M 0 0 L 500 0 L 500 700 L 0 700 Z",
+          upm: 1000,
+          codepoint: 0x41,
+          viewbox: { width: 1000, height: 1000 },
+        )
+        pts = glyph.contours.first.points
+        expect(pts.map { |p| [p.x, p.y] }).to eq([[0, 1000], [500, 1000], [500, 300], [0, 300]])
+      end
     end
 
     describe ".from_svg_file" do


### PR DESCRIPTION
## Summary

`SvgToGlyf`'s Normalizer used the SVG `viewBox` dimensions to compute the coordinate-to-font-units scale. But SVG path data can have coordinates outside the viewBox (valid SVG — they're just visually clipped). Coordinates up to **11× the viewBox** passed through unscaled, producing glyphs with extreme coordinates (yMax=11160 in a 1000-UPM font).

This caused **960 phantom glyphs** in essenfont's SMP face — synthetic SVG-generated donor fonts (Gurung Khema, Nyiakeng Puachue Hmong, Tulu Tigalari, etc.) had path coordinates far exceeding their declared viewBox, producing glyphs 2-11× too large. These inflated the face's `head.bbox` and distorted rendering of all glyphs in the face.

### Fix

New `Path::Bounds` class measures the actual bounding box of built contours. The `Assembler` uses `max(actual_bounds, viewBox)` for the Normalizer dimensions, ensuring all coordinates are scaled to the em-square.

### Architecture

- **`Path::Bounds`** (new): value object with single responsibility — measure contour extents. Registered via autoload in `path.rb`.
- **`Assembler`** (modified): new `normalization_dimensions` method computes the correct width/height from both the declared viewBox and the measured contour bounds.
- **`Normalizer`** (unchanged): OCP — closed for modification. Its interface stays the same.
- No `require_relative`, no `send`, no `instance_variable_get`, no `respond_to`.

### Specs

- 8 new `Bounds` specs: measure contours, empty case, negative coordinates, width/height
- 2 new integration specs: coordinates exceeding viewBox get scaled; coordinates within viewBox preserved
- All 88 SvgToGlyf specs pass, RuboCop clean

## Test plan

- [x] `bundle exec rspec spec/fontisan/svg_to_glyf/` — 88 examples, 0 failures
- [x] `bundle exec rubocop lib/fontisan/svg_to_glyf/ spec/fontisan/svg_to_glyf/` — clean
- [x] No AI attribution
