### PR TITLE
refactor: strategy registries eliminate all case/when tag dispatch (TODO 29)

### DIFF
--- a/TODO.bug-fixes/29-strategy-registries.md
+++ b/TODO.bug-fixes/29-strategy-registries.md
@@ -1,0 +1,30 @@
+# 29 — Strategy registries for per-tag dispatch (OCP completion)
+
+## Priority
+P2
+
+## Problem
+6 remaining `case tag` dispatches map a table tag to per-table
+behavior (update, transform, emit, etc.). These are OCP violations:
+adding a new table's behavior requires editing every dispatch site.
+
+## Sites
+- `export/ttx_generator.rb:100` — 13-way case → generate_X_table
+- `variable/static_font_builder.rb:91` — 4-way case → update_X_table
+- `variation/instance_writer.rb:259` — 5-way case → table class parse
+- `variation/metrics_adjuster.rb:221` — 5-way case → MVAR metric
+- `woff2/table_transformer.rb:36` — 3-way case → transform_X
+- `woff2/table_transformer.rb:62` — 3-way case → transform version
+
+## Approach
+Each case/when becomes a class-level dispatch hash mapping tag →
+method name. The dispatch site reads from the hash. Adding a new
+table means adding one line to the hash in the same file.
+
+For dispatches that use `Tables::Registry.for(tag)` to look up a
+class (like instance_writer), extend the Registry to also know how
+to construct from raw data.
+
+## Acceptance criteria
+- 0 `case tag` dispatches in `lib/fontisan/`
+- All specs pass

