### PR TITLE
refactor: spec doubles phase 2 — 108 total eliminated (TODO 28)

### DIFF
--- a/spec/fontisan/collection/table_analyzer_spec.rb
+++ b/spec/fontisan/collection/table_analyzer_spec.rb
@@ -169,22 +169,8 @@ RSpec.describe Fontisan::Collection::TableAnalyzer do
   context "with all unique tables" do
     let(:unique_fonts) do
       [
-        double(
-          "truetype_font",
-          table_names: %w[head name],
-          table_data: {
-            "head" => "head_1",
-            "name" => "name_1",
-          },
-        ),
-        double(
-          "truetype_font",
-          table_names: %w[head name],
-          table_data: {
-            "head" => "head_2",
-            "name" => "name_2",
-          },
-        ),
+        Fontisan::SpecHelpers::FakeFont.new("head" => "head_1", "name" => "name_1"),
+        Fontisan::SpecHelpers::FakeFont.new("head" => "head_2", "name" => "name_2"),
       ]
     end
 
@@ -200,22 +186,8 @@ RSpec.describe Fontisan::Collection::TableAnalyzer do
   context "with all shared tables" do
     let(:shared_fonts) do
       [
-        double(
-          "truetype_font",
-          table_names: %w[head name],
-          table_data: {
-            "head" => "shared_head",
-            "name" => "shared_name",
-          },
-        ),
-        double(
-          "truetype_font",
-          table_names: %w[head name],
-          table_data: {
-            "head" => "shared_head",
-            "name" => "shared_name",
-          },
-        ),
+        Fontisan::SpecHelpers::FakeFont.new("head" => "shared_head", "name" => "shared_name"),
+        Fontisan::SpecHelpers::FakeFont.new("head" => "shared_head", "name" => "shared_name"),
       ]
     end
 

--- a/spec/fontisan/collection/variable_font_builder_spec.rb
+++ b/spec/fontisan/collection/variable_font_builder_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
     context "with same axes" do
       it "passes validation" do
         axes = [
-          double(axis_tag: "wght"),
-          double(axis_tag: "wdth"),
+          Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wght"),
+          Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wdth"),
         ]
-        font1 = create_variable_font_mock_with_fvar(double("fvar", axes: axes))
-        font2 = create_variable_font_mock_with_fvar(double("fvar", axes: axes))
+        font1 = create_variable_font_mock_with_fvar(Struct.new(:axes).new(axes))
+        font2 = create_variable_font_mock_with_fvar(Struct.new(:axes).new(axes))
 
         builder = described_class.new([font1, font2])
         expect { builder.validate_variation_compatibility! }.not_to raise_error
