### PR TITLE
Bump fontisan to 0.4.45

### DIFF
--- a/lib/fontisan/version.rb
+++ b/lib/fontisan/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Fontisan
-  VERSION = "0.4.44"
+  VERSION = "0.4.45"
 end


### PR DESCRIPTION
Patch release for TODO 30 (eliminate .send in specs).