--- a/TODO.bug-fixes/README.md
+++ b/TODO.bug-fixes/README.md
@@ -44,5 +44,6 @@ Each file is `NN-short-name.md` where `NN` is the priority order.
 - [x] ~~[26 — Variation preserver spec migration](26-variation-preserver-spec-migration.md)~~ ✓ Done (#137)
 
 ### P3 — Architecture polish (post-#137 audit)
-- [ ] [27 — Table class registry (OCP: eliminate case/when tag dispatch)](27-table-class-registry.md)
+- [x] ~~[27 — Table class registry (OCP: eliminate case/when tag dispatch)](27-table-class-registry.md)~~ ✓ Done (#138)
 - [ ] [28 — Spec doubles cleanup](28-spec-doubles-cleanup.md)
+- [x] ~~[29 — Strategy registries for per-tag dispatch](29-strategy-registries.md)~~ ✓ Done

--- a/lib/fontisan/export/transformers/font_to_ttx.rb
+++ b/lib/fontisan/export/transformers/font_to_ttx.rb
@@ -63,26 +63,26 @@ module Fontisan
 
         # Transform individual table
         #
-        # @param ttx [Models::Ttx::TtFont] TTX model being built
-        # @param tag [String] Table tag
-        # @return [void]
+        public
+
+        # Per-tag TTX model transformer dispatch.
+        TABLE_TRANSFORMERS = {
+          "head" => [HeadTransformer, :head_table=],
+          "hhea" => [HheaTransformer, :hhea_table=],
+          "maxp" => [MaxpTransformer, :maxp_table=],
+          "name" => [NameTransformer, :name_table=],
+          "OS/2" => [Os2Transformer, :os2_table=],
+          "post" => [PostTransformer, :post_table=],
+        }.freeze
+
         def transform_table(ttx, tag)
           table = @font.table(tag)
           return unless table
 
-          case tag
-          when "head"
-            ttx.head_table = HeadTransformer.transform(table)
-          when "hhea"
-            ttx.hhea_table = HheaTransformer.transform(table)
-          when "maxp"
-            ttx.maxp_table = MaxpTransformer.transform(table)
-          when "name"
-            ttx.name_table = NameTransformer.transform(table)
-          when "OS/2"
-            ttx.os2_table = Os2Transformer.transform(table)
-          when "post"
-            ttx.post_table = PostTransformer.transform(table)
+          entry = TABLE_TRANSFORMERS[tag]
+          if entry
+            transformer, setter = entry
+            ttx.public_send(setter, transformer.transform(table))
           else
             # Fallback to binary table
             binary_table = transform_binary_table(tag, table)

--- a/lib/fontisan/export/ttx_generator.rb
+++ b/lib/fontisan/export/ttx_generator.rb
@@ -84,8 +84,28 @@ module Fontisan
       # Generate individual table XML
       #
       # @param xml [Nokogiri::XML::Builder] XML builder
-      # @param tag [String] Table tag
-      # @return [void]
+      public
+
+      # Per-tag emitter dispatch table. Adding a new table's TTX
+      # emitter means adding one entry here, not editing generate_table.
+      TABLE_EMITTERS = {
+        "head" => :generate_head_table,
+        "hhea" => :generate_hhea_table,
+        "maxp" => :generate_maxp_table,
+        "post" => :generate_post_table,
+        "name" => :generate_name_table,
+        "cmap" => :generate_cmap_table,
+        "loca" => :generate_loca_table,
+        "glyf" => :generate_glyf_table,
+        "CFF" => :generate_cff_table,
+        "CFF " => :generate_cff_table,
+        "hmtx" => :generate_hmtx_table,
+        "fvar" => :generate_fvar_table,
+      }.freeze
+
+      # Variation tags all share the same emitter shape.
+      VARIATION_TAGS = %w[gvar cvar HVAR VVAR MVAR].freeze
+
       def generate_table(xml, tag)
         table = @font.table(tag)
 
@@ -97,36 +117,15 @@ module Fontisan
           return
         end
 
-        case tag
-        when "head"
-          generate_head_table(xml, table)
-        when "hhea"
-          generate_hhea_table(xml, table)
-        when "maxp"
-          generate_maxp_table(xml, table)
-        when "post"
-          generate_post_table(xml, table)
-        when "name"
-          generate_name_table(xml, table)
-        when "OS/2"
-          # Skip OS/2 for now - Nokogiri builder can't handle slashes in element names
-          # TODO: Implement OS/2 table generation with proper XML escaping
+        if tag == "OS/2"
           xml.comment(" OS/2 table skipped - requires special XML handling ")
-        when "cmap"
-          generate_cmap_table(xml, table)
-        when "loca"
-          generate_loca_table(xml, table)
-        when "glyf"
-          generate_glyf_table(xml, table)
-        when "CFF"
-          generate_cff_table(xml, table)
-        when "CFF "
-          generate_cff_table(xml, table)
-        when "hmtx"
-          generate_hmtx_table(xml, table)
-        when "fvar"
-          generate_fvar_table(xml, table)
-        when "gvar", "cvar", "HVAR", "VVAR", "MVAR"
+          return
+        end
+
+        emitter = TABLE_EMITTERS[tag]
+        if emitter
+          method(emitter).call(xml, table)
+        elsif VARIATION_TAGS.include?(tag)
           generate_variation_table(xml, tag, table)
         else
           generate_binary_table(xml, tag, table)

--- a/lib/fontisan/variable/static_font_builder.rb
+++ b/lib/fontisan/variable/static_font_builder.rb
@@ -65,14 +65,17 @@ options = {})
         File.binwrite(output_path, binary)
       end
 
+      # Per-tag table update dispatch. Each entry maps a tag to
+      # [method_name, context_key] for looking up the right args.
+      TABLE_UPDATERS = {
+        "hmtx" => %i[update_hmtx_table varied_metrics],
+        "hhea" => %i[update_hhea_table font_metrics],
+        "OS/2" => %i[update_os2_table font_metrics],
+        "head" => %i[update_head_table options],
+      }.freeze
+
       private
 
-      # Collect all tables for static font
-      #
-      # @param varied_metrics [Hash] Varied glyph metrics
-      # @param font_metrics [Hash] Varied font metrics
-      # @param options [Hash] Build options
-      # @return [Hash<String, String>] Map of table tag to binary data
       def collect_tables(varied_metrics, font_metrics, options)
         tables = {}
 
@@ -88,17 +91,14 @@ options = {})
           next if original_data.nil? || original_data.empty?
 
           # Update specific tables with varied data
-          tables[tag] = case tag
-                        when "hmtx"
-                          update_hmtx_table(original_data, varied_metrics)
-                        when "hhea"
-                          update_hhea_table(original_data, font_metrics)
-                        when "OS/2"
-                          update_os2_table(original_data, font_metrics)
-                        when "head"
-                          update_head_table(original_data, options)
+          updater = TABLE_UPDATERS[tag]
+          tables[tag] = if updater
+                          method_name, ctx_key = updater
+                          ctx = { varied_metrics: varied_metrics,
+                                  font_metrics: font_metrics,
+                                  options: options }
+                          method(method_name).call(original_data, ctx[ctx_key])
                         else
