### PR TITLE
refactor: encapsulation, model-driven cleanup, SfntSource module (TODOs 12-19)

### DIFF
--- a/TODO.bug-fixes/12-type1-generators-duck-typing.md
+++ b/TODO.bug-fixes/12-type1-generators-duck-typing.md
@@ -1,0 +1,80 @@
+# 12 — Type 1 generators duck-typing cleanup
+
+## Priority
+P0
+
+## Problem
+50+ `respond_to?` calls in `lib/fontisan/type1/` check for methods that
+don't exist on the BinData Name/OS/2/Post tables. Every check returns
+false and the generators silently fall through to empty/unknown values.
+
+## Sites (by file)
+
+### `pfm_generator.rb` (10)
+- :506 `respond_to?(:copyright)` — Name table has no `#copyright`
+- :521 `respond_to?(:full_font_name)` — Name table has no `#full_font_name`
+- :523 `respond_to?(:font_family)` — Name table has no `#font_family`
+- :525 `respond_to?(:postscript_name)` — Name table has no `#postscript_name`
+- :541/:543 `respond_to?(:us_weight_class)` / `respond_to?(:weight_class)` — OS/2 has neither
+- :372/:374 `respond_to?(:cap_height)` / `respond_to?(:s_typo_ascender)` — same
+- :382 `respond_to?(:x_height)` — OS/2 has no `#x_height`
+- :567 `respond_to?(:is_fixed_pitch)` — Post has no `#is_fixed_pitch`
+- :148 `respond_to?(:unicode_mappings)` — Cmap DOES have this; check unnecessary
+
+### `pfa_generator.rb` (6)
+- :137/:142 `respond_to?(:version_string)` / `:copyright` on Name
+- :164 `respond_to?(:typo_ascender)` on OS/2
+- :181/:189 `respond_to?(:weight_class)` on OS/2
+- :307 `respond_to?(:points)` on glyph — same broken pattern as #20
+
+### `pfb_generator.rb` (3)
+- :162/:170 `respond_to?(:weight_class)` on OS/2
+- :276 `respond_to?(:points)` on glyph
+
+### `afm_generator.rb` (16)
+- :170/:173 `respond_to?(:underline_position)` / `:underline_thickness` on Post
+- :255/:257 `respond_to?(:us_weight_class)` / `:weight_class`
+- :283 `respond_to?(:italic_angle)`
+- :297 `respond_to?(:is_fixed_pitch)`
+- :311/:323 `respond_to?(:version_string)` / `:copyright` on Name
+- :339/:341/:343 `respond_to?(:unicode_mappings)` / `:unicode_bmp_mapping` / `:subtables` on Cmap
+- :346/:348/:352 subtable field probes
+- :368/:370/:371 `respond_to?(:font_bounding_box)` / `:x_min` / `:y_min` on Head
+- :393 `respond_to?(:parse_with_context)` on Loca
+- :401 `respond_to?(:glyph_for)` on Glyf
+- :405/:407/:408 `respond_to?(:bounding_box)` / `:x_min` etc. on glyph
+
+### `inf_generator.rb` (10)
+- :187/:202/:217/:269/:281/:293/:305 Name/Post field probes
+- :229/:231 OS/2 weight class probes
+- :257 `respond_to?(:italic_angle)`
+
+### `generator.rb` (1)
+- :203 `respond_to?(:postscript_name)` on Name
+
+### `decryptor.rb` (1)
+- :115 `respond_to?(:b)` on String — always true for Ruby strings
+
+## Approach
+1. Add a `NameIds` constants module if not present (NAME_COPYRIGHT=0,
+   NAME_FONT_FAMILY=1, NAME_FULL_FONT_NAME=4, NAME_VERSION=5,
+   NAME_POSTSCRIPT_NAME=6, NAME_MANUFACTURER=8, NAME_LICENSE=13).
+2. Replace `name_table.respond_to?(:X) ? name_table.X(1) : ""` with
+   `name_table&.english_name(NAME_ID_X) || ""`.
+3. For OS/2 fields, declare the BinData field accessor (most already
+   exist) and access directly: `os2&.us_weight_class`.
+4. For Post fields, same: `post&.italic_angle`.
+5. For Cmap, `cmap.unicode_mappings` is the documented API — drop the
+   `respond_to?` and just call it (nil guard at the boundary).
+6. For Loca parse_with_context, Loca responds to it always — drop the
+   check.
+7. For glyph bounding boxes, use the typed SimpleGlyph/CompoundGlyph
+   `bounding_box` method (always present).
+8. For `glyph.respond_to?(:points)`, see TODO 15 — the underlying bug
+   is fixed there.
+
+## Acceptance criteria
+- 0 `respond_to?` in `lib/fontisan/type1/` (excluding `respond_to_missing?`)
+- All Type 1 generation specs pass with real Libertinus fixture
+- AFM/PFM/PFA/PFB/INF output now contains real Name table values
+  (previously was empty for most fields)

--- a/TODO.bug-fixes/13-hint-extractor-duck-typing.md
+++ b/TODO.bug-fixes/13-hint-extractor-duck-typing.md
@@ -1,0 +1,30 @@
+# 13 — Hint extractor duck-typing cleanup
+
+## Priority
+P1
+
+## Problem
+15 `respond_to?` calls in `lib/fontisan/hints/postscript_hint_extractor.rb`
+probe PrivateDict fields that are always declared on the BinData record.
+Plus 2 sites in `postscript_hint_extractor.rb:60-62` that probe Charstring
+shape (`:data` vs `:bytes`).
+
+## Sites
+- :60/:62 `charstring.respond_to?(:data)` / `:bytes` — Charstring has one shape
+- :292/:296/:300/:304 `respond_to?(:blue_values)` / `:other_blues` / `:family_blues` / `:family_other_blues`
+- :308/:312/:316 `respond_to?(:blue_scale)` / `:blue_shift` / `:blue_fuzz`
+- :320/:324 `respond_to?(:std_hw)` / `:std_vw`
+- :328/:332 `respond_to?(:stem_snap_h)` / `:stem_snap_v`
+- :336/:340 `respond_to?(:force_bold)` / `:language_group`
+
+## Approach
+1. Verify which fields are declared on `Tables::Cff::PrivateDict`.
+2. For declared fields, drop the `respond_to?` and read directly with
+   nil-coalescence: `private_dict.blue_values`.
+3. For undeclared fields (rare BinData optional), either declare them
+   with a default `nil` or remove the dead branch.
+4. For Charstring, standardize on one accessor (probably `#data`).
+
+## Acceptance criteria
+- 0 `respond_to?` in `lib/fontisan/hints/`
+- All hint extraction specs pass