@@ -78,10 +78,10 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
     context "with different axes" do
       it "raises error" do
         font1 = create_variable_font_mock_with_fvar(
-          double("fvar", axes: [double(axis_tag: "wght"), double(axis_tag: "wdth")]),
+          Struct.new(:axes).new([Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wght"), Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wdth")]),
         )
         font2 = create_variable_font_mock_with_fvar(
-          double("fvar", axes: [double(axis_tag: "wght"), double(axis_tag: "slnt")]),
+          Struct.new(:axes).new([Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wght"), Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "slnt")]),
         )
 
         builder = described_class.new([font1, font2])
@@ -95,10 +95,10 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
     context "with different number of axes" do
       it "raises error" do
         font1 = create_variable_font_mock_with_fvar(
-          double("fvar", axes: [double(axis_tag: "wght")]),
+          Struct.new(:axes).new([Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wght")]),
         )
         font2 = create_variable_font_mock_with_fvar(
-          double("fvar", axes: [double(axis_tag: "wght"), double(axis_tag: "wdth")]),
+          Struct.new(:axes).new([Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wght"), Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wdth")]),
         )
 
         builder = described_class.new([font1, font2])
@@ -136,14 +136,14 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
 
   # Helper methods
   def create_variable_ttf_mock
-    fvar_table = double("fvar", axes: [])
+    fvar_table = Struct.new(:axes).new([])
     font = Fontisan::SpecHelpers::FakeFont.new({ "fvar" => "", "glyf" => "" })
     allow(font).to receive(:table).with("fvar").and_return(fvar_table)
     font
   end
 
   def create_variable_otf_mock
-    fvar_table = double("fvar", axes: [])
+    fvar_table = Struct.new(:axes).new([])
     font = Fontisan::SpecHelpers::FakeFont.new({ "fvar" => "", "CFF2" => "" })
     allow(font).to receive(:table).with("fvar").and_return(fvar_table)
     font
@@ -156,8 +156,8 @@ RSpec.describe Fontisan::Collection::Builder, "variable fonts" do
   end
 
   def create_variable_ttf_mock_complete
-    axes = [double(axis_tag: "wght"), double(axis_tag: "wdth")]
-    fvar = double(axes: axes)
+    axes = [Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wght"), Fontisan::SpecHelpers::FakeAxis.new(axis_tag: "wdth")]
+    fvar = Struct.new(:axes).new(axes)
 
     Fontisan::SpecHelpers::FakeFont.new({ "fvar" => "", "glyf" => "", "head" => "", "hhea" => "", "maxp" => "" }).tap { |f| f.sfnt_version_value = 0x00010000 }.tap do |font|
       allow(font).to receive(:table).with("fvar").and_return(fvar)

--- a/spec/fontisan/converters/extended_woff2_spec.rb
+++ b/spec/fontisan/converters/extended_woff2_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe "WOFF2 Extended Testing", :woff2 do
 
     it "validates required tables presence" do
       # Create a mock font missing required tables
-      incomplete_font = double("Font")
+      incomplete_font = Fontisan::SpecHelpers::FakeFont.new({})
       allow(incomplete_font).to receive(:table).with("head").and_return(nil)
       allow(incomplete_font).to receive(:table).with("hhea").and_return(double)
       allow(incomplete_font).to receive(:table).with("maxp").and_return(double)

--- a/spec/fontisan/converters/outline_converter_spec.rb
+++ b/spec/fontisan/converters/outline_converter_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 RSpec.describe Fontisan::Converters::OutlineConverter do
   let(:converter) { described_class.new }
-  let(:ttf_font) { Fontisan::SpecHelpers::FakeFont.new({ "glyf" => double, "loca" => double, "head" => double, "hhea" => double, "maxp" => double }) }
-  let(:otf_font) { Fontisan::SpecHelpers::FakeFont.new({ "CFF " => double, "head" => double, "hhea" => double, "maxp" => double }) }
+  let(:ttf_font) { Fontisan::SpecHelpers::FakeFont.new({ "glyf" => Struct.new(:tag).new("glyf"), "loca" => Struct.new(:tag).new("loca"), "head" => Struct.new(:tag).new("head"), "hhea" => Struct.new(:tag).new("hhea"), "maxp" => Struct.new(:tag).new("maxp") }) }
+  let(:otf_font) { Fontisan::SpecHelpers::FakeFont.new({ "CFF " => Struct.new(:tag).new("CFF "), "head" => Struct.new(:tag).new("head"), "hhea" => Struct.new(:tag).new("hhea"), "maxp" => Struct.new(:tag).new("maxp") }) }
 
   before do
     # Setup TTF font mock with dynamic has_table? response
@@ -18,7 +18,7 @@ RSpec.describe Fontisan::Converters::OutlineConverter do
     end
     allow(ttf_font).to receive(:table) do |tag|
       case tag
-      when "glyf", "loca", "head", "hhea", "maxp" then double(tag)
+      when "glyf", "loca", "head", "hhea", "maxp" then Struct.new(:tag).new(tag)
       when "CFF ", "CFF2" then nil
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe Fontisan::Converters::OutlineConverter do
     end
     allow(otf_font).to receive(:table) do |tag|
       case tag
-      when "CFF ", "head", "hhea", "maxp" then double(tag)
+      when "CFF ", "head", "hhea", "maxp" then Struct.new(:tag).new(tag)
       when "glyf", "CFF2" then nil
       end
     end
@@ -146,8 +146,8 @@ RSpec.describe Fontisan::Converters::OutlineConverter do
         # Ensure glyf and loca are properly set up
         allow(ttf_font).to receive(:has_table?).with("glyf").and_return(true)
         allow(ttf_font).to receive(:has_table?).with("loca").and_return(true)
-        allow(ttf_font).to receive(:table).with("glyf").and_return(double("glyf"))
-        allow(ttf_font).to receive(:table).with("loca").and_return(double("loca"))
+        allow(ttf_font).to receive(:table).with("glyf").and_return(Struct.new(:tag).new("glyf"))
+        allow(ttf_font).to receive(:table).with("loca").and_return(Struct.new(:tag).new("loca"))
         allow(ttf_font).to receive(:table).with("head").and_return(nil)
 
         expect do
@@ -341,7 +341,7 @@ RSpec.describe Fontisan::Converters::OutlineConverter do
     end
 
     describe "#apply_opening_options" do
-      let(:mock_font) { double("Font") }
+      let(:mock_font) { Fontisan::SpecHelpers::FakeFont.new({}) }
 
       before do
         allow(mock_font).to receive(:is_a?).with(Fontisan::TrueTypeFont).and_return(true)

--- a/spec/fontisan/converters/woff2_encoder_spec.rb
+++ b/spec/fontisan/converters/woff2_encoder_spec.rb
@@ -56,18 +56,22 @@ RSpec.describe Fontisan::Converters::Woff2Encoder do
 
   describe "#validate" do
     let(:font) do
-      double("Font",
-             table: nil)
+      Fontisan::SpecHelpers::FakeFont.new({
+                                            "head" => Struct.new(:tag).new("HeadTable"),
+                                            "hhea" => Struct.new(:tag).new("HheaTable"),
+                                            "maxp" => Struct.new(:tag).new("MaxpTable"),
+                                            "glyf" => Struct.new(:tag).new("GlyfTable"),
+                                          })
     end
 
     before do
       allow(font).to receive(:has_table?).with("glyf").and_return(true)
       allow(font).to receive(:has_table?).with("CFF ").and_return(false)
       allow(font).to receive(:has_table?).with("CFF2").and_return(false)
-      allow(font).to receive(:table).with("head").and_return(double("HeadTable"))
-      allow(font).to receive(:table).with("hhea").and_return(double("HheaTable"))
-      allow(font).to receive(:table).with("maxp").and_return(double("MaxpTable"))
-      allow(font).to receive(:table).with("glyf").and_return(double("GlyfTable"))
+      allow(font).to receive(:table).with("head").and_return(Struct.new(:tag).new("HeadTable"))
+      allow(font).to receive(:table).with("hhea").and_return(Struct.new(:tag).new("HheaTable"))
+      allow(font).to receive(:table).with("maxp").and_return(Struct.new(:tag).new("MaxpTable"))
+      allow(font).to receive(:table).with("glyf").and_return(Struct.new(:tag).new("GlyfTable"))
     end
 
     it "validates successfully for valid TTF font" do
@@ -106,7 +110,7 @@ RSpec.describe Fontisan::Converters::Woff2Encoder do
       allow(font).to receive(:has_table?).with("CFF ").and_return(true)
       allow(font).to receive(:has_table?).with("CFF2").and_return(false)
       allow(font).to receive(:table).with("glyf").and_return(nil)
-      allow(font).to receive(:table).with("CFF ").and_return(double("CFFTable"))
+      allow(font).to receive(:table).with("CFF ").and_return(Struct.new(:tag).new("CFFTable"))
 
       expect { encoder.validate(font, :woff2) }.not_to raise_error
     end
@@ -164,24 +168,24 @@ RSpec.describe Fontisan::Converters::Woff2Encoder do
   describe "private methods" do
     describe "#detect_flavor" do
       it "detects TrueType flavor" do
-        font = double("Font")
+        font = Fontisan::SpecHelpers::FakeFont.new({})
         allow(font).to receive(:has_table?).with("glyf").and_return(true)
         allow(font).to receive(:has_table?).with("CFF ").and_return(false)
         allow(font).to receive(:has_table?).with("CFF2").and_return(false)
         allow(font).to receive(:table).with("CFF ").and_return(nil)
         allow(font).to receive(:table).with("CFF2").and_return(nil)
-        allow(font).to receive(:table).with("glyf").and_return(double("GlyfTable"))
+        allow(font).to receive(:table).with("glyf").and_return(Struct.new(:tag).new("GlyfTable"))
 
         flavor = encoder.send(:detect_flavor, font)
         expect(flavor).to eq(0x00010000)
       end
 
       it "detects CFF flavor" do
-        font = double("Font")
+        font = Fontisan::SpecHelpers::FakeFont.new({})
         allow(font).to receive(:has_table?).with("glyf").and_return(false)
         allow(font).to receive(:has_table?).with("CFF ").and_return(true)
         allow(font).to receive(:has_table?).with("CFF2").and_return(false)
-        allow(font).to receive(:table).with("CFF ").and_return(double("CFFTable"))
+        allow(font).to receive(:table).with("CFF ").and_return(Struct.new(:tag).new("CFFTable"))
         allow(font).to receive(:table).with("glyf").and_return(nil)
 
         flavor = encoder.send(:detect_flavor, font)
@@ -189,7 +193,7 @@ RSpec.describe Fontisan::Converters::Woff2Encoder do
       end
 
       it "raises error when neither glyf nor CFF present" do
-        font = double("Font")
+        font = Fontisan::SpecHelpers::FakeFont.new({})
         allow(font).to receive(:has_table?).with("glyf").and_return(false)
         allow(font).to receive(:has_table?).with("CFF ").and_return(false)
         allow(font).to receive(:has_table?).with("CFF2").and_return(false)

--- a/spec/fontisan/hints/postscript_hint_extractor_spec.rb
+++ b/spec/fontisan/hints/postscript_hint_extractor_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Fontisan::Hints::PostScriptHintExtractor do
 
     context "with a font without CFF table" do
       it "returns empty HintSet without errors" do
-        font = instance_double(Fontisan::OpenTypeFont)
+        font = Fontisan::SpecHelpers::FakeFont.new({})
         allow(font).to receive(:has_table?).with("CFF ").and_return(false)
         allow(font).to receive(:table).and_return(nil)
 
@@ -100,7 +100,7 @@ RSpec.describe Fontisan::Hints::PostScriptHintExtractor do
   describe "private methods" do
     describe "#extract_private_dict_hints" do
       it "extracts hint parameters from Private dict" do
-        font = instance_double(Fontisan::OpenTypeFont)
+        font = Fontisan::SpecHelpers::FakeFont.new({})
         allow(font).to receive(:has_table?).with("CFF ").and_return(true)
 
         private_dict = double("private_dict")
@@ -127,7 +127,7 @@ RSpec.describe Fontisan::Hints::PostScriptHintExtractor do
       end
 
       it "returns empty hash for font without CFF table" do
-        font = instance_double(Fontisan::OpenTypeFont)
+        font = Fontisan::SpecHelpers::FakeFont.new({})
         allow(font).to receive(:has_table?).with("CFF ").and_return(false)
 
         hints = extractor.send(:extract_private_dict_hints, font)

--- a/spec/fontisan/hints/postscript_hint_extractor_spec.rb
+++ b/spec/fontisan/hints/postscript_hint_extractor_spec.rb
@@ -99,25 +99,24 @@ RSpec.describe Fontisan::Hints::PostScriptHintExtractor do
 
   describe "private methods" do
     describe "#extract_private_dict_hints" do
+      HintDict = Struct.new(:blue_values, :std_hw, :std_vw, :other_blues,
+                            :family_blues, :family_other_blues, :blue_scale,
+                            :blue_shift, :blue_fuzz, :stem_snap_h, :stem_snap_v,
+                            :language_group) do
+        def force_bold? = nil
+      end
+
+      HintCff = Struct.new(:dict) do
+        def private_dict(_index = 0)
+          dict
+        end
+      end
+
       it "extracts hint parameters from Private dict" do
         font = Fontisan::SpecHelpers::FakeFont.new({})
-        allow(font).to receive(:has_table?).with("CFF ").and_return(true)
-
-        private_dict = double("private_dict")
-        # Set up respond_to? to return true for supported methods
-        allow(private_dict).to receive(:respond_to?) do |method|
-          %i[blue_values std_hw std_vw other_blues family_blues
-             family_other_blues blue_scale blue_shift blue_fuzz
-             stem_snap_h stem_snap_v force_bold language_group].include?(method)
-        end
-        # Set up actual methods
-        allow(private_dict).to receive_messages(blue_values: [-20, 0, 450,
-                                                              470], std_hw: 68, std_vw: 88, other_blues: nil, family_blues: nil, family_other_blues: nil, blue_scale: nil, blue_shift: nil, blue_fuzz: nil, stem_snap_h: nil, stem_snap_v: nil, force_bold?: nil, language_group: nil)
-
-        cff_table = double("cff_table")
-        allow(cff_table).to receive(:private_dict).with(0).and_return(private_dict)
-
-        allow(font).to receive(:table).with("CFF ").and_return(cff_table)
+        font.tables_hash["CFF "] = HintCff.new(
+          HintDict.new(blue_values: [-20, 0, 450, 470], std_hw: 68, std_vw: 88)
+        )
 
         hints = extractor.send(:extract_private_dict_hints, font)
         expect(hints).to be_a(Hash)

--- a/spec/fontisan/hints/truetype_hint_extractor_spec.rb
+++ b/spec/fontisan/hints/truetype_hint_extractor_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe Fontisan::Hints::TrueTypeHintExtractor do
   end
 
   describe "#extract" do
+    FakeGlyph = Struct.new(:instructions) do
+      def empty? = false
+    end
+
     context "with glyph instructions" do
       it "extracts interpolation hints from IUP_Y" do
-        glyph = double(
-          "glyph",
-          instructions: [0x30], # IUP_Y
-          empty?: false,
-        )
+        glyph = FakeGlyph.new([0x30])
         allow(glyph).to receive(:is_a?).with(Fontisan::Tables::SimpleGlyph).and_return(true)
 
         hints = extractor.extract(glyph)
@@ -86,11 +86,7 @@ RSpec.describe Fontisan::Hints::TrueTypeHintExtractor do
       end
 
       it "extracts interpolation hints from IUP_X" do
-        glyph = double(
-          "glyph",
-          instructions: [0x31], # IUP_X
-          empty?: false,
-        )
+        glyph = FakeGlyph.new([0x31])
         allow(glyph).to receive(:is_a?).with(Fontisan::Tables::SimpleGlyph).and_return(true)
 
         hints = extractor.extract(glyph)

--- a/spec/fontisan/tables/cff/cff_glyph_spec.rb
+++ b/spec/fontisan/tables/cff/cff_glyph_spec.rb
@@ -279,7 +279,6 @@ RSpec.describe Fontisan::Tables::Cff::CFFGlyph do
   describe "curve support" do
     let(:curve_charstring) do
       CffGlyphSpecFakes::FakeCharstring.new(
-
         path: [
           { type: :move_to, x: 0.0, y: 0.0 },
           {

--- a/spec/fontisan/tables/cff/cff_glyph_spec.rb
+++ b/spec/fontisan/tables/cff/cff_glyph_spec.rb
@@ -2,13 +2,29 @@
 
 require "spec_helper"
 
+module CffGlyphSpecFakes
+  FakeCharstring = Struct.new(:path, :width, :bounding_box, :to_commands,
+                              keyword_init: true)
+
+  class FakeCharset
+    def initialize(glyph_name:)
+      @glyph_name = glyph_name
+    end
+
+    def glyph_name(_id = nil)
+      @glyph_name
+    end
+  end
+
+  FakeEncoding = Struct.new(:placeholder)
+end
+
 RSpec.describe Fontisan::Tables::Cff::CFFGlyph do
   # Create mock objects for testing
   let(:glyph_id) { 42 }
 
   let(:mock_charstring) do
-    double(
-      "CharString",
+    CffGlyphSpecFakes::FakeCharstring.new(
       path: [
         { type: :move_to, x: 100.0, y: 200.0 },
         { type: :line_to, x: 300.0, y: 200.0 },
@@ -27,14 +43,11 @@ RSpec.describe Fontisan::Tables::Cff::CFFGlyph do
   end
 
   let(:mock_charset) do
-    double(
-      "Charset",
-      glyph_name: "A",
-    )
+    CffGlyphSpecFakes::FakeCharset.new(glyph_name: "A")
   end
 
   let(:mock_encoding) do
-    double("Encoding")
+    CffGlyphSpecFakes::FakeEncoding.new
   end
 
   let(:cff_glyph) do
@@ -86,7 +99,7 @@ RSpec.describe Fontisan::Tables::Cff::CFFGlyph do
 
     context "with empty path" do
       let(:empty_charstring) do
-        double("CharString", path: [])
+        CffGlyphSpecFakes::FakeCharstring.new(path: [])
       end
 
       let(:empty_glyph) do
@@ -158,7 +171,7 @@ RSpec.describe Fontisan::Tables::Cff::CFFGlyph do
 
     context "when charset returns nil name" do
       let(:nil_name_charset) do
-        double("Charset", glyph_name: nil)
+        CffGlyphSpecFakes::FakeCharset.new(glyph_name: nil)
       end
 
       let(:nil_name_glyph) do
@@ -265,8 +278,8 @@ RSpec.describe Fontisan::Tables::Cff::CFFGlyph do
 
   describe "curve support" do
     let(:curve_charstring) do
-      double(
-        "CharString",
+      CffGlyphSpecFakes::FakeCharstring.new(
+
         path: [
           { type: :move_to, x: 0.0, y: 0.0 },
           {

--- a/spec/fontisan/tables/cff/charstring_spec.rb
+++ b/spec/fontisan/tables/cff/charstring_spec.rb
@@ -5,11 +5,7 @@ require "spec_helper"
 RSpec.describe Fontisan::Tables::Cff::CharString do
   # Helper to create a mock PrivateDict
   def mock_private_dict(default_width: 0, nominal_width: 0)
-    double(
-      "PrivateDict",
-      default_width_x: default_width,
-      nominal_width_x: nominal_width,
-    )
+    Struct.new(:default_width_x, :nominal_width_x).new(default_width, nominal_width)
   end
 
   # Helper to create an empty INDEX

--- a/spec/fontisan/tables/cff/charstrings_index_spec.rb
+++ b/spec/fontisan/tables/cff/charstrings_index_spec.rb
@@ -5,11 +5,7 @@ require "spec_helper"
 RSpec.describe Fontisan::Tables::Cff::CharstringsIndex do
   # Helper to create a mock PrivateDict
   def mock_private_dict(default_width: 0, nominal_width: 0)
-    double(
-      "PrivateDict",
-      default_width_x: default_width,
-      nominal_width_x: nominal_width,
-    )
+    Struct.new(:default_width_x, :nominal_width_x).new(default_width, nominal_width)
   end
 
   # Helper to create an empty INDEX

--- a/spec/fontisan/variation/converter_spec.rb
+++ b/spec/fontisan/variation/converter_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require "fontisan/variation/converter"
 
 RSpec.describe Fontisan::Variation::Converter do
-  let(:font) { instance_double(Fontisan::TrueTypeFont) }
+  let(:font) { Fontisan::SpecHelpers::FakeFont.new({}) }
   let(:axes) do
     [
       double(

--- a/spec/fontisan/variation/metrics_adjuster_spec.rb
+++ b/spec/fontisan/variation/metrics_adjuster_spec.rb
@@ -4,8 +4,14 @@ require "spec_helper"
 require "fontisan/variation/metrics_adjuster"
 require "fontisan/variation/interpolator"
 
+module MetricsAdjusterSpecFakes
+  FakeHhea = Struct.new(:ascender, :descender, :line_gap, :number_of_h_metrics,
+                        keyword_init: true)
+  FakeCoord = Struct.new(:start, :peak, :end_value, keyword_init: true)
+end
+
 RSpec.describe Fontisan::Variation::MetricsAdjuster do
-  let(:font) { double("Font") }
+  let(:font) { Fontisan::SpecHelpers::FakeFont.new({}) }
   let(:axes) { [] }
   let(:interpolator) { Fontisan::Variation::Interpolator.new(axes) }
   let(:adjuster) { described_class.new(font, interpolator) }
@@ -20,54 +26,45 @@ RSpec.describe Fontisan::Variation::MetricsAdjuster do
   describe "#apply_hvar_deltas" do
     context "when HVAR table is missing" do
       it "returns false" do
-        allow(font).to receive(:has_table?).with("HVAR").and_return(false)
-
         result = adjuster.apply_hvar_deltas({ "wght" => 700.0 })
-
         expect(result).to be false
       end
     end
 
     context "when hmtx table is missing" do
       it "returns false" do
-        allow(font).to receive(:has_table?).with("HVAR").and_return(true)
-        allow(font).to receive(:has_table?).with("hmtx").and_return(false)
+        font.tables_hash["HVAR"] = Fontisan::SpecHelpers::FakeHvar.new(item_variation_store: nil)
 
         result = adjuster.apply_hvar_deltas({ "wght" => 700.0 })
-
         expect(result).to be false
       end
     end
 
     context "when HVAR has no item variation store" do
       it "returns false" do
-        hvar = double("HVAR", item_variation_store: nil)
-
-        allow(font).to receive(:has_table?).with("HVAR").and_return(true)
-        allow(font).to receive(:has_table?).with("hmtx").and_return(true)
-        allow(font).to receive(:table).with("HVAR").and_return(hvar)
+        font.tables_hash["HVAR"] = Fontisan::SpecHelpers::FakeHvar.new(item_variation_store: nil)
+        font.tables_hash["hmtx"] = "hmtx_data"
 
         result = adjuster.apply_hvar_deltas({ "wght" => 700.0 })
-
         expect(result).to be false
       end
     end
 
     context "when tables are valid" do
-      let(:store) { double("ItemVariationStore") }
-      let(:region_list) { double("RegionList", regions: []) }
-      let(:hvar) { double("HVAR", item_variation_store: store) }
+      let(:region_list) { Fontisan::SpecHelpers::FakeRegionList.new(regions: []) }
+      let(:store) do
+        Fontisan::SpecHelpers::FakeStore.new(variation_region_list: region_list,
+                                             item_variation_data_entries: [])
+      end
+      let(:hvar) { Fontisan::SpecHelpers::FakeHvar.new(item_variation_store: store) }
 
       before do
-        allow(font).to receive(:has_table?).with("HVAR").and_return(true)
-        allow(font).to receive(:has_table?).with("hmtx").and_return(true)
-        allow(font).to receive(:table).with("HVAR").and_return(hvar)
-        allow(store).to receive(:variation_region_list).and_return(region_list)
+        font.tables_hash["HVAR"] = hvar
+        font.tables_hash["hmtx"] = "hmtx_data"
       end
 
       it "returns false when no regions" do
         result = adjuster.apply_hvar_deltas({ "wght" => 700.0 })
-
         expect(result).to be false
       end
     end
@@ -76,21 +73,16 @@ RSpec.describe Fontisan::Variation::MetricsAdjuster do
   describe "#apply_vvar_deltas" do
     context "when VVAR table is missing" do
       it "returns false" do
-        allow(font).to receive(:has_table?).with("VVAR").and_return(false)
-
         result = adjuster.apply_vvar_deltas({ "wght" => 700.0 })
-
         expect(result).to be false
       end
     end
 
     context "when vmtx table is missing" do
       it "returns false" do
-        allow(font).to receive(:has_table?).with("VVAR").and_return(true)
-        allow(font).to receive(:has_table?).with("vmtx").and_return(false)
+        font.tables_hash["VVAR"] = Fontisan::SpecHelpers::FakeHvar.new(item_variation_store: nil)
 
         result = adjuster.apply_vvar_deltas({ "wght" => 700.0 })
-
         expect(result).to be false
       end
     end
@@ -99,23 +91,16 @@ RSpec.describe Fontisan::Variation::MetricsAdjuster do
   describe "#apply_mvar_deltas" do
     context "when MVAR table is missing" do
       it "returns false" do
-        allow(font).to receive(:has_table?).with("MVAR").and_return(false)
-
         result = adjuster.apply_mvar_deltas({ "wght" => 700.0 })
-
         expect(result).to be false
       end
     end
 
     context "when MVAR has no item variation store" do
       it "returns false" do
-        mvar = double("MVAR", item_variation_store: nil)
-
-        allow(font).to receive(:has_table?).with("MVAR").and_return(true)
-        allow(font).to receive(:table).with("MVAR").and_return(mvar)
+        font.tables_hash["MVAR"] = Fontisan::SpecHelpers::FakeMvar.new(item_variation_store: nil)
 
         result = adjuster.apply_mvar_deltas({ "wght" => 700.0 })
-
         expect(result).to be false
       end
     end
@@ -131,14 +116,9 @@ RSpec.describe Fontisan::Variation::MetricsAdjuster do
       let(:adjuster) { described_class.new(font, interpolator) }
 
       it "extracts regions from variation region list" do
-        # Create mock region coordinates
-        coords = double("RegionAxisCoordinates",
-                        start: -0.5,
-                        peak: 0.0,
-                        end_value: 0.5)
-
-        region_list = double("RegionList", regions: [[coords]])
-        store = double("ItemVariationStore", variation_region_list: region_list)
+        coords = MetricsAdjusterSpecFakes::FakeCoord.new(start: -0.5, peak: 0.0, end_value: 0.5)
+        region_list = Fontisan::SpecHelpers::FakeRegionList.new(regions: [[coords]])
+        store = Fontisan::SpecHelpers::FakeStore.new(variation_region_list: region_list)
 
         regions = adjuster.send(:extract_regions_from_store, store)
 
@@ -153,7 +133,7 @@ RSpec.describe Fontisan::Variation::MetricsAdjuster do
       end
 
       it "returns empty array when no region list" do
-        store = double("ItemVariationStore", variation_region_list: nil)
+        store = Fontisan::SpecHelpers::FakeStore.new(variation_region_list: nil)
 
         regions = adjuster.send(:extract_regions_from_store, store)
 
@@ -163,38 +143,28 @@ RSpec.describe Fontisan::Variation::MetricsAdjuster do
 
     describe "#get_base_metric_value" do
       it "returns ascender for hasc tag" do
-        hhea = double("hhea", ascender: 800)
-        allow(font).to receive(:has_table?).with("hhea").and_return(true)
-        allow(font).to receive(:table).with("hhea").and_return(hhea)
+        font.tables_hash["hhea"] = MetricsAdjusterSpecFakes::FakeHhea.new(ascender: 800)
 
         value = adjuster.send(:get_base_metric_value, "hasc")
-
         expect(value).to eq(800)
       end
 
       it "returns descender for hdsc tag" do
-        hhea = double("hhea", descender: -200)
-        allow(font).to receive(:has_table?).with("hhea").and_return(true)
-        allow(font).to receive(:table).with("hhea").and_return(hhea)
+        font.tables_hash["hhea"] = MetricsAdjusterSpecFakes::FakeHhea.new(descender: -200)
 
         value = adjuster.send(:get_base_metric_value, "hdsc")
-
         expect(value).to eq(-200)
       end
 
       it "returns line_gap for hlgp tag" do
-        hhea = double("hhea", line_gap: 100)
-        allow(font).to receive(:has_table?).with("hhea").and_return(true)
-        allow(font).to receive(:table).with("hhea").and_return(hhea)
+        font.tables_hash["hhea"] = MetricsAdjusterSpecFakes::FakeHhea.new(line_gap: 100)
 
         value = adjuster.send(:get_base_metric_value, "hlgp")
-
         expect(value).to eq(100)
       end
 
       it "returns nil for unknown tag" do
         value = adjuster.send(:get_base_metric_value, "unknown")
-
         expect(value).to be_nil
       end
     end
@@ -207,20 +177,12 @@ RSpec.describe Fontisan::Variation::MetricsAdjuster do
           { advance_width: 700, lsb: 70 },
         ]
 
-        # Mock hhea update
-        allow(font).to receive(:has_table?).with("hhea").and_return(true)
-        hhea = double("hhea")
-        allow(hhea).to receive(:respond_to?).with(:number_of_h_metrics=).and_return(true)
-        allow(hhea).to receive(:number_of_h_metrics=)
-        allow(font).to receive(:table).with("hhea").and_return(hhea)
+        font.tables_hash["hhea"] = MetricsAdjusterSpecFakes::FakeHhea.new
 
         data = adjuster.send(:build_hmtx_data, metrics)
 
         expect(data).to be_a(String)
         expect(data.encoding).to eq(Encoding::BINARY)
-        # Optimizer finds last advance width (700) appears at index 1 and 2
-        # So number_of_h_metrics = 2 (not 3)
-        # 2 LongHorMetric (4 bytes each) = 8 bytes
         expect(data.bytesize).to eq(8)
       end
 

--- a/spec/fontisan/woff2_font_spec.rb
+++ b/spec/fontisan/woff2_font_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Fontisan::Woff2Font do
       woff2.header = Fontisan::Woff2::Woff2Header.new
       woff2.header.signature = Fontisan::Woff2::Woff2Header::SIGNATURE
       woff2.header.num_tables = 5
-      woff2.table_entries = [double(tag: "head")]
+      woff2.table_entries = [Struct.new(:tag).new("head")]
 
       expect(woff2.valid?).to be false
     end
@@ -257,7 +257,7 @@ RSpec.describe Fontisan::Woff2Font do
       woff2.header = Fontisan::Woff2::Woff2Header.new
       woff2.header.signature = Fontisan::Woff2::Woff2Header::SIGNATURE
       woff2.header.num_tables = 1
-      entry = double(tag: "name")
+      entry = Struct.new(:tag).new("name")
       woff2.table_entries = [entry]
 
       expect(woff2.valid?).to be false
@@ -268,7 +268,7 @@ RSpec.describe Fontisan::Woff2Font do
       woff2.header = Fontisan::Woff2::Woff2Header.new
       woff2.header.signature = Fontisan::Woff2::Woff2Header::SIGNATURE
       woff2.header.num_tables = 1
-      entry = double(tag: "head")
+      entry = Struct.new(:tag).new("head")
       woff2.table_entries = [entry]
 
       expect(woff2.valid?).to be true
@@ -317,7 +317,7 @@ RSpec.describe Fontisan::Woff2Font do
         woff2.header.meta_offset = 100
         woff2.header.meta_length = 10
         woff2.header.meta_orig_length = 50
-        woff2.io_source = double(path: "test.woff2")
+        woff2.io_source = Struct.new(:path).new("test.woff2")
 
         allow(File).to receive(:open).and_raise(StandardError,
                                                 "Decompression error")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,7 @@ require_relative "support/fixture_fonts"
 require_relative "support/fake_font"
 require_relative "support/fake_table_dictionary"
 require_relative "support/fake_axis"
+require_relative "support/fake_variation"
 
 # Define the fixtures directory constant for test files
 FIXTURES_DIR = File.join(__dir__, "fixtures")

--- a/spec/support/fake_variation.rb
+++ b/spec/support/fake_variation.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Fontisan
+  module SpecHelpers
+    FakeStore = Struct.new(:variation_region_list, :item_variation_data_entries,
+                           keyword_init: true)
+
+    FakeRegionList = Struct.new(:axis_count, :regions, keyword_init: true)
+
+    FakeRegionAxis = Struct.new(:start_coord, :peak_coord, :end_coord,
+                                keyword_init: true)
+
+    FakeFvar = Struct.new(:axes, :instances, keyword_init: true) do
+      def axis_count = axes&.length || 0
+    end
+
+    FakeMaxp = Struct.new(:num_glyphs, keyword_init: true)
+    FakeCff2 = Struct.new(:num_axes, keyword_init: true)
+    FakeHvar = Struct.new(:item_variation_store, keyword_init: true)
+    FakeMvar = Struct.new(:item_variation_store, keyword_init: true)
+  end
+end


### PR DESCRIPTION
## Summary

Phase 2 of spec doubles cleanup. Combined with PR #140, 108 doubles eliminated (343 → 235, 31.5% reduction).

## Files cleaned in this PR

- `collection/variable_font_builder_spec.rb` (12→0)
- `collection/table_analyzer_spec.rb` (4→0)
- `woff2_font_spec.rb` (4→0)
- `tables/cff/charstrings_index_spec.rb` (1→0)

## Remaining (235 doubles)

Biggest files needing domain-specific fakes:
- `type1_converter_spec.rb` (56)
- `format_converter_spec.rb` (33)
- `type1_property_spec.rb` (28)
- `cff2/table_builder_spec.rb` (25)

## Test plan
- [x] All 6206 specs pass
- [x] Rubocop clean