-                          # Copy unchanged
                           original_data
                         end
         end

--- a/lib/fontisan/variation/instance_writer.rb
+++ b/lib/fontisan/variation/instance_writer.rb
@@ -251,24 +251,26 @@ module Fontisan
       # Parse table data into table object
       #
       # @param tag [String] Table tag
-      # @param data [String] Table binary data
-      # @return [Object] Parsed table object
+      public
+
+      # Per-tag table parser dispatch. Each entry maps tag → [class, init_mode].
+      # :parse means call obj.parse(data); :data= means call obj.data = data.
+      TABLE_PARSERS = {
+        "head" => [Tables::Head, :parse],
+        "maxp" => [Tables::Maxp, :parse],
+        "loca" => [Tables::Loca, :data_assign],
+        "glyf" => [Tables::Glyf, :data_assign],
+        "CFF " => [Tables::Cff, :parse],
+        "CFF2" => [Tables::Cff2, :parse],
+      }.freeze
+
       def parse_table(tag, data)
-        # For OutlineConverter, we need head, maxp, loca, glyf for TTF
-        # and CFF for OTF
-        case tag
-        when "head"
-          Tables::Head.new.tap { |t| t.parse(data) }
-        when "maxp"
-          Tables::Maxp.new.tap { |t| t.parse(data) }
-        when "loca"
-          Tables::Loca.new.tap { |t| t.data = data }
-        when "glyf"
-          Tables::Glyf.new.tap { |t| t.data = data }
-        when "CFF "
-          Tables::Cff.new.tap { |t| t.parse(data) }
-        when "CFF2"
-          Tables::Cff2.new.tap { |t| t.parse(data) }
+        entry = TABLE_PARSERS[tag]
+        if entry
+          klass, init_mode = entry
+          obj = klass.new
+          init_mode == :parse ? obj.parse(data) : obj.data = data
+          obj
         else
           # For other tables, return a simple object that just holds data
           Object.new.tap do |obj|

--- a/lib/fontisan/variation/metrics_adjuster.rb
+++ b/lib/fontisan/variation/metrics_adjuster.rb
@@ -213,24 +213,23 @@ module Fontisan
         end
       end
 
-      # Get base metric value by tag
-      #
-      # @param tag [String] Metric tag (e.g., "hasc", "hdsc")
-      # @return [Integer, nil] Base metric value
+      public
+
+      # Maps MVAR metric tags to [table_tag, method] for base value lookup.
+      METRIC_SOURCES = {
+        "hasc" => ["hhea", :ascender],
+        "hdsc" => ["hhea", :descender],
+        "hlgp" => ["hhea", :line_gap],
+        "xhgt" => ["OS/2", :sx_height],
+        "cpht" => ["OS/2", :s_cap_height],
+      }.freeze
+
       def get_base_metric_value(tag)
-        case tag
-        when "hasc"
-          variation_table("hhea")&.ascender
-        when "hdsc"
-          variation_table("hhea")&.descender
-        when "hlgp"
-          variation_table("hhea")&.line_gap
-        when "xhgt"
-          variation_table("OS/2")&.sx_height
-        when "cpht"
-          variation_table("OS/2")&.s_cap_height
-          # Add more metrics as needed
-        end
+        source = METRIC_SOURCES[tag]
+        return nil unless source
+
+        table_tag, method = source
+        variation_table(table_tag)&.public_send(method)
       end
 
       # Update font metric in appropriate table

--- a/lib/fontisan/woff2/table_transformer.rb
+++ b/lib/fontisan/woff2/table_transformer.rb
@@ -32,41 +32,34 @@ module Fontisan
       #
       # @param tag [String] Table tag
       # @return [String, nil] Transformed table data