--- a/TODO.bug-fixes/14-font-interface-type-checks.md
+++ b/TODO.bug-fixes/14-font-interface-type-checks.md
@@ -1,0 +1,82 @@
+# 14 — Font interface type checks
+
+## Priority
+P1
+
+## Problem
+~30 `respond_to?` calls probe whether an object is font-like by
+checking for `:table`, `:tables`, `:table_data`, `:has_table?`,
+`:header`, `:cff?`. The codebase has a typed font hierarchy
+(`SfntFont`, `TrueTypeFont`, `OpenTypeFont`, `WoffFont`, `Woff2Font`,
+`Type1Font`) — these should be checked with `is_a?`.
+
+## Sites (by category)
+
+### Collection builders
+- `collection/builder.rb:61` `respond_to?(:table_data)`
+- `collection/dfont_builder.rb:47` `respond_to?(:table_data)`
+
+### Subset
+- `subset/builder.rb:115` `respond_to?(:table)`
+- `subset/table_strategy/cff2.rb` — already cleaned
+
+### Converters
+- `converters/woff2_encoder.rb:221` `respond_to?(:table_names)`
+- `converters/woff2_encoder.rb:250` `respond_to?(:has_table?)`
+- `converters/woff2_encoder.rb:313/:315/:317` font shape probes
+- `converters/outline_converter.rb:278/:282` `respond_to?(:tables)` / `:table`
+- `converters/table_copier.rb:33/:37/:76/:80` font shape probes
+- `converters/woff_writer.rb:116/:305` font shape / `:cff?`
+- `converters/type1_converter.rb:115/:160/:222/:723-749` font shape + font_info probes
+- `converters/format_converter.rb:415` `respond_to?(:table)`
+
+### Stitcher
+- `stitcher/source.rb:83` `respond_to?(:has_table?)`
+- `stitcher/source.rb:193/:220/:228` table parse probes
+- `stitcher/source.rb:287/:289/:375/:377` glyph type probes (see TODO 15)
+
+### Variable
+- `variable/delta_aplicator.rb:263` `respond_to?(:table_data)`
+- `variable/static_font_builder.rb:80` `respond_to?(:tables)`
+- `variation/variation_preserver.rb:151/:152` `respond_to?(:has_table?)` / `:table_data`
+
+### Commands
+- `commands/validate_command.rb:216` `respond_to?(:table)`
+- `commands/pack_command.rb:177/:188` `respond_to?(:header)`
+
+### Validation
+- `validation/collection_validator.rb:249/:259` `respond_to?(:has_table?)`
+
+### Woff2 table transformer
+- `woff2/table_transformer.rb:153` `respond_to?(:table_data)`
+
+### Other
+- `commands/unpack_command.rb:210` `respond_to?(:table)`
+
+## Approach
+1. Define `SfntFont` as the type for any TrueType/OpenType/WOFF/WOFF2
+   font (already the base class).
+2. Define `Type1Font` similarly (already exists).
+3. Replace `respond_to?(:table)` / `:tables` / `:table_data` / `:has_table?`
+   with `is_a?(SfntFont)` (or `is_a?(Type1Font)` where applicable).
+4. Where the input legitimately can be either SfntFont or Type1Font,
+   accept a union: `font.is_a?(SfntFont) || font.is_a?(Type1Font)`.
+5. For `respond_to?(:header)` in pack_command, the SfntFont exposes
+   `sfnt_version` directly (already used elsewhere).
+6. For converters/type1_converter.rb font_info probes, the `font_info`
+   is always a `Type1::FontInfo` record — replace with `is_a?`.
+
+## Affected specs
+- spec/fontisan/collection/builder_spec.rb (uses doubles)
+- spec/fontisan/subset/builder_spec.rb (uses doubles)
+- spec/fontisan/converters/* (most use real fonts; check each)
+- spec/fontisan/stitcher/* (check)
+
+The collection/builder_spec and subset/builder_spec were identified in
+PR #135 as using doubles that block the is_a?(SfntFont) migration.
+Migrate them to real SfntFont instances or SimpleDelegator-based fakes.
+
+## Acceptance criteria
+- 0 `respond_to?(:table)` / `:tables` / `:table_data` / `:has_table?` /
+  `:header` / `:cff?` in `lib/fontisan/`
+- All affected specs pass with real fonts or SimpleDelegator-based fakes

--- a/TODO.bug-fixes/15-glyph-type-checks-and-simple-glyph-points-bug.md
+++ b/TODO.bug-fixes/15-glyph-type-checks-and-simple-glyph-points-bug.md
@@ -1,0 +1,49 @@
+# 15 — Glyph type checks + SimpleGlyph#points bug
+
+## Priority
+P0
+
+## Problem
+~15 `respond_to?` calls probe glyph shape (`:simple?`, `:compound?`,
+`:points`, `:bounding_box`). Plus the latent bug discovered in PR #135:
+`Type1::TTFToType1Converter#extract_points` calls `glyph.points.each`
+but `Tables::SimpleGlyph` has no `points` method. The `respond_to?`
+check silently masked this for years.
+
+## Sites
+- `type1/ttf_to_type1_converter.rb:140` `respond_to?(:points)` — masks bug
+- `type1/pfa_generator.rb:307` `respond_to?(:points)` — same bug
+- `type1/pfb_generator.rb:276` `respond_to?(:points)` — same bug
+- `ufo/convert/from_bin_data.rb:192/:312/:323/:325` `respond_to?(:simple?)` / `:compound?`
+- `ufo/convert/from_bin_data.rb:361` `respond_to?(:glyph_name)`
+- `stitcher/source.rb:287/:289/:375/:377` `respond_to?(:simple?)` / `:compound?`
+- `hints/truetype_hint_extractor.rb:66` `respond_to?(:instructions)`
+- `tables/glyf.rb:243` already fixed in PR #135
+
+## SimpleGlyph API surface (current)
+- `num_contours`, `num_points`
+- `points_for_contour(index)` → Array<Hash{x,y,on_curve}>
+- `point_at(index)`, `on_curve?(index)`
+- `bounding_box` → [x_min, y_min, x_max, y_max]
+- `simple?`, `compound?`, `empty?`
+
+## Approach
+1. Add `Tables::SimpleGlyph#points` — returns a flat Array<Hash> across
+   all contours. Single source of truth, lazy-built.
+2. Add `Tables::CompoundGlyph#points` — returns the union of component
+   points (or empty if no components).
+3. Replace all `respond_to?(:points)` with `is_a?(Tables::SimpleGlyph)`.
+4. Replace `respond_to?(:simple?)` / `:compound?` with `is_a?` against
+   `Tables::SimpleGlyph`, `Tables::CompoundGlyph`, `Tables::Cff::CFFGlyph`.
+5. For `:bounding_box`, the typed glyph classes all have it — drop the
+   check.
+6. For `:glyph_name` on Post glyph records, declare it as a method (or
+   always-present BinData field).
+7. For `:instructions` on SimpleGlyph, declare it.
+
+## Acceptance criteria
+- 0 `respond_to?(:simple?)` / `:compound?` / `:points` / `:bounding_box` /
+  `:glyph_name` / `:instructions` in `lib/fontisan/`
+- Type 1 conversion now produces non-empty CharString data for simple
+  glyphs (the previously-broken `extract_points` path)
+- All Type 1 specs pass

--- a/TODO.bug-fixes/16-variation-table-checks.md
+++ b/TODO.bug-fixes/16-variation-table-checks.md
@@ -1,0 +1,31 @@
+# 16 — Variation table checks
+
+## Priority
+P2
+
+## Problem
+~15 `respond_to?` calls in `lib/fontisan/variation/` probe variation
+table shape (`:item_variation_store`, `:region_list`, `:num_axes`,
+`:advance_height_delta_set`, etc.). All variation tables are typed
+BinData records — these checks should be `is_a?` or direct calls.
+
+## Sites
+- `variation/validator.rb:106/:136/:142/:144/:199/:211/:275/:278/:281/:286`
+- `variation/metrics_adjuster.rb:230/:233/:310`
+- `variable/metric_delta_processor.rb:224/:229/:234`
+- `variable/delta_applicator.rb:296`
+
+## Approach
+1. For each variation table (Fvar, Hvar, Vvar, Mvar, Cff2, ItemVariationStore),
+   verify the BinData-declared fields and methods.
+2. Replace `respond_to?(:item_variation_store)` with `is_a?(Tables::Hvar)`
+   or `is_a?(Tables::Vvar)` etc., then call `.item_variation_store`
+   directly.
+3. For optional fields (rare in variation tables), declare them with
+   defaults on the BinData record.
+4. For `metrics_adjuster.rb:310` `respond_to?(:number_of_h_metrics=)`,
+   Hhea is a BinData record with a declared writer — drop the check.
+
+## Acceptance criteria
+- 0 `respond_to?` in `lib/fontisan/variation/` and `lib/fontisan/variable/`
+- All variation specs pass

--- a/TODO.bug-fixes/17-ufo-and-stitcher-cleanup.md
+++ b/TODO.bug-fixes/17-ufo-and-stitcher-cleanup.md
@@ -1,0 +1,32 @@
+# 17 — UFO convert and Stitcher cleanup
+
+## Priority
+P2
+
+## Problem
+~10 `respond_to?` calls in `ufo/convert/from_bin_data.rb` probe BinData
+table shape. Plus 1 site in `ufo/compile/fvar.rb`.
+
+## Sites
+- `ufo/convert/from_bin_data.rb:64/:82` Name records access
+- `ufo/convert/from_bin_data.rb:103/:105` Post italic_angle
+- `ufo/convert/from_bin_data.rb:131` Cmap unicode_mappings
+- `ufo/convert/from_bin_data.rb:149/:155` Hmtx parse/metric
+- `ufo/convert/from_bin_data.rb:172` Loca parse
+- `ufo/convert/from_bin_data.rb:192/:312/:323/:325` Glyph type (see TODO 15)
+- `ufo/convert/from_bin_data.rb:361` Post glyph_name
+- `ufo/compile/fvar.rb:23/:24` Info axes/named_instances
+- `stitcher/source.rb:83/:193/:220/:228/:287/:289/:375/:377` (see TODO 14/15)
+
+## Approach
+1. Replace `name_table.respond_to?(:name_records)` with `is_a?(Tables::Name)`.
+2. Replace `post.respond_to?(:italic_angle)` with `is_a?(Tables::Post)`.
+3. Replace `cmap_table.respond_to?(:unicode_mappings)` with `is_a?(Tables::Cmap)`.
+4. Replace `hmtx.respond_to?(:parse_with_context)` with `is_a?(Tables::Hmtx)`.
+5. Replace `loca.respond_to?(:parse_with_context)` with `is_a?(Tables::Loca)`.
+6. For `ufo/compile/fvar.rb`, the `font.info` is always a `Ufo::Info`.
+   Check `Ufo::Info#axes` exists; if not, add it.
+
+## Acceptance criteria
+- 0 `respond_to?` in `lib/fontisan/ufo/convert/` and `lib/fontisan/ufo/compile/`
+- 0 stitcher/source.rb respond_to? (split across TODO 14/15)

--- a/TODO.bug-fixes/18-generic-value-and-io-checks.md
+++ b/TODO.bug-fixes/18-generic-value-and-io-checks.md
@@ -1,0 +1,56 @@
+# 18 — Generic value and IO checks
+
+## Priority
+P3
+
+## Problem
+~20 `respond_to?` calls probe generic value shape (`:to_i`, `:bytesize`,
+`:to_binary_s`, `:empty?`, `:b`) or IO capabilities (`:seek`, `:rewind`).
+Some are valid duck-typing at system boundaries; others are dead
+defensive code.
+
+## Sites
+### Generic value conversion
+- `export/ttx_generator.rb:67/:474` `respond_to?(:to_i)`
+- `export/transformers/name_transformer.rb:47`
+- `export/transformers/post_transformer.rb:36`
+- `export/transformers/head_transformer.rb:45`
+- `export/transformers/maxp_transformer.rb:48`
+- `export/transformers/os2_transformer.rb:104`
+- `export/transformers/hhea_transformer.rb:44`
+- `export/transformers/font_to_ttx.rb:106`
+- `export/exporter.rb:184/:204/:209` `respond_to?(:to_binary_s)` / `:checksum`
+- `export/ttx_generator.rb:296/:435`
+
+### String/bytes shape
+- `utilities/padding.rb:30/:55` `respond_to?(:bytesize)`
+- `utilities/brotli_wrapper.rb:136` `respond_to?(:bytesize)`
+- `type1/decryptor.rb:115` `respond_to?(:b)` — String always has `.b`
+
+### IO capability
+- `binary/base_record.rb:27/:37` `respond_to?(:empty?)` / `:rewind`
+- `tables/cff/index.rb:61` `respond_to?(:seek)`
+
+### Charstring shape
+- `hints/postscript_hint_extractor.rb:60/:62` (see TODO 13)
+
+### Pattern matching
+- `optimizers/charstring_rewriter.rb:130` `respond_to?(:positions)`
+
+## Approach
+1. For `respond_to?(:to_i)`, replace with `Integer(value) rescue value`
+   — accepts Integer-coercible values, falls back to original.
+2. For `respond_to?(:bytesize)`, narrow the type at the boundary: accept
+   `String` only, call `.bytesize` directly.
+3. For `respond_to?(:to_binary_s)`, all BinData records respond to it.
+   Drop the check; if a non-BinData object is passed, fix the caller.
+4. For `respond_to?(:b)` on String, just call `.b` (String always has it).
+5. For IO `respond_to?(:seek)` / `:rewind`, accept `IO` / `StringIO`
+   only. Convert String inputs to StringIO at the boundary.
+6. For `respond_to?(:empty?)`, the BinData array always responds — drop.
+
+## Acceptance criteria
+- 0 unnecessary `respond_to?` in `lib/fontisan/export/`, `lib/fontisan/utilities/`,
+  `lib/fontisan/binary/`
+- Where duck-typing is genuinely needed at a system boundary, document
+  it with a comment

--- a/TODO.bug-fixes/19-serialization-migration.md
+++ b/TODO.bug-fixes/19-serialization-migration.md
@@ -1,0 +1,52 @@
+# 19 — Hand-rolled serialization migration to lutaml-model
+
+## Priority
+P2
+
+## Problem
+5 sites hand-roll `to_h` / `to_hash` on model classes, bypassing
+lutaml-model's declarative serialization. Violates the absolute rule:
+"NEVER write `def to_h`, `def to_hash`, `def from_h`, `def from_hash` on
+a model class."
+
+## Sites
+- `lib/fontisan/tables/hmtx.rb:54` `def to_h` — manual hash from instance vars
+- `lib/fontisan/tables/cff/dict.rb:112` `def to_h` — manual hash
+- `lib/fontisan/type1/generator.rb:167` `def to_hash` — manual result hash
+- `lib/fontisan/type1/conversion_options.rb:105` `def to_hash` — manual hash
+- `lib/fontisan/ufo/point.rb:32` `def to_h` — manual hash for GLIF output
+
+## Approach
+For each model class:
+
+1. Make it inherit from `Lutaml::Model::Serializable`.
+2. Replace instance variables with `attribute :name, :type` declarations.
+3. Replace `to_h` / `to_hash` with a `key_value do ... end` mapping block.
+4. Callers use `model.to_hash` (framework-provided) instead of
+   hand-rolled `to_h`.
+
+### Special considerations
+
+- **`Ufo::Point#to_h`**: produces a Hash for GLIF XML output. The
+  lutaml-model `key_value` mapping with `:x`, `:y`, `:type`, `:smooth`
+  fields handles this. The `smooth: true` only-if-set behavior is
+  modeled via lutaml-model's optional attribute pattern.
+
+- **`Type1::Generator#to_hash`**: this is a *result* hash, not a model
+  serialization. Rename to `#to_result_hash` (or expose individual
+  accessors) to clarify it's not lutaml-model-shaped. OR convert the
+  result to a `Models::Type1GenerationResult` model.
+
+- **`Type1::ConversionOptions#to_hash`**: this is a value object
+  representing conversion options. Migrate to lutaml-model with
+  `attribute` declarations for each option.
+
+- **`Tables::Hmtx#to_h`**: BinData records already provide `snapshot`.
+  Remove the hand-rolled `to_h` and let callers use `snapshot`.
+
+- **`Tables::Cff::Dict#to_h`**: same — use `snapshot`.
+
+## Acceptance criteria
+- 0 `def to_h` / `def to_hash` in `lib/fontisan/` (excluding lutaml-model
+  framework methods)
+- All serialization goes through `lutaml-model`

--- a/TODO.bug-fixes/README.md
+++ b/TODO.bug-fixes/README.md
@@ -23,3 +23,13 @@ Each file is `NN-short-name.md` where `NN` is the priority order.
 - [x] ~~[07 — Encapsulation violations (instance_variable_get/set, send to private)](07-encapsulation-violations.md)~~ ✓ Done (v0.4.42)
 - [x] ~~[08 — respond_to? duck typing violations](08-respond-to-violations.md)~~ ✓ Done (v0.4.42)
 - [x] ~~[11 — Remaining respond_to? violations](11-remaining-respond-to.md)~~ ✓ Done
+
+### P3 — Encapsulation and architecture cleanup (post-#135 audit)
+- [ ] [12 — Type 1 generators duck-typing](12-type1-generators-duck-typing.md)
+- [ ] [13 — Hint extractor duck-typing](13-hint-extractor-duck-typing.md)
+- [ ] [14 — Font interface type checks](14-font-interface-type-checks.md)
+- [ ] [15 — Glyph type checks + SimpleGlyph#points bug](15-glyph-type-checks-and-simple-glyph-points-bug.md)
+- [ ] [16 — Variation table checks](16-variation-table-checks.md)
+- [ ] [17 — UFO and Stitcher cleanup](17-ufo-and-stitcher-cleanup.md)
+- [ ] [18 — Generic value and IO checks](18-generic-value-and-io-checks.md)
+- [ ] [19 — Hand-rolled serialization migration to lutaml-model](19-serialization-migration.md)

--- a/lib/fontisan.rb
+++ b/lib/fontisan.rb
@@ -116,6 +116,7 @@ module Fontisan
   autoload :OpenTypeFontExtensions, "fontisan/open_type_font_extensions"
   autoload :OutlineExtractor, "fontisan/outline_extractor"
   autoload :SfntFont, "fontisan/sfnt_font"
+  autoload :SfntSource, "fontisan/sfnt_source"
   autoload :SfntTable, "fontisan/sfnt_table"
   autoload :SfntBuilder, "fontisan/sfnt_builder"
   autoload :Stitcher, "fontisan/stitcher"

--- a/lib/fontisan/collection/builder.rb
+++ b/lib/fontisan/collection/builder.rb
@@ -56,11 +56,9 @@ module Fontisan
         end
         raise ArgumentError, "fonts must be an array" unless fonts.is_a?(Array)
 
-        # TODO: replace respond_to? duck-type with is_a?(SfntFont) once
-        # the builder spec suite is migrated off doubles (see audit).
-        unless fonts.all? { |f| f.respond_to?(:table_data) }
+        unless fonts.all?(SfntSource)
           raise ArgumentError,
-                "all fonts must respond to table_data"
+                "all fonts must be SfntSource instances (TrueTypeFont, OpenTypeFont, WoffFont, Woff2Font)"
         end
 
         @fonts = fonts

--- a/lib/fontisan/collection/dfont_builder.rb
+++ b/lib/fontisan/collection/dfont_builder.rb
@@ -42,10 +42,8 @@ module Fontisan
         end
         raise ArgumentError, "fonts must be an array" unless fonts.is_a?(Array)
 
-        # TODO: replace respond_to? duck-type with is_a?(SfntFont) once
-        # the dfont builder spec suite is migrated off doubles (see audit).
-        unless fonts.all? { |f| f.respond_to?(:table_data) }
-          raise ArgumentError, "all fonts must respond to table_data"
+        unless fonts.all?(SfntSource)
+          raise ArgumentError, "all fonts must be SfntSource instances"
         end
 
         @fonts = fonts

--- a/lib/fontisan/commands/pack_command.rb
+++ b/lib/fontisan/commands/pack_command.rb
@@ -174,9 +174,9 @@ module Fontisan
       # @param font [Object] Font object
       # @return [Boolean]
       def truetype_font?(font)
-        return false unless font.respond_to?(:header)
+        return false unless font.is_a?(SfntSource)
 
-        sfnt = font.header.sfnt_version
+        sfnt = font.sfnt_version
         [0x00010000, 0x74727565].include?(sfnt) # 0x74727565 = 'true'
       end
 
@@ -185,9 +185,9 @@ module Fontisan
       # @param font [Object] Font object
       # @return [Boolean]
       def opentype_font?(font)
-        return false unless font.respond_to?(:header)
+        return false unless font.is_a?(SfntSource)
 
-        sfnt = font.header.sfnt_version
+        sfnt = font.sfnt_version
         sfnt == 0x4F54544F # 'OTTO'
       end
 

--- a/lib/fontisan/commands/unpack_command.rb
+++ b/lib/fontisan/commands/unpack_command.rb
@@ -207,7 +207,7 @@ module Fontisan
       def generate_filename(font, index)
         # Try to get font name from name table
         base_name = nil
-        if font.respond_to?(:table) && font.table("name")
+        if font.is_a?(SfntSource) && font.table("name")
           name_table = font.table("name")
           # Try to get PostScript name, then family name
           base_name = name_table.english_name(Tables::Name::POSTSCRIPT_NAME) ||

--- a/lib/fontisan/commands/validate_command.rb
+++ b/lib/fontisan/commands/validate_command.rb
@@ -213,7 +213,7 @@ module Fontisan
       # @param index [Integer] Font index (fallback)
       # @return [String] Font name
       def extract_font_name(font, index)
-        return "Font #{index}" unless font.respond_to?(:table)
+        return "Font #{index}" unless font.is_a?(SfntSource)
 
         name_table = font.table("name")
         return "Font #{index}" unless name_table

--- a/lib/fontisan/converters/format_converter.rb
+++ b/lib/fontisan/converters/format_converter.rb
@@ -412,9 +412,9 @@ _options)
         # rather than the SFNT table interface
         is_type1 = font.is_a?(Type1Font)
 
-        unless is_type1 || font.respond_to?(:table)
+        unless is_type1 || font.is_a?(SfntSource)
           raise ArgumentError,
-                "Font must respond to :table method or be a Type1Font"
+                "Font must be an SfntSource instance or a Type1Font"
         end
 
         unless target_format.is_a?(Symbol)

--- a/lib/fontisan/converters/outline_converter.rb
+++ b/lib/fontisan/converters/outline_converter.rb
@@ -275,12 +275,8 @@ module Fontisan
       def validate(font, target_format)
         raise ArgumentError, "Font cannot be nil" if font.nil?
 
-        unless font.respond_to?(:tables)
-          raise ArgumentError, "Font must respond to :tables"
-        end
-
-        unless font.respond_to?(:table)
-          raise ArgumentError, "Font must respond to :table"
+        unless font.is_a?(SfntSource)
+          raise ArgumentError, "Font must be an SfntSource instance"
         end
 
         source_format = detect_format(font)

--- a/lib/fontisan/converters/table_copier.rb
+++ b/lib/fontisan/converters/table_copier.rb
@@ -30,12 +30,8 @@ module Fontisan
       def convert(font, _options = {})
         raise ArgumentError, "Font cannot be nil" if font.nil?
 
-        unless font.respond_to?(:tables)
-          raise ArgumentError, "Font must respond to :tables"
-        end
-
-        unless font.respond_to?(:table_data)
-          raise ArgumentError, "Font must respond to :table_data"
+        unless font.is_a?(SfntSource)
+          raise ArgumentError, "Font must be an SfntSource instance"
         end
 
         target_format = detect_format(font)
@@ -73,12 +69,8 @@ module Fontisan
       def validate(font, target_format)
         raise ArgumentError, "Font cannot be nil" if font.nil?
 
-        unless font.respond_to?(:tables)
-          raise ArgumentError, "Font must respond to :tables"
-        end
-
-        unless font.respond_to?(:table_data)
-          raise ArgumentError, "Font must respond to :table_data"
+        unless font.is_a?(SfntSource)
+          raise ArgumentError, "Font must be an SfntSource instance"
         end
 
         # Detect source format and verify it matches target

--- a/lib/fontisan/converters/type1_converter.rb
+++ b/lib/fontisan/converters/type1_converter.rb
@@ -112,9 +112,9 @@ module Fontisan
       def validate(font, target_format)
         raise ArgumentError, "Font cannot be nil" if font.nil?
 
-        unless font.respond_to?(:font_dictionary) || font.respond_to?(:tables)
+        unless font.is_a?(Type1Font) || font.is_a?(SfntSource)
           raise ArgumentError,
-                "Font must be Type1Font or have :tables method"
+                "Font must be a Type1Font or SfntSource instance"
         end
 
         source_format = detect_format(font)
@@ -219,7 +219,7 @@ module Fontisan
           :otf
         else
           # Try to detect from tables
-          if font.respond_to?(:tables)
+          if font.is_a?(SfntSource)
             if font.tables.key?("glyf")
               :ttf
             elsif font.tables.key?("CFF ") || font.tables.key?("CFF2")

--- a/lib/fontisan/converters/woff2_encoder.rb
+++ b/lib/fontisan/converters/woff2_encoder.rb
@@ -218,7 +218,7 @@ module Fontisan
       # are applied by `Woff2::EncoderRules`, not here — this method is a
       # pure reader.
       def collect_tables(font, _options = {})
-        table_names = if font.respond_to?(:table_names)
+        table_names = if font.is_a?(SfntSource)
                         font.table_names
                       else
                         %w[head hhea maxp OS/2 name cmap post hmtx glyf loca
@@ -247,7 +247,7 @@ module Fontisan
       #
       # @return [Hash{Symbol => Object}, nil]
       def apply_glyf_loca_transform!(table_data, font)
-        return nil unless font.respond_to?(:has_table?)
+        return nil unless font.is_a?(SfntSource)
         return nil unless font.has_table?("glyf") && font.has_table?("loca")
 
         glyf_data = table_data["glyf"]
@@ -310,12 +310,10 @@ module Fontisan
       end
 
       def get_table_data(font, tag)
-        if font.respond_to?(:table_data)
-          font.table_data[tag]
-        elsif font.respond_to?(:table)
-          table = font.table(tag)
-          table&.to_binary_s if table.respond_to?(:to_binary_s)
-        end
+        return font.table_data[tag] if font.is_a?(SfntSource)
+
+        table = font.table(tag)
+        table&.to_binary_s
       end
 
       # Build table directory entries.

--- a/lib/fontisan/converters/woff_writer.rb
+++ b/lib/fontisan/converters/woff_writer.rb
@@ -113,8 +113,8 @@ module Fontisan
 
         raise ArgumentError, "Font cannot be nil" if font.nil?
 
-        unless font.respond_to?(:tables) && font.respond_to?(:table_data)
-          raise ArgumentError, "Font must respond to :tables and :table_data"
+        unless font.is_a?(SfntSource)
+          raise ArgumentError, "Font must be an SfntSource instance"
         end
       end
 
@@ -302,7 +302,7 @@ module Fontisan
       def write_woff_header(io, font, total_size, total_sfnt_size, num_tables,
                            compressed_metadata, metadata_offset, metadata_size,
                            private_offset, private_size)
-        flavor = if font.respond_to?(:cff?) && font.cff?
+        flavor = if font.is_a?(SfntSource) && font.cff?
                    Constants::SFNT_VERSION_OTTO
                  else
                    Constants::SFNT_VERSION_TRUETYPE

--- a/lib/fontisan/export/exporter.rb
+++ b/lib/fontisan/export/exporter.rb
@@ -181,7 +181,7 @@ module Fontisan
       # @return [void]
       def export_binary_fallback(export_model, tag, error)
         table = @font.table(tag)
-        binary_data = table.respond_to?(:to_binary_s) ? table.to_binary_s : ""
+        binary_data = table ? table.to_binary_s : ""
         checksum = calculate_table_checksum(tag)
 
         export_model.add_table(
@@ -201,14 +201,13 @@ module Fontisan
         table_entry = @font.tables.find { |entry| entry.tag == tag }
         return 0 unless table_entry
 
-        if table_entry.respond_to?(:checksum)
-          table_entry.checksum.to_i
-        else
-          # Calculate from binary data
-          table = @font.table(tag)
-          data = table.respond_to?(:to_binary_s) ? table.to_binary_s : ""
-          Utilities::ChecksumCalculator.calculate(data)
-        end
+        checksum = table_entry.checksum
+        return checksum.to_i if checksum
+
+        # Calculate from binary data
+        table = @font.table(tag)
+        data = table ? table.to_binary_s : ""
+        Utilities::ChecksumCalculator.calculate(data)
       end
 
       # Format checksum as hex string

--- a/lib/fontisan/export/transformers/font_to_ttx.rb
+++ b/lib/fontisan/export/transformers/font_to_ttx.rb
@@ -103,7 +103,7 @@ module Fontisan
         # @param table [Object] Table object
         # @return [Models::Ttx::Tables::BinaryTable, nil] Binary table model
         def transform_binary_table(tag, table)
-          binary_data = table.respond_to?(:to_binary_s) ? table.to_binary_s : ""
+          binary_data = table ? table.to_binary_s : ""
           return nil if binary_data.empty?
 
           Models::Ttx::Tables::BinaryTable.new.tap do |bin_table|
@@ -140,7 +140,7 @@ module Fontisan
         # @return [String] Glyph name
         def get_glyph_name(glyph_id)
           post = @font.table("post")
-          if post.respond_to?(:glyph_names) && post.glyph_names
+          if post.is_a?(Tables::Post) && post.glyph_names
             post.glyph_names[glyph_id] || ".notdef"
           elsif glyph_id.zero?
             ".notdef"

--- a/lib/fontisan/export/transformers/head_transformer.rb
+++ b/lib/fontisan/export/transformers/head_transformer.rb
@@ -42,7 +42,7 @@ module Fontisan
         # @param value [Object] BinData value or integer
         # @return [Integer] Native integer
         def self.to_int(value)
-          value.respond_to?(:to_i) ? value.to_i : value
+          Integer(value)
         end
 
         # Format fixed-point number (16.16)

--- a/lib/fontisan/export/transformers/hhea_transformer.rb
+++ b/lib/fontisan/export/transformers/hhea_transformer.rb
@@ -41,7 +41,7 @@ module Fontisan
         # @param value [Object] BinData value or integer
         # @return [Integer] Native integer
         def self.to_int(value)
-          value.respond_to?(:to_i) ? value.to_i : value
+          Integer(value)
         end
 
         # Format hex value

--- a/lib/fontisan/export/transformers/maxp_transformer.rb
+++ b/lib/fontisan/export/transformers/maxp_transformer.rb
@@ -45,7 +45,7 @@ module Fontisan
         # @param value [Object] BinData value or integer
         # @return [Integer] Native integer
         def self.to_int(value)
-          value.respond_to?(:to_i) ? value.to_i : value
+          Integer(value)
         end
 
         # Format hex value

--- a/lib/fontisan/export/transformers/name_transformer.rb
+++ b/lib/fontisan/export/transformers/name_transformer.rb
@@ -44,7 +44,7 @@ module Fontisan
         # @param value [Object] BinData value or integer
         # @return [Integer] Native integer
         def self.to_int(value)
-          value.respond_to?(:to_i) ? value.to_i : value
+          Integer(value)
         end
 
         # Format hex value

--- a/lib/fontisan/export/transformers/os2_transformer.rb
+++ b/lib/fontisan/export/transformers/os2_transformer.rb
@@ -101,7 +101,7 @@ module Fontisan
         # @param value [Object] BinData value or integer
         # @return [Integer] Native integer
         def self.to_int(value)
-          value.respond_to?(:to_i) ? value.to_i : value
+          Integer(value)
         end
 
         # Format binary flags

--- a/lib/fontisan/export/transformers/post_transformer.rb
+++ b/lib/fontisan/export/transformers/post_transformer.rb
@@ -33,7 +33,7 @@ module Fontisan
         # @param value [Object] BinData value or integer
         # @return [Integer] Native integer
         def self.to_int(value)
-          value.respond_to?(:to_i) ? value.to_i : value
+          Integer(value)
         end
 
         # Format fixed-point number (16.16)

--- a/lib/fontisan/export/ttx_generator.rb
+++ b/lib/fontisan/export/ttx_generator.rb
@@ -64,7 +64,7 @@ module Fontisan
       # @param value [Object] BinData value or integer
       # @return [Integer] Native integer
       def to_int(value)
-        value.respond_to?(:to_i) ? value.to_i : value
+        Integer(value)
       end
 
       # Generate GlyphOrder section (required first)
@@ -293,7 +293,7 @@ module Fontisan
       # @param table [Object] Table object
       # @return [void]
       def generate_binary_table(xml, tag, table)
-        binary_data = table.respond_to?(:to_binary_s) ? table.to_binary_s : ""
+        binary_data = table.to_binary_s
         xml.send(tag.to_sym) do
           xml.hexdata do
             xml.text("\n    #{format_hex_data(binary_data)}\n  ")
@@ -432,7 +432,7 @@ module Fontisan
       # @return [String] Glyph name
       def get_glyph_name(glyph_id)
         post = @font.table("post")
-        if post.respond_to?(:glyph_names) && post.glyph_names
+        if post.is_a?(Tables::Post) && post.glyph_names
           post.glyph_names[glyph_id] || ".notdef"
         elsif glyph_id.zero?
           ".notdef"
@@ -471,7 +471,7 @@ module Fontisan
       # @param width [Integer] Minimum hex width
       # @return [String] Hex string (e.g., "0x1234")
       def format_hex(value, width: 8)
-        int_value = value.respond_to?(:to_i) ? value.to_i : value
+        int_value = Integer(value)
         "0x#{int_value.to_s(16).rjust(width, '0')}"
       end
 

--- a/lib/fontisan/hints/postscript_hint_extractor.rb
+++ b/lib/fontisan/hints/postscript_hint_extractor.rb
@@ -56,23 +56,22 @@ module Fontisan
       def extract(charstring)
         return [] if charstring.nil?
 
-        # Get CharString bytes
-        bytes = if charstring.respond_to?(:data)
-                  charstring.data
-                elsif charstring.respond_to?(:bytes)
-                  charstring.bytes
-                elsif charstring.is_a?(String)
-                  charstring.bytes
-                else
-                  return []
-                end
-
-        return [] if bytes.empty?
+        bytes = charstring_to_bytes(charstring)
+        return [] if bytes.nil? || bytes.empty?
 
         parse_charstring(bytes)
       end
 
       private
+
+      # Coerce a CharString input to an Array<Integer> of bytes.
+      # Accepts a String (raw bytes) or a CFF::CharString.
+      def charstring_to_bytes(charstring)
+        return charstring.bytes if charstring.is_a?(String)
+        return charstring.data if charstring.is_a?(Tables::Cff::CharString)
+
+        raise TypeError, "Unsupported charstring type: #{charstring.class}"
+      end
 
       # Parse CharString bytes to extract hints
       #
@@ -289,58 +288,19 @@ module Fontisan
 
         # Extract hint-related parameters from Private DICT
         # These are the key hinting parameters in CFF
-        if private_dict.respond_to?(:blue_values)
-          hints[:blue_values] =
-            private_dict.blue_values
-        end
-        if private_dict.respond_to?(:other_blues)
-          hints[:other_blues] =
-            private_dict.other_blues
-        end
-        if private_dict.respond_to?(:family_blues)
-          hints[:family_blues] =
-            private_dict.family_blues
-        end
-        if private_dict.respond_to?(:family_other_blues)
-          hints[:family_other_blues] =
-            private_dict.family_other_blues
-        end
-        if private_dict.respond_to?(:blue_scale)
-          hints[:blue_scale] =
-            private_dict.blue_scale
-        end
-        if private_dict.respond_to?(:blue_shift)
-          hints[:blue_shift] =
-            private_dict.blue_shift
-        end
-        if private_dict.respond_to?(:blue_fuzz)
-          hints[:blue_fuzz] =
-            private_dict.blue_fuzz
-        end
-        if private_dict.respond_to?(:std_hw)
-          hints[:std_hw] =
-            private_dict.std_hw
-        end
-        if private_dict.respond_to?(:std_vw)
-          hints[:std_vw] =
-            private_dict.std_vw
-        end
-        if private_dict.respond_to?(:stem_snap_h)
-          hints[:stem_snap_h] =
-            private_dict.stem_snap_h
-        end
-        if private_dict.respond_to?(:stem_snap_v)
-          hints[:stem_snap_v] =
-            private_dict.stem_snap_v
-        end
-        if private_dict.respond_to?(:force_bold)
-          hints[:force_bold] =
-            private_dict.force_bold
-        end
-        if private_dict.respond_to?(:language_group)
-          hints[:language_group] =
-            private_dict.language_group
-        end
+        hints[:blue_values] = private_dict.blue_values
+        hints[:other_blues] = private_dict.other_blues
+        hints[:family_blues] = private_dict.family_blues
+        hints[:family_other_blues] = private_dict.family_other_blues
+        hints[:blue_scale] = private_dict.blue_scale
+        hints[:blue_shift] = private_dict.blue_shift
+        hints[:blue_fuzz] = private_dict.blue_fuzz
+        hints[:std_hw] = private_dict.std_hw
+        hints[:std_vw] = private_dict.std_vw
+        hints[:stem_snap_h] = private_dict.stem_snap_h
+        hints[:stem_snap_v] = private_dict.stem_snap_v
+        hints[:force_bold] = private_dict.force_bold?
+        hints[:language_group] = private_dict.language_group
 
         hints.compact
       rescue StandardError => e

--- a/lib/fontisan/hints/truetype_hint_extractor.rb
+++ b/lib/fontisan/hints/truetype_hint_extractor.rb
@@ -63,7 +63,7 @@ module Fontisan
       # @return [Array<Hint>] Extracted hints
       def extract(glyph)
         return [] if glyph.nil? || glyph.empty?
-        return [] unless glyph.respond_to?(:instructions)
+        return [] unless glyph.is_a?(Fontisan::Tables::SimpleGlyph)
 
         instructions = glyph.instructions || []
         return [] if instructions.empty?

--- a/lib/fontisan/optimizers/charstring_rewriter.rb
+++ b/lib/fontisan/optimizers/charstring_rewriter.rb
@@ -127,7 +127,7 @@ module Fontisan
         replacements = []
 
         patterns.each do |pattern|
-          if glyph_id && pattern.respond_to?(:positions) && pattern.positions.is_a?(Hash)
+          if glyph_id && pattern.is_a?(PatternAnalyzer::Pattern) && pattern.positions.is_a?(Hash)
             # Use exact positions from pattern analysis for this glyph
             glyph_positions = pattern.positions[glyph_id] || []
 

--- a/lib/fontisan/sfnt_font.rb
+++ b/lib/fontisan/sfnt_font.rb
@@ -52,6 +52,8 @@ module Fontisan
   # @example Writing a font
   #   ttf.to_file("output.ttf")
   class SfntFont < BinData::Record
+    include SfntSource
+
     endian :big
 
     offset_table :header

--- a/lib/fontisan/sfnt_source.rb
+++ b/lib/fontisan/sfnt_source.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Fontisan
+  # Marks a class as providing the SFNT font source interface.
+  #
+  # SfntFont, WoffFont, and Woff2Font all expose the same table-access
+  # surface (#table, #tables, #table_data, #table_names, #has_table?)
+  # but don't share a common base class (WOFF/WOFF2 wrap an SfntFont
+  # but inherit from BinData::Record directly).
+  #
+  # Including this module lets callers type-check with `is_a?(SfntSource)`
+  # instead of `respond_to?(:table)` duck-typing.
+  module SfntSource
+    # @param tag [String] table tag
+    # @return [Object, nil] parsed table or nil
+    def table(tag); end
+
+    # @return [Hash<String, String>] raw table bytes by tag
+    def table_data(tag = nil); end
+
+    # @return [Array<String>] table tags present in this font
+    def table_names; end
+
+    # @param tag [String] table tag
+    # @return [Boolean]
+    def has_table?(tag); end
+  end
+end

--- a/lib/fontisan/stitcher/source.rb
+++ b/lib/fontisan/stitcher/source.rb
@@ -80,7 +80,7 @@ module Fontisan
       # @return [Symbol]
       def bitmap_mode
         return :none if @font.is_a?(Fontisan::Ufo::Font)
-        return :none unless @font.respond_to?(:has_table?)
+        return :none unless @font.is_a?(SfntSource)
 
         has_cbdt = @font.has_table?("CBDT") && @font.has_table?("CBLC")
         has_glyf = @font.has_table?("glyf") || @font.has_table?("CFF ")
@@ -190,7 +190,7 @@ module Fontisan
           cache[:loca] = @font.table("loca")
           cache[:glyf] = @font.table("glyf")
           # loca needs head's index_to_loc_format to size its offsets
-          if cache[:loca].respond_to?(:parse_with_context) && cache[:head]
+          if cache[:head]
             cache[:loca].parse_with_context(
               cache[:head].index_to_loc_format,
               @font.table("maxp")&.num_glyphs || 0,
@@ -217,15 +217,13 @@ module Fontisan
         num_h_metrics = hhea&.number_of_h_metrics || 1
         num_glyphs = maxp&.num_glyphs || 0
 
-        if hmtx.respond_to?(:parse_with_context)
-          hmtx.parse_with_context(num_h_metrics, num_glyphs)
-        end
+        hmtx.parse_with_context(num_h_metrics, num_glyphs)
 
         # Fallback advance width when hmtx lookup fails for a GID.
         # Per the OpenType spec, glyphs at GID >= numberOfHMetrics
         # inherit the last LongHorMetric's advanceWidth. If the table
         # is empty or corrupt, fall back to the font's unitsPerEm.
-        fallback_width = if hmtx.respond_to?(:h_metrics) && hmtx.h_metrics&.any?
+        fallback_width = if hmtx.h_metrics&.any?
                            hmtx.h_metrics.last[:advance_width]
                          else
                            head&.units_per_em || 1000
@@ -284,9 +282,9 @@ module Fontisan
         glyph = Fontisan::Ufo::Glyph.new(name: name)
         glyph.width = glyph_width(gid)
 
-        if raw.respond_to?(:simple?) && raw.simple?
+        if raw.is_a?(Fontisan::Tables::SimpleGlyph) && raw.simple?
           copy_simple_contours(raw, glyph)
-        elsif raw.respond_to?(:compound?) && raw.compound?
+        elsif raw.is_a?(Fontisan::Tables::CompoundGlyph) && raw.compound?
           flatten_compound_into(raw, glyph, cache, Set.new)
         end
 
@@ -372,9 +370,9 @@ module Fontisan
 
           matrix = component.transformation_matrix
 
-          if raw.respond_to?(:simple?) && raw.simple?
+          if raw.is_a?(Fontisan::Tables::SimpleGlyph) && raw.simple?
             flatten_simple_component(raw, ufo_glyph, matrix)
-          elsif raw.respond_to?(:compound?) && raw.compound?
+          elsif raw.is_a?(Fontisan::Tables::CompoundGlyph) && raw.compound?
             flatten_compound_into(raw, ufo_glyph, cache, visited, depth + 1)
           end
         end

--- a/lib/fontisan/subset/builder.rb
+++ b/lib/fontisan/subset/builder.rb
@@ -110,10 +110,8 @@ module Fontisan
       def validate_input!
         raise ArgumentError, "Font cannot be nil" if font.nil?
 
-        # TODO: replace respond_to? duck-type with is_a?(SfntFont) once
-        # the subset builder spec suite is migrated off doubles (see audit).
-        unless font.respond_to?(:table)
-          raise ArgumentError, "Font must respond to :table method"
+        unless font.is_a?(SfntSource)
+          raise ArgumentError, "Font must be an SfntSource instance"
         end
 
         # Validate options

--- a/lib/fontisan/tables/cff/index.rb
+++ b/lib/fontisan/tables/cff/index.rb
@@ -58,7 +58,7 @@ module Fontisan
         def initialize(io, start_offset: 0)
           @io = io.is_a?(String) ? StringIO.new(io) : io
           @start_offset = start_offset
-          @io.seek(start_offset) if @io.respond_to?(:seek)
+          @io.seek(start_offset)
 
           parse!
         end

--- a/lib/fontisan/tables/cff/private_dict_writer.rb
+++ b/lib/fontisan/tables/cff/private_dict_writer.rb
@@ -69,7 +69,7 @@ module Fontisan
         #
         # @param source_dict [PrivateDict] Source dictionary
         def parse_source(source_dict)
-          return unless source_dict.respond_to?(:to_h)
+          return unless source_dict.is_a?(Tables::Cff::Dict)
 
           # Extract only non-hint params (subrs, widths)
           @params = source_dict.to_h.select do |k, _|

--- a/lib/fontisan/tables/cff2/table_builder.rb
+++ b/lib/fontisan/tables/cff2/table_builder.rb
@@ -161,9 +161,7 @@ module Fontisan
         # @return [Integer] Total stem count (hstem + vstem)
         def calculate_stem_count
           return 0 unless @hint_set
-
-          # Get font-level hints (from private_dict_hints JSON)
-          return 0 unless @hint_set.respond_to?(:private_dict_hints)
+          return 0 unless @hint_set.is_a?(Models::HintSet)
 
           begin
             font_hints = JSON.parse(@hint_set.private_dict_hints || "{}")
@@ -194,7 +192,7 @@ module Fontisan
         #
         # @return [Boolean] True if private_dict_hints are present
         def has_font_level_hints?
-          return false unless @hint_set.respond_to?(:private_dict_hints)
+          return false unless @hint_set.is_a?(Models::HintSet)
 
           hints = JSON.parse(@hint_set.private_dict_hints || "{}")
           !hints.empty?

--- a/lib/fontisan/tables/glyf/simple_glyph.rb
+++ b/lib/fontisan/tables/glyf/simple_glyph.rb
@@ -155,6 +155,15 @@ module Fontisan
         end
       end
 
+      # All points across every contour, in contour order.
+      #
+      # @return [Array<Hash>] Array of {x:, y:, on_curve:} hashes
+      def points
+        return [] if empty?
+
+        num_contours.times.flat_map { |c| points_for_contour(c) }
+      end
+
       private
 
       # Parse glyph header (10 bytes)

--- a/lib/fontisan/type1/afm_generator.rb
+++ b/lib/fontisan/type1/afm_generator.rb
@@ -167,10 +167,10 @@ module Fontisan
 
         # Underline properties
         post = @font.table(Constants::POST_TAG)
-        underline_position = post&.underline_position if post.respond_to?(:underline_position)
+        underline_position = post&.underline_position
         afm_lines << "UnderlinePosition #{underline_position}" if underline_position
 
-        underline_thickness = post&.underline_thickness if post.respond_to?(:underline_thickness)
+        underline_thickness = post&.underline_thickness
         afm_lines << "UnderlineThickness #{underline_thickness}" if underline_thickness
       end
 
@@ -252,11 +252,7 @@ module Fontisan
         os2 = @font.table(Constants::OS2_TAG)
         return "Regular" unless os2
 
-        weight_class = if os2.respond_to?(:us_weight_class)
-                         os2.us_weight_class
-                       elsif os2.respond_to?(:weight_class)
-                         os2.weight_class
-                       end
+        weight_class = os2.us_weight_class
         return "Regular" unless weight_class
 
         case weight_class
@@ -280,11 +276,7 @@ module Fontisan
         post = @font.table(Constants::POST_TAG)
         return 0.0 unless post
 
-        if post.respond_to?(:italic_angle)
-          post.italic_angle
-        else
-          0.0
-        end
+        post.italic_angle
       end
 
       # Check if font is monospace
@@ -294,11 +286,7 @@ module Fontisan
         post = @font.table(Constants::POST_TAG)
         return false unless post
 
-        if post.respond_to?(:is_fixed_pitch)
-          post.is_fixed_pitch
-        else
-          false
-        end
+        post.is_fixed_pitch
       end
 
       # Extract version from name table
@@ -308,9 +296,7 @@ module Fontisan
         name_table = @font.table(Constants::NAME_TAG)
         return nil unless name_table
 
-        if name_table.respond_to?(:version_string)
-          name_table.version_string(1) || name_table.version_string(3)
-        end
+        name_table.english_name(Tables::Name::VERSION)
       end
 
       # Extract copyright from name table
@@ -320,9 +306,7 @@ module Fontisan
         name_table = @font.table(Constants::NAME_TAG)
         return nil unless name_table
 
-        if name_table.respond_to?(:copyright)
-          name_table.copyright(1) || name_table.copyright(3)
-        end
+        name_table.english_name(Tables::Name::COPYRIGHT)
       end
 
       # Extract character mappings from cmap table
@@ -332,30 +316,7 @@ module Fontisan
         cmap = @font.table(Constants::CMAP_TAG)
         return {} unless cmap
 
-        @extract_character_mappings ||= begin
-          mappings = {}
-
-          # Try to get Unicode mappings (most reliable method)
-          if cmap.respond_to?(:unicode_mappings)
-            mappings = cmap.unicode_mappings || {}
-          elsif cmap.respond_to?(:unicode_bmp_mapping)
-            mappings = cmap.unicode_bmp_mapping || {}
-          elsif cmap.respond_to?(:subtables)
-            # Look for Unicode BMP subtable
-            unicode_subtable = cmap.subtables.find do |subtable|
-              subtable.respond_to?(:platform_id) &&
-                subtable.platform_id == 3 &&
-                subtable.respond_to?(:encoding_id) &&
-                subtable.encoding_id == 1
-            end
-
-            if unicode_subtable.respond_to?(:glyph_index_map)
-              mappings = unicode_subtable.glyph_index_map
-            end
-          end
-
-          mappings
-        end
+        @extract_character_mappings ||= cmap.unicode_mappings || {}
       end
 
       # Extract font bounding box
@@ -365,12 +326,7 @@ module Fontisan
         head = @font.table(Constants::HEAD_TAG)
         return nil unless head
 
-        if head.respond_to?(:font_bounding_box)
-          head.font_bounding_box
-        elsif head.respond_to?(:x_min) && head.respond_to?(:y_min) &&
-            head.respond_to?(:x_max) && head.respond_to?(:y_max)
-          [head.x_min, head.y_min, head.x_max, head.y_max]
-        end
+        [head.x_min, head.y_min, head.x_max, head.y_max]
       end
 
       # Extract glyph bounding box
@@ -390,7 +346,7 @@ module Fontisan
         return nil unless head_table
 
         # Ensure loca is parsed with context
-        if loca_table.respond_to?(:parse_with_context) && !loca_table.parsed?
+        if loca_table.is_a?(Tables::Loca) && !loca_table.parsed?
           maxp = @font.table(Constants::MAXP_TAG)
           if maxp
             loca_table.parse_with_context(head_table.index_to_loc_format,
@@ -398,17 +354,8 @@ module Fontisan
           end
         end
 
-        if glyf_table.respond_to?(:glyph_for)
-          glyph = glyf_table.glyph_for(glyph_id, loca_table, head_table)
-          return nil unless glyph
-
-          if glyph.respond_to?(:bounding_box)
-            glyph.bounding_box
-          elsif glyph.respond_to?(:x_min) && glyph.respond_to?(:y_min) &&
-              glyph.respond_to?(:x_max) && glyph.respond_to?(:y_max)
-            [glyph.x_min, glyph.y_min, glyph.x_max, glyph.y_max]
-          end
-        end
+        glyph = glyf_table.glyph_for(glyph_id, loca_table, head_table)
+        glyph&.bounding_box
       end
 
       # Extract kerning pairs from GPOS table

--- a/lib/fontisan/type1/decryptor.rb
+++ b/lib/fontisan/type1/decryptor.rb
@@ -112,7 +112,7 @@ module Fontisan
         return "" if data.nil? || data.empty?
 
         # Ensure binary encoding before concatenation
-        data = data.b if data.respond_to?(:b)
+        data = data.b
 
         # Prepend lenIV random bytes
         if len_iv.positive?

--- a/lib/fontisan/type1/generator.rb
+++ b/lib/fontisan/type1/generator.rb
@@ -200,8 +200,8 @@ module Fontisan
       # @return [String] Base filename
       def self.extract_base_name(font)
         name_table = font.table(Constants::NAME_TAG)
-        if name_table.respond_to?(:postscript_name)
-          name = name_table.postscript_name(1) || name_table.postscript_name(3)
+        if name_table
+          name = name_table.english_name(Tables::Name::POSTSCRIPT_NAME)
           return name if name
         end
 

--- a/lib/fontisan/type1/inf_generator.rb
+++ b/lib/fontisan/type1/inf_generator.rb
@@ -181,15 +181,10 @@ module Fontisan
       # @return [String] Font name
       def extract_font_name
         name_table = @font.table(Constants::NAME_TAG)
-        return "" unless name_table
+        return extract_postscript_name unless name_table
 
-        # Try full font name first, then postscript name
-        if name_table.respond_to?(:full_font_name)
-          name_table.full_font_name(1) || name_table.full_font_name(3) ||
-            extract_postscript_name
-        else
+        name_table.english_name(Tables::Name::FULL_NAME) ||
           extract_postscript_name
-        end
       end
 
       # Extract PostScript name
@@ -199,12 +194,8 @@ module Fontisan
         name_table = @font.table(Constants::NAME_TAG)
         return @font.post_script_name || "Unknown" unless name_table
 
-        if name_table.respond_to?(:postscript_name)
-          name_table.postscript_name(1) || name_table.postscript_name(3) ||
-            @font.post_script_name || "Unknown"
-        else
+        name_table.english_name(Tables::Name::POSTSCRIPT_NAME) ||
           @font.post_script_name || "Unknown"
-        end
       end
 
       # Extract family name
@@ -214,9 +205,7 @@ module Fontisan
         name_table = @font.table(Constants::NAME_TAG)
         return nil unless name_table
 
-        if name_table.respond_to?(:font_family)
-          name_table.font_family(1) || name_table.font_family(3)
-        end
+        name_table.english_name(Tables::Name::FAMILY)
       end
 
       # Extract weight
@@ -226,11 +215,7 @@ module Fontisan
         os2 = @font.table(Constants::OS2_TAG)
         return nil unless os2
 
-        weight_class = if os2.respond_to?(:us_weight_class)
-                         os2.us_weight_class
-                       elsif os2.respond_to?(:weight_class)
-                         os2.weight_class
-                       end
+        weight_class = os2.us_weight_class
         return nil unless weight_class
 
         case weight_class
@@ -254,9 +239,7 @@ module Fontisan
         post = @font.table(Constants::POST_TAG)
         return nil unless post
 
-        if post.respond_to?(:italic_angle)
-          post.italic_angle
-        end
+        post.italic_angle
       end
 
       # Extract version
@@ -266,9 +249,7 @@ module Fontisan
         name_table = @font.table(Constants::NAME_TAG)
         return nil unless name_table
 
-        if name_table.respond_to?(:version_string)
-          name_table.version_string(1) || name_table.version_string(3)
-        end
+        name_table.english_name(Tables::Name::VERSION)
       end
 
       # Extract copyright
@@ -278,9 +259,7 @@ module Fontisan
         name_table = @font.table(Constants::NAME_TAG)
         return nil unless name_table
 
-        if name_table.respond_to?(:copyright)
-          name_table.copyright(1) || name_table.copyright(3)
-        end
+        name_table.english_name(Tables::Name::COPYRIGHT)
       end
 
       # Extract vendor/manufacturer
@@ -290,9 +269,7 @@ module Fontisan
         name_table = @font.table(Constants::NAME_TAG)
         return nil unless name_table
 
-        if name_table.respond_to?(:manufacturer)
-          name_table.manufacturer(1) || name_table.manufacturer(3)
-        end
+        name_table.english_name(Tables::Name::MANUFACTURER)
       end
 
       # Extract license information
@@ -302,9 +279,7 @@ module Fontisan
         name_table = @font.table(Constants::NAME_TAG)
         return nil unless name_table
 
-        if name_table.respond_to?(:license)
-          name_table.license(1) || name_table.license(3)
-        end
+        name_table.english_name(Tables::Name::LICENSE_DESCRIPTION)
       end
 
       # Get default PFB filename

--- a/lib/fontisan/type1/pfa_generator.rb
+++ b/lib/fontisan/type1/pfa_generator.rb
@@ -134,15 +134,11 @@ module Fontisan
 
         # Font info
         if name_table
-          if name_table.respond_to?(:version_string)
-            version = name_table.version_string(1) || name_table.version_string(3)
-            dict << "/Version (#{version}) def" if version
-          end
+          version = name_table.english_name(Tables::Name::VERSION)
+          dict << "/Version (#{version}) def" if version
 
-          if name_table.respond_to?(:copyright)
-            copyright = name_table.copyright(1) || name_table.copyright(3)
-            dict << "/Notice (#{copyright}) def" if copyright
-          end
+          copyright = name_table.english_name(Tables::Name::COPYRIGHT)
+          dict << "/Notice (#{copyright}) def" if copyright
         end
 
         dict << "currentdict end"
@@ -161,12 +157,12 @@ module Fontisan
         # Blue values (for hinting)
         # These are typically derived from the font's alignment zones
         os2 = @font.table(Constants::OS2_TAG)
-        if os2.respond_to?(:typo_ascender) && os2.typo_ascender
+        if os2&.s_typo_ascender
           blue_values = [
-            @scaler.scale(os2.typo_descender || -200),
-            @scaler.scale(os2.typo_descender || -200) + 20,
-            @scaler.scale(os2.typo_ascender),
-            @scaler.scale(os2.typo_ascender) + 10,
+            @scaler.scale(os2.s_typo_descender || -200),
+            @scaler.scale(os2.s_typo_descender || -200) + 20,
+            @scaler.scale(os2.s_typo_ascender),
+            @scaler.scale(os2.s_typo_ascender) + 10,
           ]
           dict << "/BlueValues {#{blue_values.join(' ')}} def"
         else
@@ -178,15 +174,15 @@ module Fontisan
         dict << "/BlueFuzz 1 def"
 
         # Stem snap hints
-        if os2.respond_to?(:weight_class) && os2.weight_class
+        if os2&.us_weight_class
           stem_width = @scaler.scale([100, 80,
-                                      90][os2.weight_class / 100] || 80)
+                                      90][os2.us_weight_class / 100] || 80)
           dict << "/StemSnapH [#{stem_width}] def"
           dict << "/StemSnapV [#{stem_width}] def"
         end
 
         # Force bold flag
-        dict << if os2.respond_to?(:weight_class) && os2.weight_class && os2.weight_class >= 700
+        dict << if os2&.us_weight_class && os2.us_weight_class >= 700
                   "/ForceBold true def"
                 else
                   "/ForceBold false def"
@@ -286,33 +282,33 @@ module Fontisan
 
       # Generate a simple CharString for a glyph
       #
-      # @param glyf_table [Object] TTF glyf table
+      # @param glyf_table [Tables::Glyf] TTF glyf table
       # @param gid [Integer] Glyph ID
       # @return [String] Type 1 CharString data
       def simple_charstring(glyf_table, gid)
         glyph = glyf_table.glyph(gid)
 
         # Empty or compound glyph
-        if glyph.nil? || glyph.contour_count.zero? || glyph.compound?
+        if glyph.nil? || glyph.num_contours.zero? || glyph.compound?
           # Return empty charstring (hsbw + endchar)
           return [0, 500, 14].pack("C*")
         end
 
         # For simple glyphs without curve conversion, generate minimal charstring
-        lsb = @scaler.scale(glyph.left_side_bearing || 0)
-        width = @scaler.scale(glyph.advance_width || 500)
-        bytes = [13, lsb, width] # hsbw command (13)
+        lsb, width = hmtx_metrics_for(gid)
+        bytes = [13, @scaler.scale(lsb), @scaler.scale(width)] # hsbw command (13)
 
         # Add simple line commands (very basic)
-        if glyph.respond_to?(:points) && glyph.points && !glyph.points.empty?
+        points = glyph.points
+        unless points.empty?
           # Just draw lines between consecutive on-curve points
           prev_point = nil
-          glyph.points.each do |point|
-            next unless point.on_curve?
+          points.each do |point|
+            next unless point[:on_curve]
 
             if prev_point
-              dx = @scaler.scale(point.x) - @scaler.scale(prev_point.x)
-              dy = @scaler.scale(point.y) - @scaler.scale(prev_point.y)
+              dx = @scaler.scale(point[:x]) - @scaler.scale(prev_point[:x])
+              dy = @scaler.scale(point[:y]) - @scaler.scale(prev_point[:y])
               bytes << 5 # rlineto
               bytes.concat(encode_number(dx))
               bytes.concat(encode_number(dy))
@@ -323,6 +319,20 @@ module Fontisan
 
         bytes << 14 # endchar
         bytes.pack("C*")
+      end
+
+      # Look up LSB and advance width from hmtx for a glyph.
+      #
+      # @param gid [Integer] Glyph ID
+      # @return [Array(Integer, Integer)] [lsb, advance_width]
+      def hmtx_metrics_for(gid)
+        hmtx = @font.table(Constants::HMTX_TAG)
+        return [0, 500] unless hmtx
+
+        metric = hmtx.metric_for(gid)
+        return [0, 500] unless metric
+
+        [metric[:lsb] || 0, metric[:advance_width] || 500]
       end
 
       # Encode a number for Type 1 CharString

--- a/lib/fontisan/type1/pfb_generator.rb
+++ b/lib/fontisan/type1/pfb_generator.rb
@@ -159,15 +159,15 @@ module Fontisan
 
         # Stem snap hints
         os2 = @font.table(Constants::OS2_TAG)
-        if os2.respond_to?(:weight_class)
+        if os2&.us_weight_class
           stem_width = @scaler.scale([100, 80,
-                                      90][os2.weight_class / 100] || 80)
+                                      90][os2.us_weight_class / 100] || 80)
           dict << "/StemSnapH [#{stem_width}] def"
           dict << "/StemSnapV [#{stem_width}] def"
         end
 
         # Force bold flag
-        dict << if os2.respond_to?(:weight_class) && os2.weight_class && os2.weight_class >= 700
+        dict << if os2&.us_weight_class && os2.us_weight_class >= 700
                   "/ForceBold true def"
                 else
                   "/ForceBold false def"
@@ -261,28 +261,40 @@ module Fontisan
         glyph = glyf_table.glyph(gid)
 
         # Empty or compound glyph
-        if glyph.nil? || glyph.contour_count.zero? || glyph.compound?
+        if glyph.nil? || glyph.num_contours.zero? || glyph.compound?
           # Return empty charstring (hsbw + endchar)
           return [0, 500, 14].pack("C*")
         end
 
         # For simple glyphs without curve conversion, generate line-based charstring
         # This is a simplified implementation
-        lsb = @scaler.scale(glyph.left_side_bearing || 0)
-        width = @scaler.scale(glyph.advance_width || 500)
-        bytes = [0, lsb, width] # hsbw
+        lsb, width = hmtx_metrics_for(gid)
+        bytes = [0, @scaler.scale(lsb), @scaler.scale(width)] # hsbw
 
         # Add lines between points (simplified)
-        if glyph.respond_to?(:points) && glyph.points && !glyph.points.empty?
-          glyph.points.each do |point|
-            next unless point.on_curve?
+        points = glyph.points
+        points.each do |point|
+          next unless point[:on_curve]
 
-            # This is very simplified - proper implementation would handle curves
-          end
+          # This is very simplified - proper implementation would handle curves
         end
 
         bytes << 14 # endchar
         bytes.pack("C*")
+      end
+
+      # Look up LSB and advance width from hmtx for a glyph.
+      #
+      # @param gid [Integer] Glyph ID
+      # @return [Array(Integer, Integer)] [lsb, advance_width]
+      def hmtx_metrics_for(gid)
+        hmtx = @font.table(Constants::HMTX_TAG)
+        return [0, 500] unless hmtx
+
+        metric = hmtx.metric_for(gid)
+        return [0, 500] unless metric
+
+        [metric[:lsb] || 0, metric[:advance_width] || 500]
       end
 
       # Build second ASCII segment (trailer)

--- a/lib/fontisan/type1/pfm_generator.rb
+++ b/lib/fontisan/type1/pfm_generator.rb
@@ -145,7 +145,7 @@ module Fontisan
         return widths unless cmap
 
         # Get Unicode mappings
-        mappings = if cmap.respond_to?(:unicode_mappings)
+        mappings = if cmap
                      cmap.unicode_mappings || {}
                    else
                      {}
@@ -369,18 +369,14 @@ module Fontisan
         metrics << [0].pack("V")
 
         # etmCapHeight (4 bytes)
-        cap_height = if os2.respond_to?(:cap_height) && os2.cap_height
-                       os2.cap_height
-                     elsif os2.respond_to?(:s_typo_ascender) && os2.s_typo_ascender
-                       os2.s_typo_ascender
-                     else
-                       @metrics.ascent || 1000
-                     end
+        cap_height = os2.s_cap_height ||
+          os2.s_typo_ascender ||
+          @metrics.ascent || 1000
         metrics << [@scaler.scale(cap_height)].pack("V")
 
         # etmXHeight (4 bytes)
-        x_height = if os2.respond_to?(:x_height) && os2.x_height&.positive?
-                     os2.x_height
+        x_height = if os2.sx_height&.positive?
+                     os2.sx_height
                    else
                      # Fallback: use roughly half the ascent for x-height
                      (@metrics.ascent / 2) || 500
@@ -503,11 +499,7 @@ module Fontisan
         name_table = @font.table(Constants::NAME_TAG)
         return "" unless name_table
 
-        if name_table.respond_to?(:copyright)
-          name_table.copyright(1) || name_table.copyright(3) || ""
-        else
-          ""
-        end
+        name_table.english_name(Tables::Name::COPYRIGHT) || ""
       end
 
       # Extract face name from font
@@ -515,18 +507,13 @@ module Fontisan
       # @return [String] Face name
       def extract_face_name
         name_table = @font.table(Constants::NAME_TAG)
-        return "" unless name_table
+        return @font.post_script_name.to_s unless name_table
 
         # Try full font name first, then font family, then postscript name
-        face_name = if name_table.respond_to?(:full_font_name)
-                      name_table.full_font_name(1) || name_table.full_font_name(3) || ""
-                    elsif name_table.respond_to?(:font_family)
-                      name_table.font_family(1) || name_table.font_family(3) || ""
-                    elsif name_table.respond_to?(:postscript_name)
-                      name_table.postscript_name(1) || name_table.postscript_name(3) || ""
-                    else
-                      @font.post_script_name || ""
-                    end
+        face_name = name_table.english_name(Tables::Name::FULL_NAME) ||
+          name_table.english_name(Tables::Name::FAMILY) ||
+          name_table.english_name(Tables::Name::POSTSCRIPT_NAME) ||
+          @font.post_script_name
 
         face_name.to_s
       end
@@ -538,11 +525,7 @@ module Fontisan
         os2 = @font.table(Constants::OS2_TAG)
         return 400 unless os2
 
-        weight_class = if os2.respond_to?(:us_weight_class)
-                         os2.us_weight_class
-                       elsif os2.respond_to?(:weight_class)
-                         os2.weight_class
-                       end
+        weight_class = os2.us_weight_class
         return 400 unless weight_class
 
         # Map OS/2 weight class to PFM weight
@@ -564,7 +547,7 @@ module Fontisan
       # @return [Integer] Pitch and family byte
       def pitch_and_family_value
         post = @font.table(Constants::POST_TAG)
-        is_fixed = post.respond_to?(:is_fixed_pitch) ? post.is_fixed_pitch : false
+        is_fixed = post&.is_fixed_pitch || false
 
         pitch = is_fixed ? FIXED_PITCH : VARIABLE_PITCH
 

--- a/lib/fontisan/type1/ttf_to_type1_converter.rb
+++ b/lib/fontisan/type1/ttf_to_type1_converter.rb
@@ -97,23 +97,23 @@ module Fontisan
         end
 
         # Convert simple glyph
-        convert_simple_glyph(glyph)
+        convert_simple_glyph(glyph, gid)
       end
 
       # Convert a simple glyph to CharString
       #
-      # @param glyph [Object] TTF simple glyph
+      # @param glyph [Tables::SimpleGlyph] TTF simple glyph
+      # @param gid [Integer] Glyph ID (for hmtx lookup)
       # @return [String] Type 1 CharString data
-      def convert_simple_glyph(glyph)
+      def convert_simple_glyph(glyph, gid)
         commands = []
         points = extract_points(glyph)
 
         return empty_charstring if points.empty?
 
         # Start with hsbw (horizontal side bearing and width)
-        lsb = @scaler.scale(glyph.left_side_bearing || 0)
-        width = @scaler.scale(glyph.advance_width || 500)
-        commands << [HSBW, lsb, width]
+        lsb, width = hmtx_metrics_for(gid)
+        commands << [HSBW, @scaler.scale(lsb), @scaler.scale(width)]
 
         # Convert contours to Type 1 commands
         contour_commands = convert_contours(points)
@@ -126,29 +126,34 @@ module Fontisan
         encode_charstring(commands)
       end
 
-      # Extract points from a simple glyph
+      # Extract points from a simple glyph, scaled to target UPM.
       #
-      # TODO: SimpleGlyph has no `points` method — this path has never
-      # executed against a real glyph. The fix requires either exposing
-      # a points iterator on SimpleGlyph or rewriting against the
-      # points_for_contour API. Tracked separately from the encapsulation
-      # audit; left as-is to avoid silently masking the bug.
-      #
-      # @param glyph [Object] TTF simple glyph
-      # @return [Array<Hash>] Array of points with on_curve flag
+      # @param glyph [Tables::SimpleGlyph] TTF simple glyph
+      # @return [Array<Hash>] Array of {x:, y:, on_curve:} hashes
       def extract_points(glyph)
-        return [] unless glyph.respond_to?(:points)
+        return [] unless glyph.is_a?(Tables::SimpleGlyph)
 
-        points = []
-        glyph.points.each do |point|
-          points << {
-            x: @scaler.scale(point.x),
-            y: @scaler.scale(point.y),
-            on_curve: point.on_curve?,
+        glyph.points.map do |point|
+          {
+            x: @scaler.scale(point[:x]),
+            y: @scaler.scale(point[:y]),
+            on_curve: point[:on_curve],
           }
         end
+      end
 
-        points
+      # Look up LSB and advance width from hmtx for a glyph.
+      #
+      # @param gid [Integer] Glyph ID
+      # @return [Array(Integer, Integer)] [lsb, advance_width]
+      def hmtx_metrics_for(gid)
+        hmtx = @font.table(Constants::HMTX_TAG)
+        return [0, 500] unless hmtx
+
+        metric = hmtx.metric_for(gid)
+        return [0, 500] unless metric
+
+        [metric[:lsb] || 0, metric[:advance_width] || 500]
       end
 
       # Convert contours to Type 1 commands

--- a/lib/fontisan/ufo/compile/fvar.rb
+++ b/lib/fontisan/ufo/compile/fvar.rb
@@ -20,8 +20,8 @@ module Fontisan
         # @param instances [Array<Hash>] named instance definitions
         # @return [String, nil] fvar table bytes, or nil if no axes
         def self.build(font, axes: nil, instances: nil)
-          axes ||= font.info.respond_to?(:axes) ? font.info.axes : nil
-          instances ||= font.info.respond_to?(:named_instances) ? font.info.named_instances : nil
+          axes ||= font.info.axes
+          instances ||= font.info.named_instances
 
           axes ||= []
           return nil if axes.empty?

--- a/lib/fontisan/ufo/convert/from_bin_data.rb
+++ b/lib/fontisan/ufo/convert/from_bin_data.rb
@@ -61,8 +61,7 @@ module Fontisan
           name_table = font.table("name")
           return unless name_table
 
-          records = name_table.respond_to?(:name_records) ? name_table.name_records : []
-          records.each do |record|
+          name_table.name_records.each do |record|
             next unless record.platform_id == 3 && record.encoding_id == 1 # Windows Unicode BMP
 
             value = decode_name_value(record, name_table)
@@ -79,9 +78,7 @@ module Fontisan
         end
 
         def self.decode_name_value(record, name_table)
-          raw = if name_table.respond_to?(:string_for_record)
-                  name_table.string_for_record(record)
-                end
+          raw = name_table.string_for_record(record)
 
           if raw && raw.encoding == Encoding::UTF_16BE
             raw.encode("UTF-8")
@@ -100,12 +97,7 @@ module Fontisan
           post = font.table("post")
           return unless post
 
-          if post.respond_to?(:italic_angle)
-            info.italic_angle = post.italic_angle
-          elsif post.respond_to?(:italic_angle_raw)
-            raw = post.italic_angle_raw
-            info.italic_angle = raw.to_i / 65536.0
-          end
+          info.italic_angle = post.italic_angle
         rescue NoMethodError
           # post table may not have italic_angle
         end
@@ -128,7 +120,7 @@ module Fontisan
           cmap_table = font.table("cmap")
           return {} unless cmap_table
 
-          mappings = cmap_table.respond_to?(:unicode_mappings) ? cmap_table.unicode_mappings : {}
+          mappings = cmap_table.unicode_mappings || {}
           # Invert: gid → [codepoints]
           inverted = Hash.new { |h, k| h[k] = [] }
           mappings.each { |cp, gid| inverted[gid] << cp }
@@ -146,13 +138,11 @@ module Fontisan
           num_glyphs = maxp&.num_glyphs || 0
 
           # Hmtx requires context-aware parsing before metric_for works.
-          if hmtx.respond_to?(:parse_with_context)
-            hmtx.parse_with_context(num_h_metrics, num_glyphs)
-          end
+          hmtx.parse_with_context(num_h_metrics, num_glyphs)
 
           widths = {}
           num_glyphs.times do |gid|
-            metric = hmtx.respond_to?(:metric_for) ? hmtx.metric_for(gid) : nil
+            metric = hmtx.metric_for(gid)
             widths[gid] = metric ? metric[:advance_width] : 0
           end
           widths
@@ -169,10 +159,8 @@ module Fontisan
           return unless glyf && loca && head
 
           # Tables need context-aware initialization before per-glyph access.
-          if loca.respond_to?(:parse_with_context)
-            loca.parse_with_context(head.index_to_loc_format,
-                                    num_glyphs)
-          end
+          loca.parse_with_context(head.index_to_loc_format,
+                                  num_glyphs)
 
           num_glyphs.times do |gid|
             glyph_name = glyph_name_for(font, gid) || "glyph#{gid}"
@@ -189,7 +177,7 @@ module Fontisan
 
             if simple.is_a?(Fontisan::Tables::SimpleGlyph)
               extract_simple_contours(simple, ufo_glyph)
-            elsif simple.respond_to?(:compound?) && simple.compound?
+            elsif simple.is_a?(Fontisan::Tables::CompoundGlyph) && simple.compound?
               extract_compound_contours(simple, ufo_glyph, glyf, loca, head)
             end
 
@@ -309,7 +297,7 @@ module Fontisan
           visited = visited.dup.add(compound.glyph_id)
 
           compound.components.each do |component|
-            next unless component.respond_to?(:args_are_xy?) ? component.args_are_xy? : true
+            next unless component.args_are_xy?
 
             raw = begin
               glyf.glyph_for(component.glyph_index, loca, head)
@@ -320,9 +308,9 @@ module Fontisan
 
             matrix = component.transformation_matrix
 
-            if raw.respond_to?(:simple?) && raw.simple?
+            if raw.is_a?(Fontisan::Tables::SimpleGlyph) && raw.simple?
               flatten_simple_component(raw, ufo_glyph, matrix)
-            elsif raw.respond_to?(:compound?) && raw.compound?
+            elsif raw.is_a?(Fontisan::Tables::CompoundGlyph) && raw.compound?
               flatten_compound(raw, ufo_glyph, glyf, loca, head, visited, depth + 1)
             end
           end
@@ -358,12 +346,10 @@ module Fontisan
           post = font.table("post")
           return nil unless post
 
-          if post.respond_to?(:glyph_name)
-            name = post.glyph_name(gid)
-            return name unless name.nil? || name.empty?
-          end
+          name = post.glyph_name(gid)
+          return nil if name.nil? || name.empty?
 
-          nil
+          name
         rescue NoMethodError
           nil
         end

--- a/lib/fontisan/ufo/info.rb
+++ b/lib/fontisan/ufo/info.rb
@@ -26,6 +26,10 @@ module Fontisan
 
       attr_accessor(*STANDARD_FIELDS)
 
+      # Variation font metadata. Populated by UFO 3 extensions or by
+      # explicit compiler configuration; nil when not set.
+      attr_accessor :axes, :named_instances
+
       # Catch-all for non-standard (vendor-specific) fields.
       attr_accessor :extras
 

--- a/lib/fontisan/utilities/brotli_wrapper.rb
+++ b/lib/fontisan/utilities/brotli_wrapper.rb
@@ -129,13 +129,11 @@ module Fontisan
         # @param data [String] Data to validate
         # @raise [ArgumentError] If data is invalid
         def validate_data!(data)
-          if data.nil?
-            raise ArgumentError, "Data cannot be nil"
-          end
+          raise ArgumentError, "Data cannot be nil" if data.nil?
 
-          unless data.respond_to?(:bytesize)
+          unless data.is_a?(String)
             raise ArgumentError,
-                  "Data must be a String-like object, got #{data.class}"
+                  "Data must be a String, got #{data.class}"
           end
         end
       end

--- a/lib/fontisan/validation/collection_validator.rb
+++ b/lib/fontisan/validation/collection_validator.rb
@@ -246,7 +246,7 @@ module Fontisan
       # @param font [Object] Font object
       # @return [Boolean] true if TrueType
       def truetype_font?(font)
-        return false unless font.respond_to?(:has_table?)
+        return false unless font.is_a?(SfntSource)
 
         font.has_table?("glyf")
       end
@@ -256,7 +256,7 @@ module Fontisan
       # @param font [Object] Font object
       # @return [Boolean] true if CFF
       def cff_font?(font)
-        return false unless font.respond_to?(:has_table?)
+        return false unless font.is_a?(SfntSource)
 
         font.has_table?("CFF ") || font.has_table?("CFF2")
       end

--- a/lib/fontisan/variable/delta_applicator.rb
+++ b/lib/fontisan/variable/delta_applicator.rb
@@ -260,7 +260,7 @@ module Fontisan
       # @param tag [String] Table tag
       # @return [Object, nil] Table object or nil
       def load_table(tag)
-        return nil unless @font.respond_to?(:table_data)
+        return nil unless @font.is_a?(SfntSource)
 
         data = @font.table_data(tag)
         return nil if data.nil? || data.empty?
@@ -293,7 +293,7 @@ module Fontisan
         end
 
         # Try VVAR
-        if @vvar.respond_to?(:item_variation_store) && @vvar.item_variation_store
+        if @vvar.is_a?(Tables::Vvar) && @vvar.item_variation_store
           return @vvar.item_variation_store.variation_region_list
         end
 

--- a/lib/fontisan/variable/metric_delta_processor.rb
+++ b/lib/fontisan/variable/metric_delta_processor.rb
@@ -221,17 +221,17 @@ module Fontisan
 
         # Similar to HVAR but for vertical metrics
         # VVAR has the same structure as HVAR
-        if @vvar.respond_to?(:advance_height_delta_set) && (delta_set = @vvar.advance_height_delta_set(glyph_id))
+        if (delta_set = @vvar.advance_height_delta_set(glyph_id))
           accumulated = calculate_accumulated_delta(delta_set, region_scalars)
           result[:advance_height] = apply_rounding(accumulated)
         end
 
-        if @vvar.respond_to?(:tsb_delta_set) && (delta_set = @vvar.tsb_delta_set(glyph_id))
+        if (delta_set = @vvar.tsb_delta_set(glyph_id))
           accumulated = calculate_accumulated_delta(delta_set, region_scalars)
           result[:tsb] = apply_rounding(accumulated)
         end
 
-        if @vvar.respond_to?(:bsb_delta_set) && (delta_set = @vvar.bsb_delta_set(glyph_id))
+        if (delta_set = @vvar.bsb_delta_set(glyph_id))
           accumulated = calculate_accumulated_delta(delta_set, region_scalars)
           result[:bsb] = apply_rounding(accumulated)
         end

--- a/lib/fontisan/variable/static_font_builder.rb
+++ b/lib/fontisan/variable/static_font_builder.rb
@@ -77,7 +77,7 @@ options = {})
         tables = {}
 
         # Get all table tags from font
-        table_tags = @font.respond_to?(:tables) ? @font.tables.keys : []
+        table_tags = @font.is_a?(SfntSource) ? @font.table_names : []
 
         table_tags.each do |tag|
           # Skip variation tables

--- a/lib/fontisan/variation/metrics_adjuster.rb
+++ b/lib/fontisan/variation/metrics_adjuster.rb
@@ -226,11 +226,9 @@ module Fontisan
         when "hlgp"
           variation_table("hhea")&.line_gap
         when "xhgt"
-          os2 = variation_table("OS/2")
-          os2&.s_x_height if os2.respond_to?(:s_x_height)
+          variation_table("OS/2")&.sx_height
         when "cpht"
-          os2 = variation_table("OS/2")
-          os2&.s_cap_height if os2.respond_to?(:s_cap_height)
+          variation_table("OS/2")&.s_cap_height
           # Add more metrics as needed
         end
       end
@@ -307,7 +305,7 @@ module Fontisan
         return unless hhea
 
         # Update the field if hhea supports it
-        hhea.number_of_h_metrics = count if hhea.respond_to?(:number_of_h_metrics=)
+        hhea.number_of_h_metrics = count
       end
     end
   end

--- a/lib/fontisan/variation/variation_preserver.rb
+++ b/lib/fontisan/variation/variation_preserver.rb
@@ -148,6 +148,8 @@ module Fontisan
       def validate_source!
         raise ArgumentError, "Source font cannot be nil" if @source_font.nil?
 
+        # TODO: replace respond_to? duck-type with is_a?(SfntSource) once
+        # the variation_preserver spec suite is migrated off instance_double.
         unless @source_font.respond_to?(:has_table?) &&
             @source_font.respond_to?(:table_data)
           raise ArgumentError,

--- a/lib/fontisan/woff2/table_transformer.rb
+++ b/lib/fontisan/woff2/table_transformer.rb
@@ -150,7 +150,7 @@ module Fontisan
       # @param tag [String] Table tag
       # @return [String, nil] Table data or nil if not found
       def get_table_data(tag)
-        return nil unless font.respond_to?(:table_data)
+        return nil unless font.is_a?(SfntSource)
 
         font.table_data[tag]
       end

--- a/lib/fontisan/woff2_font.rb
+++ b/lib/fontisan/woff2_font.rb
@@ -73,6 +73,8 @@ module Fontisan
   #   puts font.header.flavor
   #   puts font.table_names
   class Woff2Font
+    include SfntSource
+
     # High-level pipeline format identifier. Owned by the font class so the
     # conversion pipeline can dispatch without case statements (OCP).
     #

--- a/lib/fontisan/woff_font.rb
+++ b/lib/fontisan/woff_font.rb
@@ -53,6 +53,8 @@ module Fontisan
   #   woff.to_ttf("output.ttf")  # if TrueType flavored
   #   woff.to_otf("output.otf")  # if CFF flavored
   class WoffFont < BinData::Record
+    include SfntSource
+
     # High-level pipeline format identifier. Owned by the font class so the
     # conversion pipeline can dispatch without case statements (OCP).
     #

--- a/spec/fontisan/collection/builder_spec.rb
+++ b/spec/fontisan/collection/builder_spec.rb
@@ -2,43 +2,61 @@
 
 require "spec_helper"
 
+module CollectionBuilderFakes
+  # FakeFont includes SfntSource so Collection::Builder's is_a?(SfntSource)
+  # check accepts it. We override only the surface the builder consults.
+  class FakeFont
+    include Fontisan::SfntSource
+
+    attr_reader :tables_hash, :sfnt_version_value, :header_value
+
+    def initialize(tables, sfnt_version: 0x00010000)
+      @tables_hash = tables
+      @sfnt_version_value = sfnt_version
+      @header_value = Struct.new(:sfnt_version).new(sfnt_version)
+    end
+
+    def table_data(_tag = nil)
+      tables_hash
+    end
+
+    def table_names
+      tables_hash.keys
+    end
+
+    def table(tag)
+      tables_hash[tag]
+    end
+
+    def has_table?(tag)
+      tables_hash.key?(tag)
+    end
+
+    def sfnt_version
+      sfnt_version_value
+    end
+
+    def header
+      header_value
+    end
+  end
+end
+
 RSpec.describe Fontisan::Collection::Builder do
   let(:font1) do
-    double(
-      "font1",
-      table_names: %w[head hhea maxp],
-      table_data: {
-        "head" => "head_1",
-        "hhea" => "shared",
-        "maxp" => "maxp_1",
-      },
-      header: double("header", sfnt_version: 0x00010000),
-      respond_to?: true,
-    ).tap do |f|
-      allow(f).to receive(:has_table?).with("head").and_return(true)
-      allow(f).to receive(:has_table?).with("hhea").and_return(true)
-      allow(f).to receive(:has_table?).with("maxp").and_return(true)
-      allow(f).to receive(:has_table?).with("fvar").and_return(false)
-    end
+    CollectionBuilderFakes::FakeFont.new({
+                                           "head" => "head_1",
+                                           "hhea" => "shared",
+                                           "maxp" => "maxp_1",
+                                         })
   end
 
   let(:font2) do
-    double(
-      "font2",
-      table_names: %w[head hhea maxp],
-      table_data: {
-        "head" => "head_2",
-        "hhea" => "shared",
-        "maxp" => "maxp_2",
-      },
-      header: double("header", sfnt_version: 0x00010000),
-      respond_to?: true,
-    ).tap do |f|
-      allow(f).to receive(:has_table?).with("head").and_return(true)
-      allow(f).to receive(:has_table?).with("hhea").and_return(true)
-      allow(f).to receive(:has_table?).with("maxp").and_return(true)
-      allow(f).to receive(:has_table?).with("fvar").and_return(false)
-    end
+    CollectionBuilderFakes::FakeFont.new({
+                                           "head" => "head_2",
+                                           "hhea" => "shared",
+                                           "maxp" => "maxp_2",
+                                         })
   end
 
   let(:fonts) { [font1, font2] }
@@ -88,11 +106,11 @@ RSpec.describe Fontisan::Collection::Builder do
       end.to raise_error(ArgumentError, "fonts must be an array")
     end
 
-    it "raises error when fonts don't respond to table_data" do
+    it "raises error when fonts aren't SfntSource instances" do
       bad_fonts = [Object.new, Object.new]
       expect do
         described_class.new(bad_fonts)
-      end.to raise_error(ArgumentError, /must respond to table_data/)
+      end.to raise_error(ArgumentError, /must be SfntSource instances/)
     end
   end
 

--- a/spec/fontisan/collection/variable_font_builder_spec.rb
+++ b/spec/fontisan/collection/variable_font_builder_spec.rb
@@ -8,11 +8,7 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
   describe "variable font detection" do
     context "with variable fonts" do
       it "detects variable fonts in collection" do
-        # Create mock variable font
-        font = instance_double(Fontisan::TrueTypeFont)
-        allow(font).to receive(:has_table?).with("fvar").and_return(true)
-        allow(font).to receive(:table_data).and_return({})
-        allow(font).to receive(:respond_to?).with(:table_data).and_return(true)
+        font = Fontisan::SpecHelpers::FakeFont.new({ "fvar" => "" })
 
         builder = described_class.new([font, font])
         expect(builder.variable_fonts_in_collection?).to be true
@@ -21,10 +17,7 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
 
     context "without variable fonts" do
       it "returns false for static fonts" do
-        font = instance_double(Fontisan::TrueTypeFont)
-        allow(font).to receive(:has_table?).with("fvar").and_return(false)
-        allow(font).to receive(:table_data).and_return({})
-        allow(font).to receive(:respond_to?).with(:table_data).and_return(true)
+        font = Fontisan::SpecHelpers::FakeFont.new({ "head" => "" })
 
         builder = described_class.new([font, font])
         expect(builder.variable_fonts_in_collection?).to be false
@@ -74,11 +67,8 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
           double(axis_tag: "wght"),
           double(axis_tag: "wdth"),
         ]
-        fvar1 = double(axes: axes)
-        fvar2 = double(axes: axes)
-
-        font1 = create_variable_font_mock_with_fvar(fvar1)
-        font2 = create_variable_font_mock_with_fvar(fvar2)
+        font1 = create_variable_font_mock_with_fvar(double("fvar", axes: axes))
+        font2 = create_variable_font_mock_with_fvar(double("fvar", axes: axes))
 
         builder = described_class.new([font1, font2])
         expect { builder.validate_variation_compatibility! }.not_to raise_error
@@ -87,13 +77,12 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
 
     context "with different axes" do
       it "raises error" do
-        axes1 = [double(axis_tag: "wght"), double(axis_tag: "wdth")]
-        axes2 = [double(axis_tag: "wght"), double(axis_tag: "slnt")]
-        fvar1 = double(axes: axes1)
-        fvar2 = double(axes: axes2)
-
-        font1 = create_variable_font_mock_with_fvar(fvar1)
-        font2 = create_variable_font_mock_with_fvar(fvar2)
+        font1 = create_variable_font_mock_with_fvar(
+          double("fvar", axes: [double(axis_tag: "wght"), double(axis_tag: "wdth")]),
+        )
+        font2 = create_variable_font_mock_with_fvar(
+          double("fvar", axes: [double(axis_tag: "wght"), double(axis_tag: "slnt")]),
+        )
 
         builder = described_class.new([font1, font2])
         expect { builder.validate_variation_compatibility! }.to raise_error(
@@ -105,13 +94,12 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
 
     context "with different number of axes" do
       it "raises error" do
-        axes1 = [double(axis_tag: "wght")]
-        axes2 = [double(axis_tag: "wght"), double(axis_tag: "wdth")]
-        fvar1 = double(axes: axes1)
-        fvar2 = double(axes: axes2)
-
-        font1 = create_variable_font_mock_with_fvar(fvar1)
-        font2 = create_variable_font_mock_with_fvar(fvar2)
+        font1 = create_variable_font_mock_with_fvar(
+          double("fvar", axes: [double(axis_tag: "wght")]),
+        )
+        font2 = create_variable_font_mock_with_fvar(
+          double("fvar", axes: [double(axis_tag: "wght"), double(axis_tag: "wdth")]),
+        )
 
         builder = described_class.new([font1, font2])
         expect { builder.validate_variation_compatibility! }.to raise_error(
@@ -122,71 +110,48 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
     end
   end
 
-  describe "validate! with variable fonts" do
-    it "calls variation compatibility validation" do
-      font1 = create_variable_ttf_mock_complete
-      font2 = create_variable_ttf_mock_complete
+  describe "validate!" do
+    context "with variable fonts" do
+      it "calls variation compatibility validation" do
+        font1 = create_variable_ttf_mock_complete
+        font2 = create_variable_ttf_mock_complete
 
-      builder = described_class.new([font1, font2])
-      expect(builder).to receive(:validate_variation_compatibility!)
-      builder.validate!
+        builder = described_class.new([font1, font2])
+        expect(builder).to receive(:validate_variation_compatibility!)
+        builder.validate!
+      end
     end
 
-    it "skips variation validation for static fonts" do
-      font1 = create_static_font_mock
-      font2 = create_static_font_mock
+    context "with static fonts" do
+      it "skips variation validation for static fonts" do
+        font1 = create_static_font_mock
+        font2 = create_static_font_mock
 
-      builder = described_class.new([font1, font2])
-      expect(builder).not_to receive(:validate_variation_compatibility!)
-      builder.validate!
+        builder = described_class.new([font1, font2])
+        expect(builder).not_to receive(:validate_variation_compatibility!)
+        builder.validate!
+      end
     end
   end
 
   # Helper methods
   def create_variable_ttf_mock
     fvar_table = double("fvar", axes: [])
-    font = instance_double(Fontisan::TrueTypeFont)
-    allow(font).to receive(:has_table?) do |tag|
-      case tag
-      when "fvar", "glyf" then true
-      when "CFF2" then false
-      else false
-      end
-    end
+    font = Fontisan::SpecHelpers::FakeFont.new({ "fvar" => "", "glyf" => "" })
     allow(font).to receive(:table).with("fvar").and_return(fvar_table)
-    allow(font).to receive(:table_data).and_return({})
-    allow(font).to receive(:respond_to?).with(:table_data).and_return(true)
     font
   end
 
   def create_variable_otf_mock
     fvar_table = double("fvar", axes: [])
-    font = instance_double(Fontisan::OpenTypeFont)
-    allow(font).to receive(:has_table?) do |tag|
-      case tag
-      when "fvar", "CFF2" then true
-      when "glyf" then false
-      else false
-      end
-    end
+    font = Fontisan::SpecHelpers::FakeFont.new({ "fvar" => "", "CFF2" => "" })
     allow(font).to receive(:table).with("fvar").and_return(fvar_table)
-    allow(font).to receive(:table_data).and_return({})
-    allow(font).to receive(:respond_to?).with(:table_data).and_return(true)
     font
   end
 
   def create_variable_font_mock_with_fvar(fvar_table)
-    font = instance_double(Fontisan::TrueTypeFont)
-    allow(font).to receive(:has_table?) do |tag|
-      case tag
-      when "fvar", "glyf" then true
-      when "CFF2" then false
-      else false
-      end
-    end
+    font = Fontisan::SpecHelpers::FakeFont.new({ "fvar" => "", "glyf" => "" })
     allow(font).to receive(:table).with("fvar").and_return(fvar_table)
-    allow(font).to receive(:table_data).and_return({})
-    allow(font).to receive(:respond_to?).with(:table_data).and_return(true)
     font
   end
 
@@ -194,29 +159,18 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
     axes = [double(axis_tag: "wght"), double(axis_tag: "wdth")]
     fvar = double(axes: axes)
 
-    header = double(sfnt_version: 0x00010000)
-    font = double("TrueTypeFont")
-
-    allow(font).to receive(:has_table?) do |tag|
-      %w[fvar glyf head hhea maxp].include?(tag)
+    Fontisan::SpecHelpers::FakeFont.new(
+      { "fvar" => "", "glyf" => "", "head" => "", "hhea" => "", "maxp" => "" },
+      sfnt_version: 0x00010000,
+    ).tap do |font|
+      allow(font).to receive(:table).with("fvar").and_return(fvar)
     end
-    allow(font).to receive(:table).with("fvar").and_return(fvar)
-    allow(font).to receive_messages(header: header, table_data: {})
-    allow(font).to receive(:respond_to?).with(:table_data).and_return(true)
-
-    font
   end
 
   def create_static_font_mock
-    header = double(sfnt_version: 0x00010000)
-    font = double("TrueTypeFont")
-
-    allow(font).to receive(:has_table?) do |tag|
-      %w[head hhea maxp].include?(tag) && tag != "fvar"
-    end
-    allow(font).to receive_messages(header: header, table_data: {})
-    allow(font).to receive(:respond_to?).with(:table_data).and_return(true)
-
-    font
+    Fontisan::SpecHelpers::FakeFont.new(
+      { "head" => "", "hhea" => "", "maxp" => "" },
+      sfnt_version: 0x00010000,
+    )
   end
 end

--- a/spec/fontisan/converters/format_converter_spec.rb
+++ b/spec/fontisan/converters/format_converter_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 RSpec.describe Fontisan::Converters::FormatConverter do
   let(:converter) { described_class.new }
-  let(:ttf_font) { double("TrueTypeFont") }
-  let(:otf_font) { double("OpenTypeFont") }
+  let(:ttf_font) { Fontisan::SpecHelpers::FakeFont.new({ "glyf" => double, "head" => double }) }
+  let(:otf_font) { Fontisan::SpecHelpers::FakeFont.new({ "CFF " => double, "head" => double }) }
 
   # Mock tables for detecting format
   before do
@@ -135,11 +135,11 @@ RSpec.describe Fontisan::Converters::FormatConverter do
         end.to raise_error(ArgumentError, /Font cannot be nil/)
       end
 
-      it "raises ArgumentError for font without table method" do
-        invalid_font = double("InvalidFont")
+      it "raises ArgumentError for font that isn't SfntSource" do
+        invalid_font = Object.new
         expect do
           converter.convert(invalid_font, :otf)
-        end.to raise_error(ArgumentError, /must respond to :table/)
+        end.to raise_error(ArgumentError, /must be an SfntSource/)
       end
 
       it "raises ArgumentError for non-symbol target format" do
@@ -152,9 +152,7 @@ RSpec.describe Fontisan::Converters::FormatConverter do
     context "with unsupported conversions" do
       it "raises error for unsupported conversion with helpful message" do
         # Create test font without proper format
-        unknown_font = double("UnknownFont")
-        allow(unknown_font).to receive(:has_table?).and_return(false)
-        allow(unknown_font).to receive_messages(table: nil, tables: {})
+        unknown_font = Fontisan::SpecHelpers::FakeFont.new({})
 
         expect do
           converter.convert(unknown_font, :woff2)
@@ -276,9 +274,7 @@ RSpec.describe Fontisan::Converters::FormatConverter do
     end
 
     it "raises error for font without glyf or CFF" do
-      unknown_font = double("UnknownFont")
-      allow(unknown_font).to receive(:has_table?).and_return(false)
-      allow(unknown_font).to receive_messages(table: nil, tables: {})
+      unknown_font = Fontisan::SpecHelpers::FakeFont.new({})
 
       expect do
         converter.convert(unknown_font, :ttf)
@@ -330,8 +326,8 @@ RSpec.describe Fontisan::Converters::FormatConverter do
   end
 
   describe "variable font preservation" do
-    let(:variable_ttf_font) { double("VariableTrueTypeFont") }
-    let(:variable_otf_font) { double("VariableOpenTypeFont") }
+    let(:variable_ttf_font) { Fontisan::SpecHelpers::FakeFont.new({ "glyf" => double, "fvar" => double, "gvar" => double, "loca" => double, "head" => double, "hhea" => double, "maxp" => double }) }
+    let(:variable_otf_font) { Fontisan::SpecHelpers::FakeFont.new({ "CFF " => double, "fvar" => double, "head" => double, "hhea" => double, "maxp" => double }) }
 
     before do
       # Setup variable TTF font

--- a/spec/fontisan/converters/outline_converter_spec.rb
+++ b/spec/fontisan/converters/outline_converter_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 RSpec.describe Fontisan::Converters::OutlineConverter do
   let(:converter) { described_class.new }
-  let(:ttf_font) { double("TrueTypeFont") }
-  let(:otf_font) { double("OpenTypeFont") }
+  let(:ttf_font) { Fontisan::SpecHelpers::FakeFont.new({ "glyf" => double, "loca" => double, "head" => double, "hhea" => double, "maxp" => double }) }
+  let(:otf_font) { Fontisan::SpecHelpers::FakeFont.new({ "CFF " => double, "head" => double, "hhea" => double, "maxp" => double }) }
 
   before do
     # Setup TTF font mock with dynamic has_table? response
@@ -49,13 +49,12 @@ RSpec.describe Fontisan::Converters::OutlineConverter do
         end.to raise_error(ArgumentError, /Font cannot be nil/)
       end
 
-      it "raises ArgumentError for font without tables method" do
-        invalid_font = double("InvalidFont")
-        allow(invalid_font).to receive(:table).and_return(double)
+      it "raises ArgumentError for font that isn't SfntSource" do
+        invalid_font = Object.new
 
         expect do
           converter.convert(invalid_font, target_format: :otf)
-        end.to raise_error(ArgumentError, /must respond to :tables/)
+        end.to raise_error(ArgumentError, /must be an SfntSource/)
       end
     end
   end
@@ -194,8 +193,7 @@ RSpec.describe Fontisan::Converters::OutlineConverter do
     end
 
     it "raises error for unknown format" do
-      unknown_font = double("UnknownFont")
-      allow(unknown_font).to receive_messages(has_table?: false, table: nil)
+      unknown_font = Fontisan::SpecHelpers::FakeFont.new({})
 
       expect do
         converter.send(:detect_format, unknown_font)

--- a/spec/fontisan/converters/table_copier_spec.rb
+++ b/spec/fontisan/converters/table_copier_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 RSpec.describe Fontisan::Converters::TableCopier do
   let(:copier) { described_class.new }
-  let(:ttf_font) { double("TrueTypeFont") }
-  let(:otf_font) { double("OpenTypeFont") }
+  let(:ttf_font) { Fontisan::SpecHelpers::FakeFont.new({ "head" => double, "hhea" => double, "maxp" => double, "glyf" => double, "loca" => double }) }
+  let(:otf_font) { Fontisan::SpecHelpers::FakeFont.new({ "head" => double, "hhea" => double, "maxp" => double, "CFF " => double }) }
 
   before do
     # Setup TTF font mock
@@ -94,23 +94,12 @@ RSpec.describe Fontisan::Converters::TableCopier do
         end.to raise_error(ArgumentError, /Font cannot be nil/)
       end
 
-      it "raises error for font without tables method" do
-        invalid_font = double("InvalidFont")
-        allow(invalid_font).to receive(:table).and_return(double)
+      it "raises error for font that isn't SfntSource" do
+        invalid_font = Object.new
 
         expect do
           copier.convert(invalid_font)
-        end.to raise_error(ArgumentError, /must respond to :tables/)
-      end
-
-      it "raises error for font without read_table_data method" do
-        invalid_font = double("InvalidFont")
-        allow(invalid_font).to receive_messages(table: double, tables: {},
-                                                has_table?: false)
-
-        expect do
-          copier.convert(invalid_font)
-        end.to raise_error(ArgumentError, /must respond to :table_data/)
+        end.to raise_error(ArgumentError, /must be an SfntSource/)
       end
     end
   end
@@ -189,10 +178,7 @@ RSpec.describe Fontisan::Converters::TableCopier do
     end
 
     it "raises error for ambiguous format" do
-      ambiguous_font = double("AmbiguousFont")
-      allow(ambiguous_font).to receive(:has_table?).and_return(false)
-      allow(ambiguous_font).to receive_messages(table: nil, tables: {},
-                                                table_data: {})
+      ambiguous_font = Fontisan::SpecHelpers::FakeFont.new({})
 
       expect do
         copier.convert(ambiguous_font)

--- a/spec/fontisan/hints/postscript_hint_extractor_spec.rb
+++ b/spec/fontisan/hints/postscript_hint_extractor_spec.rb
@@ -61,8 +61,7 @@ RSpec.describe Fontisan::Hints::PostScriptHintExtractor do
           50 + 139,  # width = 50
           1, # hstem operator
         ]
-        charstring = double("charstring", data: charstring_bytes,
-                                          bytes: charstring_bytes)
+        charstring = charstring_bytes.pack("C*")
 
         hints = extractor.extract(charstring)
         expect(hints).not_to be_empty
@@ -77,8 +76,7 @@ RSpec.describe Fontisan::Hints::PostScriptHintExtractor do
           50 + 139,  # width = 50
           3, # vstem operator
         ]
-        charstring = double("charstring", data: charstring_bytes,
-                                          bytes: charstring_bytes)
+        charstring = charstring_bytes.pack("C*")
 
         hints = extractor.extract(charstring)
         expect(hints).not_to be_empty
@@ -92,7 +90,7 @@ RSpec.describe Fontisan::Hints::PostScriptHintExtractor do
       end
 
       it "returns empty array for empty charstring" do
-        charstring = double("charstring", data: "", bytes: [])
+        charstring = ""
         hints = extractor.extract(charstring)
         expect(hints).to be_empty
       end
@@ -114,7 +112,7 @@ RSpec.describe Fontisan::Hints::PostScriptHintExtractor do
         end
         # Set up actual methods
         allow(private_dict).to receive_messages(blue_values: [-20, 0, 450,
-                                                              470], std_hw: 68, std_vw: 88, other_blues: nil, family_blues: nil, family_other_blues: nil, blue_scale: nil, blue_shift: nil, blue_fuzz: nil, stem_snap_h: nil, stem_snap_v: nil, force_bold: nil, language_group: nil)
+                                                              470], std_hw: 68, std_vw: 88, other_blues: nil, family_blues: nil, family_other_blues: nil, blue_scale: nil, blue_shift: nil, blue_fuzz: nil, stem_snap_h: nil, stem_snap_v: nil, force_bold?: nil, language_group: nil)
 
         cff_table = double("cff_table")
         allow(cff_table).to receive(:private_dict).with(0).and_return(private_dict)

--- a/spec/fontisan/hints/truetype_hint_extractor_spec.rb
+++ b/spec/fontisan/hints/truetype_hint_extractor_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Fontisan::Hints::TrueTypeHintExtractor do
           instructions: [0x30], # IUP_Y
           empty?: false,
         )
+        allow(glyph).to receive(:is_a?).with(Fontisan::Tables::SimpleGlyph).and_return(true)
 
         hints = extractor.extract(glyph)
         expect(hints).not_to be_empty
@@ -90,6 +91,7 @@ RSpec.describe Fontisan::Hints::TrueTypeHintExtractor do
           instructions: [0x31], # IUP_X
           empty?: false,
         )
+        allow(glyph).to receive(:is_a?).with(Fontisan::Tables::SimpleGlyph).and_return(true)
 
         hints = extractor.extract(glyph)
         expect(hints).not_to be_empty

--- a/spec/fontisan/stitcher/cbdt_spec.rb
+++ b/spec/fontisan/stitcher/cbdt_spec.rb
@@ -5,46 +5,38 @@ require "fontisan"
 require "fontisan/stitcher"
 
 RSpec.describe Fontisan::Stitcher::Source, "#bitmap_mode" do
-  # Minimal double that responds to has_table? like SfntFont.
+  # FakeFont includes SfntSource so Stitcher::Source's is_a?(SfntSource)
+  # check accepts it.
   let(:fake_ttf) do
-    instance_double(Fontisan::SfntFont, has_table?: false)
+    Fontisan::SpecHelpers::FakeFont.new({})
   end
 
   it "returns :cbdt when both CBDT and CBLC are present" do
-    allow(fake_ttf).to receive(:has_table?).with("CBDT").and_return(true)
-    allow(fake_ttf).to receive(:has_table?).with("CBLC").and_return(true)
-    allow(fake_ttf).to receive(:has_table?).with("glyf").and_return(false)
-    allow(fake_ttf).to receive(:has_table?).with("CFF ").and_return(false)
+    fake_ttf.tables_hash["CBDT"] = ""
+    fake_ttf.tables_hash["CBLC"] = ""
 
     source = described_class.new(fake_ttf)
     expect(source.bitmap_mode).to eq(:cbdt)
   end
 
   it "returns :glyf when only glyf is present" do
-    allow(fake_ttf).to receive(:has_table?).with("glyf").and_return(true)
-    allow(fake_ttf).to receive(:has_table?).with("CFF ").and_return(false)
-    allow(fake_ttf).to receive(:has_table?).with("CBDT").and_return(false)
-    allow(fake_ttf).to receive(:has_table?).with("CBLC").and_return(false)
+    fake_ttf.tables_hash["glyf"] = ""
 
     source = described_class.new(fake_ttf)
     expect(source.bitmap_mode).to eq(:glyf)
   end
 
   it "returns :glyf when only CFF is present (OTF)" do
-    allow(fake_ttf).to receive(:has_table?).with("CFF ").and_return(true)
-    allow(fake_ttf).to receive(:has_table?).with("glyf").and_return(false)
-    allow(fake_ttf).to receive(:has_table?).with("CBDT").and_return(false)
-    allow(fake_ttf).to receive(:has_table?).with("CBLC").and_return(false)
+    fake_ttf.tables_hash["CFF "] = ""
 
     source = described_class.new(fake_ttf)
     expect(source.bitmap_mode).to eq(:glyf)
   end
 
   it "returns :mixed when both glyf and CBDT are present" do
-    allow(fake_ttf).to receive(:has_table?).with("CBDT").and_return(true)
-    allow(fake_ttf).to receive(:has_table?).with("CBLC").and_return(true)
-    allow(fake_ttf).to receive(:has_table?).with("glyf").and_return(true)
-    allow(fake_ttf).to receive(:has_table?).with("CFF ").and_return(false)
+    fake_ttf.tables_hash["CBDT"] = ""
+    fake_ttf.tables_hash["CBLC"] = ""
+    fake_ttf.tables_hash["glyf"] = ""
 
     source = described_class.new(fake_ttf)
     expect(source.bitmap_mode).to eq(:mixed)

--- a/spec/fontisan/subset/builder_spec.rb
+++ b/spec/fontisan/subset/builder_spec.rb
@@ -73,11 +73,11 @@ RSpec.describe Fontisan::Subset::Builder do
         end.to raise_error(ArgumentError, /Font cannot be nil/)
       end
 
-      it "raises error for font without table method" do
-        invalid_font = double("InvalidFont")
+      it "raises error for font that isn't SfntSource" do
+        invalid_font = Object.new
         expect do
           described_class.new(invalid_font, glyph_ids, options).build
-        end.to raise_error(ArgumentError, /must respond to :table/)
+        end.to raise_error(ArgumentError, /must be an SfntSource/)
       end
 
       it "raises error for empty glyph_ids" do

--- a/spec/fontisan/utilities/brotli_wrapper_spec.rb
+++ b/spec/fontisan/utilities/brotli_wrapper_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Fontisan::Utilities::BrotliWrapper do
     it "raises error for invalid data type" do
       expect do
         described_class.compress(12345)
-      end.to raise_error(ArgumentError, /Data must be a String-like object/)
+      end.to raise_error(ArgumentError, /Data must be a String/)
     end
 
     it "handles empty string" do

--- a/spec/fontisan/variable/delta_applicator_spec.rb
+++ b/spec/fontisan/variable/delta_applicator_spec.rb
@@ -6,17 +6,12 @@ require "fontisan/variable/delta_applicator"
 RSpec.describe Fontisan::Variable::DeltaApplicator do
   # Create a mock font object with necessary tables
   let(:mock_font) do
-    font = double("Font")
+    font = Fontisan::SpecHelpers::FakeFont.new({})
 
     # fvar table data
     fvar_data = build_fvar_data
-    allow(font).to receive(:table_data).with("fvar").and_return(fvar_data)
-
-    # Other tables return nil (not present)
-    allow(font).to receive(:table_data).with("gvar").and_return(nil)
-    allow(font).to receive(:table_data).with("HVAR").and_return(build_hvar_data)
-    allow(font).to receive(:table_data).with("VVAR").and_return(nil)
-    allow(font).to receive(:table_data).with("MVAR").and_return(nil)
+    font.tables_hash["fvar"] = fvar_data
+    font.tables_hash["HVAR"] = build_hvar_data
 
     font
   end
@@ -91,7 +86,7 @@ RSpec.describe Fontisan::Variable::DeltaApplicator do
     end
 
     it "raises error for non-variable font" do
-      non_var_font = double("Font")
+      non_var_font = Fontisan::SpecHelpers::FakeFont.new({})
       allow(non_var_font).to receive(:table_data).and_return(nil)
 
       applicator_non_var = described_class.new(non_var_font)
@@ -107,7 +102,7 @@ RSpec.describe Fontisan::Variable::DeltaApplicator do
     end
 
     it "returns false when fvar is not present" do
-      non_var_font = double("Font")
+      non_var_font = Fontisan::SpecHelpers::FakeFont.new({})
       allow(non_var_font).to receive(:table_data).and_return(nil)
 
       applicator_non_var = described_class.new(non_var_font)

--- a/spec/fontisan/woff2/table_transformer_spec.rb
+++ b/spec/fontisan/woff2/table_transformer_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require "fontisan/woff2/table_transformer"
 
 RSpec.describe Fontisan::Woff2::TableTransformer do
-  let(:font) { double("Font") }
+  let(:font) { Fontisan::SpecHelpers::FakeFont.new({}) }
   let(:transformer) { described_class.new(font) }
 
   describe "#initialize" do
@@ -62,8 +62,7 @@ RSpec.describe Fontisan::Woff2::TableTransformer do
     context "with non-transformable table" do
       it "returns original table data" do
         table_data = "head table data"
-        allow(font).to receive(:respond_to?).with(:table_data).and_return(true)
-        allow(font).to receive(:table_data).and_return({ "head" => table_data })
+        font.tables_hash["head"] = table_data
 
         result = transformer.transform_table("head")
         expect(result).to eq(table_data)
@@ -71,7 +70,7 @@ RSpec.describe Fontisan::Woff2::TableTransformer do
     end
 
     context "when font doesn't respond to table_data" do
-      let(:font) { double("Font") }
+      let(:font) { Fontisan::SpecHelpers::FakeFont.new({}) }
 
       it "returns nil" do
         allow(font).to receive(:respond_to?).with(:table_data).and_return(false)

--- a/spec/integration/dfont_pack_spec.rb
+++ b/spec/integration/dfont_pack_spec.rb
@@ -251,12 +251,12 @@ RSpec.describe "Dfont Pack Integration", :integration do
       end.to raise_error(ArgumentError, /must be an array/)
     end
 
-    it "rejects fonts without table_data method" do
-      invalid_font = double("invalid font")
+    it "rejects fonts that aren't SfntSource" do
+      invalid_font = Object.new
 
       expect do
         Fontisan::Collection::DfontBuilder.new([invalid_font])
-      end.to raise_error(ArgumentError, /must respond to table_data/)
+      end.to raise_error(ArgumentError, /must be SfntSource/)
     end
   end
 end

--- a/spec/integration/outline_conversion_spec.rb
+++ b/spec/integration/outline_conversion_spec.rb
@@ -369,11 +369,11 @@ RSpec.describe "Outline Conversion Integration" do
     let(:converter) { Fontisan::Converters::OutlineConverter.new }
 
     it "validates font has required methods" do
-      invalid_font = double("InvalidFont")
+      invalid_font = Object.new
 
       expect do
         converter.validate(invalid_font, :otf)
-      end.to raise_error(ArgumentError, /must respond to/)
+      end.to raise_error(ArgumentError, /must be an SfntSource/)
     end
 
     it "rejects nil font" do
@@ -383,8 +383,7 @@ RSpec.describe "Outline Conversion Integration" do
     end
 
     it "detects missing required tables" do
-      font = double("Font")
-      allow(font).to receive_messages(has_table?: false, table: nil, tables: {})
+      font = Fontisan::SpecHelpers::FakeFont.new({})
 
       expect do
         converter.validate(font, :otf)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,7 @@ require "tempfile"
 
 # Load centralized fixture configuration
 require_relative "support/fixture_fonts"
+require_relative "support/fake_font"
 
 # Define the fixtures directory constant for test files
 FIXTURES_DIR = File.join(__dir__, "fixtures")

--- a/spec/support/fake_font.rb
+++ b/spec/support/fake_font.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SpecHelpers
+    # FakeFont is a lightweight SfntSource conformant object for specs
+    # that need a font-shaped input without the cost of building a real
+    # BinData SfntFont. It includes SfntSource so is_a?(SfntSource)
+    # checks pass.
+    class FakeFont
+      include Fontisan::SfntSource
+
+      attr_reader :tables_hash, :sfnt_version_value
+
+      def initialize(tables = {}, sfnt_version: 0x00010000)
+        @tables_hash = tables
+        @sfnt_version_value = sfnt_version
+      end
+
+      def table(tag)
+        tables_hash[tag]
+      end
+
+      def table_data(tag = nil)
+        return tables_hash if tag.nil?
+
+        tables_hash[tag]
+      end
+
+      def table_names
+        tables_hash.keys
+      end
+
+      def tables
+        tables_hash
+      end
+
+      def read_table_data(_tag)
+        nil
+      end
+
+      def has_table?(tag)
+        tables_hash.key?(tag)
+      end
+
+      def sfnt_version
+        sfnt_version_value
+      end
+
+      def header
+        Struct.new(:sfnt_version).new(sfnt_version_value)
+      end
+
+      def cff?
+        tables_hash.key?("CFF ")
+      end
+
+      def truetype?
+        tables_hash.key?("glyf")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to PR #135 addressing the remaining encapsulation violations identified in the audit. Adds 8 new TODO files (TODO.bug-fixes/12-19) and implements them. **178 respond_to? violations reduced to 14** (8 legitimate boundary duck-typing, 6 Type1-specific font_info probes).

### SfntSource module (new)

`SfntFont`, `WoffFont`, and `Woff2Font` all expose the same table-access surface but share no common base. The new `Fontisan::SfntSource` module is included in each, so callers type-check with `is_a?(SfntSource)` instead of `respond_to?(:table)` duck-typing. Replaces 30+ sites across `collection/`, `subset/`, `converters/`, `stitcher/`, `commands/`, `validation/`, `woff2/`, `variation/`, `variable/`.

### TODO 12 — Type 1 generators (50+ respond_to? → 0)

The generators had `respond_to?` checks probing Name/OS/2/Post methods that **never existed** (e.g., `name_table.copyright(1)`). The generators silently produced empty metadata for years. Replaced with the correct `Name#english_name(name_id)` API and direct BinData field access. AFM/PFM/PFA/PFB/INF output now contains real Name table values.

### TODO 13 — Hint extractor (15 respond_to? → 0)

PrivateDict fields are always declared on the BinData record. Removed the dead checks. Standardized CharString input to `String` or `Tables::Cff::CharString`.

### TODO 14 — Font interface type checks (~30 sites)

See SfntSource above. Migrated affected specs to use the new shared `SpecHelpers::FakeFont` (in `spec/support/fake_font.rb`).

### TODO 15 — Glyph type checks + SimpleGlyph#points bug

**Latent bug fix:** `Type1::TTFToType1Converter#extract_points` called `glyph.points.each` — but `SimpleGlyph` had no `points` method. The `respond_to?(:points)` check silently masked this. Type 1 conversion was producing empty CharStrings for simple glyphs.

Added `Tables::SimpleGlyph#points` (flat Array of `{x:, y:, on_curve:}` hashes). Fixed `extract_points` to use it and look up LSB/advance_width from hmtx via gid. Same fix applied to the parallel broken code in `pfa_generator` and `pfb_generator`.

Replaced `respond_to?(:simple?)/:compound?` with `is_a?(Tables::SimpleGlyph)` / `is_a?(Tables::CompoundGlyph)` across `ufo/convert/from_bin_data.rb` and `stitcher/source.rb`.

### TODO 16 — Variation table checks

Cleaned up `variation/metrics_adjuster.rb`, `variable/metric_delta_processor.rb`, `variable/delta_applicator.rb`. `variation/validator.rb`'s CFF2 `is_a?` check was reverted (the spec uses minimal ItemVariationStore doubles) — left as TODO.

### TODO 17 — UFO and Stitcher cleanup

Cleaned up `ufo/convert/from_bin_data.rb` (8 sites), `ufo/compile/fvar.rb`, `stitcher/source.rb`. Added `Ufo::Info#axes` and `#named_instances` accessors (previously probed via `respond_to?`).

### TODO 18 — Generic value/IO checks

Cleaned up `export/transformers/*.rb` (5 sites: `respond_to?(:to_i)` → `Integer(value)`), `export/ttx_generator.rb`, `export/exporter.rb`, `tables/cff/index.rb`, `utilities/brotli_wrapper.rb` (narrowed to `String`), `optimizers/charstring_rewriter.rb`, `tables/cff2/table_builder.rb`, `tables/cff/private_dict_writer.rb`.

Deferred: `padding.rb` and `base_record.rb` keep `respond_to?` for legitimate String/IO boundary duck-typing.

### TODO 19 — Serialization migration (analysis-only)

The 5 `to_h`/`to_hash` sites are mostly plain Ruby value objects (`Type1::ConversionOptions`, `Cff::Dict`) where `to_h` is an accessor wrapper, not wire-format serialization. Only `Ufo::Point#to_h` is a real serialization candidate (GLIF XML). Full migration requires UFO model redesign — deferred.

## Test plan

- [x] `bundle exec rspec` — 6232 examples, 0 failures, 2 pending
- [x] `bundle exec rubocop` — 0 offenses
- [x] No `instance_variable_get`/`instance_variable_set` in lib/
- [x] No `send` to private methods in lib/
- [x] No `require_relative` in lib/
- [x] 178 → 14 `respond_to?` in lib/ (8 boundary, 6 Type1-specific)
- [x] Real Name table values now appear in Type 1 generator output
- [x] SimpleGlyph#points method added; previously-broken Type 1 conversion path now works
