### PR TITLE
Bump fontisan to 0.4.44

### DIFF
--- a/lib/fontisan/version.rb
+++ b/lib/fontisan/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Fontisan
-  VERSION = "0.4.43"
+  VERSION = "0.4.44"
 end


### PR DESCRIPTION
## Summary

Version bump for patch release.

Contains all architecture and spec cleanup work from PRs #135-#145:
- Zero `respond_to?`, `.send(`, `instance_variable_get/set` in lib/
- Zero hand-rolled serialization, zero `case/when` tag dispatches
- `Tables::Registry` for OCP-compliant table class lookup
- `SfntSource` module for typed font interface checking
- Hash-based strategy dispatch tables
- **Zero spec doubles** (343 → 0)

## Test plan
- [x] All 6192 specs pass
- [x] Rubocop clean