+      # Per-tag transform method dispatch.
+      TRANSFORM_DISPATCH = {
+        "glyf" => :transform_glyf,
+        "loca" => :transform_loca,
+        "hmtx" => :transform_hmtx,
+      }.freeze
+
+      # Per-tag transform version constant.
+      TRANSFORM_VERSIONS = {
+        "glyf" => Directory::TRANSFORM_GLYF_LOCA,
+        "loca" => Directory::TRANSFORM_GLYF_LOCA,
+        "hmtx" => Directory::TRANSFORM_HMTX,
+      }.freeze
+
       def transform_table(tag)
-        case tag
-        when "glyf"
-          transform_glyf
-        when "loca"
-          transform_loca
-        when "hmtx"
-          transform_hmtx
-        else
-          # No transformation, return original data
-          get_table_data(tag)
-        end
+        transform_method = TRANSFORM_DISPATCH[tag]
+        return method(transform_method).call if transform_method
+
+        # No transformation, return original data
+        get_table_data(tag)
       end
 
-      # Check if a table can be transformed
-      #
-      # @param tag [String] Table tag
-      # @return [Boolean] True if table supports transformation
       def transformable?(tag)
-        %w[glyf loca hmtx].include?(tag)
+        TRANSFORM_DISPATCH.key?(tag)
       end
 
-      # Determine transformation version for a table
-      #
-      # @param tag [String] Table tag
-      # @return [Integer] Transformation version
       def transformation_version(tag)
-        case tag
-        when "glyf", "loca"
-          Directory::TRANSFORM_GLYF_LOCA
-        when "hmtx"
-          Directory::TRANSFORM_HMTX
-        else
-          Directory::TRANSFORM_NONE
-        end
+        TRANSFORM_VERSIONS.fetch(tag, Directory::TRANSFORM_NONE)
       end
 
       private

--- a/lib/fontisan/woff2_font.rb
+++ b/lib/fontisan/woff2_font.rb
@@ -42,18 +42,17 @@ module Fontisan
       (@flags & 0x3F) != 0x3F && KNOWN_TAGS[tag_index]&.start_with?(/glyf|loca|hmtx/)
     end
 
+    TRANSFORM_VERSIONS = {
+      "glyf" => TRANSFORM_GLYF_LOCA,
+      "loca" => TRANSFORM_GLYF_LOCA,
+      "hmtx" => TRANSFORM_HMTX,
+    }.freeze
+
     # Get transform version for this table
     def transform_version
       return TRANSFORM_NONE unless transformed?
 
-      case tag
-      when "glyf", "loca"
-        TRANSFORM_GLYF_LOCA
-      when "hmtx"
-        TRANSFORM_HMTX
-      else
-        TRANSFORM_NONE
-      end
+      TRANSFORM_VERSIONS.fetch(tag, TRANSFORM_NONE)
     end
 
     private


### PR DESCRIPTION
## Summary

Completes the OCP refactor by eliminating all remaining `case tag` dispatches with hash-based dispatch tables. Adds TODO 29 documenting the pattern.

### TODO 29 — Strategy registries (OCP completion)

6 remaining `case/when tag` dispatches converted to hash-based lookup tables:

- **`export/ttx_generator.rb`**: 13-way `case` → `TABLE_EMITTERS` hash + `VARIATION_TAGS` constant
- **`export/transformers/font_to_ttx.rb`**: 6-way `case` → `TABLE_TRANSFORMERS` hash
- **`variable/static_font_builder.rb`**: 4-way `case` → `TABLE_UPDATERS` hash
- **`variation/instance_writer.rb`**: 5-way `case` → `TABLE_PARSERS` hash
- **`variation/metrics_adjuster.rb`**: 5-way `case` → `METRIC_SOURCES` hash
- **`woff2/table_transformer.rb`**: 2× `case` → `TRANSFORM_DISPATCH` + `TRANSFORM_VERSIONS`
- **`woff2_font.rb`**: 3-way `case` → `TRANSFORM_VERSIONS` hash

Each dispatch site now reads from a class-level constant hash. Adding a new table's behavior means adding one line to the hash in the same file — not editing the dispatch method.

**0 `case tag` dispatches remain in `lib/fontisan/`** (only `parsers/tag.rb` retains a `case` for type validation — that's a type guard, not a dispatch).

## Test plan

- [x] `bundle exec rspec` — 6213 examples, 0 failures, 2 pending
- [x] `bundle exec rubocop` — 0 offenses
- [x] 0 `case tag` dispatches in `lib/fontisan/`
